### PR TITLE
feat : Novel(소설) Episode 에 달린 댓글을 전송하는 기능 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/CommentController.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentController.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 @Controller
 @Slf4j
+@RequestMapping("/api")
 public class CommentController {
 
 
@@ -45,7 +46,7 @@ public class CommentController {
      * @param authentication   유저의 인증정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @PostMapping("/comment")
+    @PostMapping("/comments")
     public ResponseEntity<String> createComment(@Valid @RequestBody CommentCreateDto commentCreateDto,
                                                 BindingResult bindingResult,
                                                 Authentication authentication) {
@@ -80,7 +81,7 @@ public class CommentController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @PatchMapping("/comment")
+    @PatchMapping("/comments")
     public ResponseEntity<String> updateComment(@Valid @RequestBody CommentUpdateDto commentUpdateDto,
                                                 BindingResult bindingResult,
                                                 Authentication authentication) {
@@ -115,7 +116,7 @@ public class CommentController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @DeleteMapping("/comment")
+    @DeleteMapping("/comments")
     public ResponseEntity<String> deleteComment(@Valid @RequestBody CommentDeleteDto commentDeleteDto,
                                                 BindingResult bindingResult,
                                                 Authentication authentication) {
@@ -151,7 +152,7 @@ public class CommentController {
      * @param requestBody episodeId값을 저장할 객체
      * @return ResponseEntity 댓글 내용을 CommentListDto의 List 형태로 반환
      */
-    @PostMapping("/comment/list")
+    @PostMapping("/comments/episode")
     public ResponseEntity<?> getEpisodeCommentList(@RequestBody Map<String, String> requestBody) {
         String episodeId = requestBody.get("episodeId");
 
@@ -169,6 +170,37 @@ public class CommentController {
         }
 
     }
+
+    /**
+     * Novel(소설) 에피소드에 달린 댓글과 대댓글 정보를 전송하는 API
+     * @param requestBody episodeId를 담는 객체
+     * @return CommentEpisodeListDto 댓글과 대댓글 정보를 담는 객체
+     */
+    @PostMapping("/comments/novel")
+    public ResponseEntity<?> postNovelCommentList(@RequestBody Map<String, String> requestBody){
+        //클라이언트에서 받는 값 객체에 저장, String 타입임
+        String novelIdStr = requestBody.get("novelId");
+        //novelId를 정수타입으로 바꿀때 사용할 변수
+        long novelIdLong;
+        try {
+            //Long 타입으로 타입 캐스팅
+            novelIdLong = Long.parseLong(novelIdStr);
+        }
+        catch (Exception ex) {
+            //예외 발생시 IllegalArgumentException로 던짐
+                throw new IllegalArgumentException("postNovelCommentList API 에러, novelId가 정수가 아닙니다, novelId 값 ="+novelIdStr);
+            }
+            //Novel의 Episode에 달린 댓글과 대댓글을 DTO List로 받음
+            List<CommentEpisodeListDto> novelCommentList = commentService.getNovelCommentList(novelIdLong);
+
+            //클라이언트에 댓글,대댓글 정보 전송
+            return ResponseEntity.ok(novelCommentList);
+
+        }
+
+
+
+
 
     //댓글 생성 테스트용 API
     @GetMapping("/comment/test")

--- a/src/main/java/com/ham/netnovel/comment/CommentRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentRepository.java
@@ -25,6 +25,18 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     List<Comment> findByMember(@Param("providerId")String providerId);
 
 
+    /**
+     * 소설(novel)의 에피소드에 달린 댓글을 DB에서 찾는 메서드
+     * @param novelId 소설의 PK
+     * @return List<Comment>
+     */
+    @Query("select c from Comment c " +
+            "where c.episode.id in " +
+            "(select e.id from Episode e " +
+            "where e.novel.id = :novelId)")
+    List<Comment> findByNovel(@Param("novelId")Long novelId);
+
+
 
 
 

--- a/src/main/java/com/ham/netnovel/comment/service/CommentService.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentService.java
@@ -57,6 +57,14 @@ public interface CommentService {
      */
     List<MemberCommentDto> getMemberCommentList(String providerId);
 
+    /**
+     * Novel에 달린 댓글과 대댓글을 List로 반환하는 메서드
+     * Episode와 상관 없이 댓글 최신순으로 정렬
+     * @param novelId Novel 의 PK 값
+     * @return List 댓글과 대댓글 정보를 담은 DTO List
+     */
+    List<CommentEpisodeListDto> getNovelCommentList(Long novelId);
+
 
 
 

--- a/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
@@ -139,4 +139,29 @@ class CommentServiceImplTest {
 
     }
 
+    //테스트 성공
+    @Test
+    public void getNovelCommentList(){
+//        Long novelId =8L;
+        Long novelId =7L;
+        List<CommentEpisodeListDto> novelCommentList = commentService.getNovelCommentList(novelId);
+        for (CommentEpisodeListDto commentEpisodeListDto : novelCommentList) {
+            System.out.println("*****댓글 정보******");
+            System.out.println(commentEpisodeListDto.getNickName());
+            System.out.println(commentEpisodeListDto.getContent());
+            System.out.println(commentEpisodeListDto.getCreatedAt());
+
+            List<ReCommentListDto> reCommentList = commentEpisodeListDto.getReCommentList();
+            for (ReCommentListDto reCommentListDto : reCommentList) {
+                System.out.println("******대댓글 정보*******");
+                System.out.println(reCommentListDto.getNickName());
+                System.out.println(reCommentListDto.getContent());
+                System.out.println(reCommentListDto.getCreatedAt());
+
+            }
+
+
+        }
+    }
+
 }


### PR DESCRIPTION
- CommentController
  - Novel(소설) 에피소드에 달린 댓글과 대댓글 정보를 전송하는 API 추가(postNovelCommentList)
  - RequestBody에 episodeId 값을 전달받아 사용, 필요시 수정하여 사용
  - 클라이언트에서 보낸 episodeId가 정수가 맞는지 확인 후 아닐경우 IllegalArgumentException 로 던짐
  - 댓글,대댓글 정보가 있으면 DTO List로 전송, 없을경우 빈 리스트 전송

- CommentService
  - Novel(소설) 에피소드에 달린 댓글과 대댓글을 가져오는 메서드 추가(getNovelCommentList) - 파라미터로 novelId를 받음 - 반환되는 DTO 안에 대댓글 DTO List 포함

- CommentServiceImplTest
  - getNovelCommentList 테스트, 테스트 성공

- CommentRepository
  - novelId 로 에피소드에 달린 댓글 엔티티를 DB에서 찾는 메서드 추가(findByNovel)