### PR TITLE
feat: 코인 사용 기록 기능 구현 및 관련 서비스 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/GlobalExceptionAdvice.java
+++ b/src/main/java/com/ham/netnovel/GlobalExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel;
 
+import com.ham.netnovel.common.exception.NotEnoughCoinsException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -77,7 +78,16 @@ public class GlobalExceptionAdvice {
     }
 
 
-
+    /**
+     * 결제시 코인이 부족할 경우 예외처리
+     * @param ex NotEnoughCoinsException 커스텀 Exception, RunTimeException 상속받아 사용
+     * @return ResponseEntity 에러 메시지 유저에게 전달
+     */
+    @ExceptionHandler(NotEnoughCoinsException.class)
+    public ResponseEntity<String> handleNotEnoughCoinsException(NotEnoughCoinsException ex) {
+        log.error("errorMessage NotEnoughCoinsException: {} ",ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("코인이 부족합니다. 코인을 충전해 주세요");
+    }
 
 
     //    RuntimeException 핸들링

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryController.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryController.java
@@ -1,0 +1,78 @@
+package com.ham.netnovel.coinUseHistory;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
+import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
+import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.ValidationErrorHandler;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequestMapping("/api")
+public class CoinUseHistoryController {
+
+    private final CoinUseHistoryService coinUseHistoryService;
+
+    private final Authenticator authenticator;
+
+
+    public CoinUseHistoryController(CoinUseHistoryService coinUseHistoryService, Authenticator authenticator) {
+        this.coinUseHistoryService = coinUseHistoryService;
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * 유저의 코인 사용 기록을 저장하는 API(에피소드 열람시 코인 사용)
+     * @param coinUseCreateDto 에피소드정보, 유저 정보를 담는 DTO
+     * @param bindingResult DTO 검증 에러 객체
+     * @param authentication 유저 인증 정보
+     * @return
+     */
+    @PostMapping("/coin-use-histories")
+    public ResponseEntity<String> createCoinUseHistory(@Valid @RequestBody CoinUseCreateDto coinUseCreateDto,
+                                                  BindingResult bindingResult,
+                                                  Authentication authentication){
+
+        //CommentUpdateDto Validation 에러가 있을경우 badRequest 전송
+        if (bindingResult.hasErrors()) {
+            //에러 메시지들 List에 담음
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrors(bindingResult);
+            log.error("createCoinUseHistory API 에러발생={}",errorMessages);
+            //에러 메시지 body에 담아 전송
+            return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
+        }
+
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //DTO에 유저 정보 저장
+        coinUseCreateDto.setProviderId(principal.getName());
+
+        coinUseHistoryService.saveCoinUseHistory(coinUseCreateDto);
+
+        return ResponseEntity.ok("ok");
+
+    }
+
+    @GetMapping("/coin-use-histories/test")
+    public String test1(){
+
+        return "/coinUseHistory/test";
+
+    }
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
@@ -1,0 +1,19 @@
+package com.ham.netnovel.coinUseHistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory,Long> {
+
+
+
+
+    @Query("select c from CoinUseHistory c " +
+            "where c.member.providerId = :providerId " +
+            "order by c.createdAt desc ")
+    List<CoinUseHistory> findByMemberProviderId(@Param("providerId")String providerId);
+
+}

--- a/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
@@ -1,0 +1,20 @@
+package com.ham.netnovel.coinUseHistory.service;
+
+import com.ham.netnovel.coinUseHistory.CoinUseHistory;
+import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
+
+import java.util.List;
+
+public interface CoinUseHistoryService {
+
+
+   void saveCoinUseHistory(CoinUseCreateDto coinUseCreateDto);
+
+
+   List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId);
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImpl.java
@@ -1,0 +1,88 @@
+package com.ham.netnovel.coinUseHistory.service;
+
+import com.ham.netnovel.coinUseHistory.CoinUseHistory;
+import com.ham.netnovel.coinUseHistory.CoinUseHistoryRepository;
+import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.episode.EpisodeService;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
+import com.ham.netnovel.member.service.MemberService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class CoinUseHistoryServiceImpl implements CoinUseHistoryService {
+
+    private final CoinUseHistoryRepository coinUseHistoryRepository;
+
+    private final MemberService memberService;
+
+    private final EpisodeService episodeService;
+
+    public CoinUseHistoryServiceImpl(CoinUseHistoryRepository coinUseHistoryRepository, MemberService memberService, EpisodeService episodeService) {
+        this.coinUseHistoryRepository = coinUseHistoryRepository;
+        this.memberService = memberService;
+        this.episodeService = episodeService;
+    }
+
+    @Override
+    @Transactional
+    public void saveCoinUseHistory(CoinUseCreateDto coinUseCreateDto) {
+        log.info("진입");
+        //유저 정보 확인
+        Member member = memberService.getMember(coinUseCreateDto.getProviderId())
+                .orElseThrow(() -> new NoSuchElementException("Member 정보가 없습니다. providerId: " + coinUseCreateDto.getProviderId()));
+
+        //에피소드 정보 확인
+        Episode episode = episodeService.getEpisode(coinUseCreateDto.getEpisodeId())
+                .orElseThrow(() -> new NoSuchElementException("Episode 정보가 없습니다. episodeId: " + coinUseCreateDto.getEpisodeId()));
+
+        try {
+            //새로운 코인 사용 기록 엔티티 생성
+            CoinUseHistory coinUseHistory = CoinUseHistory.builder()
+                    .member(member)
+                    .episode(episode)
+                    .amount(episode.getCoinCost())
+                    .build();
+            //DB에 저장
+            coinUseHistoryRepository.save(coinUseHistory);
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("saveCoinUseHistory 메서드에서 오류 발생", ex);
+        }
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId) {
+        try {
+            return coinUseHistoryRepository.findByMemberProviderId(providerId)
+                    .stream()//유저의 코인 사용 기록을 받아와 stream 생성
+                    .map(coinUseHistory -> {//엔티티 정보 DTO에 바인딩
+                                Episode episode = coinUseHistory.getEpisode();
+                                return MemberCoinUseHistoryDto.builder()
+                                        .episodeTitle(episode.getTitle())//에피소드 제목
+                                        .createdAt(coinUseHistory.getCreatedAt())//결제 시간
+                                        .usedCoin(coinUseHistory.getAmount())//사용한 코인수
+                                        .episodeNumber(episode.getEpisodeNumber())//에피소드 번호
+                                        .novelTitle(episode.getNovel().getTitle())//소설 제목
+                                        .build();
+                            }
+                    ).toList();
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getMemberCoinUseHistory 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/common/exception/NotEnoughCoinsException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/NotEnoughCoinsException.java
@@ -1,0 +1,12 @@
+package com.ham.netnovel.common.exception;
+
+public class NotEnoughCoinsException  extends RuntimeException{//코인 개수가 부족할때 사용하는 예외처리
+
+    public NotEnoughCoinsException(String message) {
+        super(message);
+    }
+
+    public NotEnoughCoinsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.member;
 
 
 import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
@@ -50,9 +51,10 @@ public class MemberController {
 
     /**
      * 유저의 닉네임을 수정하는 API
+     *
      * @param changeNickNameDto 닉네임 변경을 위한 DTO, 유저의 providerId값과 새로운 닉네임 값을 멤버변수로 가짐
-     * @param bindingResult ChangeNickNameDto 검증 에러를 담는 객체
-     * @param authentication 유저의 인증 정보
+     * @param bindingResult     ChangeNickNameDto 검증 에러를 담는 객체
+     * @param authentication    유저의 인증 정보
      * @return ResponseEntity 결과를 헤더에 담아 전송
      */
     @PatchMapping("/members/nickname")
@@ -105,11 +107,12 @@ public class MemberController {
     /**
      * 유저가 작성한 댓글, 대댓글을 반환하는 API
      * API 요청시 인증 정보를 확인 한 후, 인증된 유저가 작성한 댓글,대댓글을 DTO 변환후 List 형태로 반환
+     *
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 댓글과 대댓글의 정보를 body에 담아 반환
      */
     @PostMapping("/members/comment")
-    public ResponseEntity<?> postMemberCommentList(Authentication authentication){
+    public ResponseEntity<?> postMemberCommentList(Authentication authentication) {
 
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
@@ -118,7 +121,7 @@ public class MemberController {
         List<MemberCommentDto> commentList = memberMyPageService.getMemberCommentAndReCommentList(principal.getName());
 
         for (MemberCommentDto memberCommentDto : commentList) {
-            log.info("정보{}",memberCommentDto.toString());
+            log.info("정보{}", memberCommentDto.toString());
 
         }
 
@@ -131,11 +134,12 @@ public class MemberController {
 
     /**
      * 유저가 좋아요 누른 소설 리스트를 전송하는 API
+     *
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity
      */
     @PostMapping("/members/novel")
-    public ResponseEntity<?> postFavoriteNovels(Authentication authentication){
+    public ResponseEntity<?> postFavoriteNovels(Authentication authentication) {
 
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
@@ -148,39 +152,52 @@ public class MemberController {
 
     }
 
+    @PostMapping("/members/coin-use-history")
+    public ResponseEntity<?> postMemberCoinUseHistory(Authentication authentication) {
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //유저 코인 사용 기록 조회
+        List<MemberCoinUseHistoryDto> coinUseHistory = memberMyPageService.getMemberCoinUseHistory(principal.getName());
+
+        // 응답 반환
+        return ResponseEntity.ok(coinUseHistory);
+
+    }
+
 
     //테스트 API
     @GetMapping("/members/novel/test")
-    public String memberNovelTest(){
+    public String memberNovelTest() {
 
         return "/member/novel-test";
     }
 
 
     @GetMapping("/members/comment/test")
-    public String memberCommentTest(){
+    public String memberCommentTest() {
 
         return "/member/comment-test";
     }
 
     @GetMapping("/members/nickname/test")
-    public String nickNameChangeTest(){
+    public String nickNameChangeTest() {
 
         return "/member/nickname-test";
     }
 
     @GetMapping("/members/session/test")
     @ResponseBody
-    public String sessionTest(Authentication authentication){
+    public String sessionTest(Authentication authentication) {
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
 
         log.info("로그인한 유저 정보");
-        log.info("로그인한 유저 providerId={}",principal.getName());
-        log.info("로그인한 유저 nickName={}",principal.getNickName());
-        log.info("로그인한 유저 role={}",principal.getRole());
-        log.info("로그인한 유저 gender={}",principal.getGender());
-        log.info("로그인한 유저 Attributes={}",principal.getAttributes());
-        log.info("로그인한 유저 Authorities={}",principal.getAuthorities());
+        log.info("로그인한 유저 providerId={}", principal.getName());
+        log.info("로그인한 유저 nickName={}", principal.getNickName());
+        log.info("로그인한 유저 role={}", principal.getRole());
+        log.info("로그인한 유저 gender={}", principal.getGender());
+        log.info("로그인한 유저 Attributes={}", principal.getAttributes());
+        log.info("로그인한 유저 Authorities={}", principal.getAuthorities());
 
         return "ok";
 

--- a/src/main/java/com/ham/netnovel/member/dto/MemberCoinUseHistoryDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberCoinUseHistoryDto.java
@@ -1,0 +1,42 @@
+package com.ham.netnovel.member.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class MemberCoinUseHistoryDto {
+
+    //에피소드 번호
+    //에피소드 이름
+    //결제 날짜
+
+    //소설 제목
+    private String novelTitle;
+
+    //에피소드 번호
+    private Integer episodeNumber;
+
+    //에피소드 제목
+    private String episodeTitle;
+
+
+    //사용 코인 갯수
+    private Integer usedCoin;
+
+    //결제 날짜
+    private LocalDateTime createdAt;
+
+
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member.service;
 
 
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
 
@@ -15,6 +16,8 @@ public interface MemberMyPageService {
 
 //    List<FavoriteNovelListDto> getMemberFavoriteNovel
 
+
+    List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId);
 
 
 

--- a/src/main/java/com/ham/netnovel/member/service/MemberService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberService.java
@@ -13,7 +13,7 @@ public interface MemberService {
     /**
      * Member 엔티티를 조회하는 메서드, null체크는 해당 메서드를 사용하는 메서드에서 진행
      * @param providerId
-     * @return
+     * @return Optional<Member>
      */
    Optional<Member> getMember(String providerId);
 
@@ -21,7 +21,7 @@ public interface MemberService {
     /**
      * 로그인시 인증정보를 위한 유저정보를 가져오는 메서드
      * @param providerId 인증 제공자(naver등)에서의 유저 ID값
-     * @return
+     * @return MemberLoginDto
      */
     MemberLoginDto getMemberLoginInfo(String providerId);
 
@@ -39,6 +39,15 @@ public interface MemberService {
      * @param changeNickNameDto providerId, 변경할 닉네임을 포함하는 DTO
      */
     void updateMemberNickName(ChangeNickNameDto changeNickNameDto);
+
+
+    /**
+     * 유저의 코인을 차감하는 메서드
+     * @param providerId 유저의 providerId 정보
+     * @param coinAmount 차감할 코인 수
+     */
+    void deductMemberCoins(String providerId, Integer coinAmount);
+
 
 
 

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
@@ -1,7 +1,9 @@
 package com.ham.netnovel.member.service.impl;
 
+import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
 import com.ham.netnovel.comment.service.CommentService;
 import com.ham.netnovel.member.MemberRepository;
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
@@ -25,12 +27,16 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
 
     private final MemberRepository memberRepository;
 
+    private final CoinUseHistoryService coinUseHistoryService;
+
     private final NovelService novelService;
 
-    public MemberMyPageServiceImpl(CommentService commentService, ReCommentService reCommentService, MemberRepository memberRepository, NovelService novelService) {
+
+    public MemberMyPageServiceImpl(CommentService commentService, ReCommentService reCommentService, MemberRepository memberRepository, CoinUseHistoryService coinUseHistoryService, NovelService novelService) {
         this.commentService = commentService;
         this.reCommentService = reCommentService;
         this.memberRepository = memberRepository;
+        this.coinUseHistoryService = coinUseHistoryService;
         this.novelService = novelService;
     }
 
@@ -65,6 +71,15 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
                         .status(novel.getStatus())
                         .build()
                 ).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId) {
+        if (providerId.isEmpty()) {
+            throw new IllegalArgumentException("잘못된 유저 providerId 정보 확인 필요");
+        }
+      return coinUseHistoryService.getMemberCoinUseHistory(providerId);
+
     }
 
 

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member.service.impl;
 
 
+import com.ham.netnovel.common.exception.NotEnoughCoinsException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.MemberRepository;
@@ -100,6 +101,48 @@ class MemberServiceImpl implements MemberService {
         }
 
         //DB에 변경사항 저장
+
+
+    }
+
+    @Override
+    @Transactional
+    public void deductMemberCoins(String providerId, Integer coinAmount) {
+
+        //사용한 코인 수가 올바르지 않을때 예외로 던짐
+        if (coinAmount==null || coinAmount<0){
+            throw new IllegalArgumentException("deductMemberCoins 에러, coinAmount 값이 유효하지 않습니다.");
+        }
+
+        Optional<Member> optionalMember = getMember(providerId);
+        if (optionalMember.isEmpty()){
+            throw new NoSuchElementException("deductMemberCoins 에러, 유저 정보가 없습니다.");
+        }
+        //Optional 벗기기
+        Member member = optionalMember.get();
+
+        //유저의 전체 코인수 변수에 저장
+        Integer totalCoin = member.getCoinCount();
+
+        //유저의 코인이 null일경우 예외처리
+        if (totalCoin ==null){
+            throw new NoSuchElementException("deductMemberCoins 에러, 유저 정보가 없습니다.");
+        //유저의 코인이 사용한 코인수보다 적을때 예외처리
+        } else if (totalCoin<coinAmount) {
+            throw new NotEnoughCoinsException("deductMemberCoins 에러, 유저의 코인이 부족합니다.");
+        }
+
+        try {
+            //엔티티의 coinAmount 차감
+            member.deductCoins(coinAmount);
+            //엔티티 DB에 저장
+            memberRepository.save(member);
+        }catch (Exception ex){
+            throw new ServiceMethodException("deductMemberCoins 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+
 
 
     }

--- a/src/test/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.ham.netnovel.coinUseHistory.service;
+
+import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CoinUseHistoryServiceImplTest {
+  private final   CoinUseHistoryService coinUseHistoryService;
+
+  @Autowired
+    CoinUseHistoryServiceImplTest(CoinUseHistoryService coinUseHistoryService) {
+        this.coinUseHistoryService = coinUseHistoryService;
+    }
+
+    @Test
+    void saveCoinUseHistory() {
+
+        String providerId = "";
+        Long episodeId = 2306L;
+        Integer amount =2;
+
+//        new
+//        coinUseHistoryService.saveCoinUseHistory(providerId,episodeId,amount);
+
+
+    }
+
+    //테스트 성공
+    @Test
+    void getMemberCoinUseHistory(){
+//        String providerId = "";
+        String providerId = "33";//없는 유저, 빈리스트 반환됨
+
+
+        List<MemberCoinUseHistoryDto> memberCoinUseHistory = coinUseHistoryService.getMemberCoinUseHistory(providerId);
+
+        if (memberCoinUseHistory.isEmpty()){
+            System.out.println("비었음");
+
+        }
+
+        for (MemberCoinUseHistoryDto memberCoinUseHistoryDto : memberCoinUseHistory) {
+            System.out.println(memberCoinUseHistoryDto.toString());
+
+        }
+
+
+    }
+}

--- a/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
@@ -38,4 +38,25 @@ class MemberServiceImplTest {
 
 
     }
+
+    //테스트 완료
+    @Test
+    public void deductMemberCoins(){
+
+//        String providerId = "";
+        //존재하지않은 사용자 테스트
+        String providerId = "testtest";//NoSuchElementException로 던져짐
+
+        Integer coinAmount = 3;
+
+        //null체크 테스트
+//        Integer coinAmount = null; //IllegalArgumentException로 던져짐
+//        Integer coinAmount = 0;
+
+
+        memberService.deductMemberCoins(providerId,coinAmount);
+
+
+
+    }
 }


### PR DESCRIPTION
## 개요
이 PR은 코인 사용 기록 기능을 구현하고 관련된 서비스, 컨트롤러 및 테스트를 추가합니다.

## 변경 사항
- **CoinUseHistoryController**
  - 컨트롤러 계층 생성
  - 코인 사용 기록을 저장하는 API 추가 (createCoinUseHistory)
    - 유저 정보(providerId), episodeId를 클라이언트로부터 넘겨받아 요청 처리

- **CoinUseHistoryService**
  - 서비스 계층 생성
  - 유저의 코인 사용을 기록하는 메서드 생성 (saveCoinUseHistory)
    - providerId, episodeId 값으로 Member, Episode 엔티티 반환받음
    - 반환받은 엔티티 정보로 CoinUseHistory 엔티티를 만들어 DB에 저장
  - 유저의 코인 사용 기록을 반환하는 메서드 생성 (getMemberCoinUseHistory)
    - providerId 값을 파라미터로 받아 로직 실행
    - ToDo: 반환 DTO 멤버변수 수정 필요 (결제 시스템 수정 후 진행)

- **CoinUseHistoryRepository**
  - 리포지토리 계층 생성
  - 유저 정보로 CoinUseHistory 엔티티를 반환하는 메서드 추가
    - 생성시간(createdAt)으로 내림차순 정렬하여 반환 (최근에 생성된 기록이 먼저 위치)

- **CoinUseHistoryServiceImplTest**
  - 테스트 계층 생성
  - saveCoinUseHistory, getMemberCoinUseHistory 메서드 단위 테스트 성공

- **MemberCoinUseHistoryDto**
  - 유저의 코인 사용 기록을 저장하기 위한 DTO 추가

- **MemberMyPageService**
  - 유저의 코인 사용 기록을 반환하는 메서드 생성 (getMemberCoinUseHistory)
    - 파라미터로 providerId 값을 받아 null 체크
    - coinUseHistoryService로부터 DTO 리스트 받아와서 MemberController에 전달

- **MemberController**
  - 유저의 코인 사용 기록을 클라이언트에 보내는 API 추가 (postMemberCoinUseHistory)

- **MemberService**
  - 유저의 코인 수를 감소시키는 메서드 생성 (deductMemberCoins)
    - 파라미터로 사용한 코인 양을 Integer로 받음
    - 코인이 null이거나 음수면 예외로 던짐
    - 유저 정보가 null이면 예외로 던짐
    - 유저 엔티티(Member)의 코인 수 필드값을 변경하는 메서드는 Member 엔티티에 있음 (deductCoins)

- **MemberServiceImplTest**
  - deductMemberCoins 테스트 성공

- **NotEnoughCoinsException**
  - RuntimeException 상속받아 사용

- **GlobalExceptionAdvice**
  - NotEnoughCoinsException 예외처리 추가

## 테스트
- saveCoinUseHistory, getMemberCoinUseHistory, deductMemberCoins 메서드에 대한 단위 테스트를 추가하였으며, 모든 테스트가 성공적으로 통과하였습니다.

## 참고 사항
- 결제 시스템 업데이트 후 반환 DTO 멤버 변수 수정이 필요할 수 있습니다.

