### PR TITLE
Pull Request: 코인 충전 및 사용 기록 기능 추가 및 수정

### DIFF
--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistory.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistory.java
@@ -4,14 +4,18 @@ package com.ham.netnovel.coinChargeHistory;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class CoinChargeHistory {
 
     @Id
@@ -24,8 +28,9 @@ public class CoinChargeHistory {
     private Integer amount;
 
     @NotNull
+    @Column(precision = 10, scale = 2)
     //지불금액
-    private Integer payment;
+    private BigDecimal payment;
 
 
     @CreationTimestamp
@@ -39,8 +44,11 @@ public class CoinChargeHistory {
     private Member member;
 
 
-
-
-
+    @Builder
+    public CoinChargeHistory(Integer amount, BigDecimal payment, Member member) {
+        this.amount = amount;
+        this.payment = payment;
+        this.member = member;
+    }
 
 }

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
@@ -1,0 +1,63 @@
+package com.ham.netnovel.coinChargeHistory;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
+import com.ham.netnovel.coinChargeHistory.service.CoinChargeHistoryService;
+import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.ValidationErrorHandler;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequestMapping("/api/coin-charge-history")
+public class CoinChargeHistoryController {
+
+    private final CoinChargeHistoryService coinChargeHistoryService;
+    private final Authenticator authenticator;
+
+    public CoinChargeHistoryController(CoinChargeHistoryService coinChargeHistoryService, Authenticator authenticator) {
+        this.coinChargeHistoryService = coinChargeHistoryService;
+        this.authenticator = authenticator;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> chargeMemberCoins(@Valid @RequestBody CoinChargeCreateDto coinChargeCreateDto,
+                                               BindingResult bindingResult,
+                                               Authentication authentication){
+        //CommentUpdateDto Validation 에러가 있을경우 badRequest 전송
+        if (bindingResult.hasErrors()) {
+            log.error("chargeMemberCoins API 에러발생 ={}", bindingResult.getFieldError());
+            //에러 메시지들 List에 담음
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrors(bindingResult);
+            //에러 메시지 body에 담아 전송
+            return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
+        }
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //DTO에 유저 정보 저장
+        coinChargeCreateDto.setProviderId(principal.getName());
+
+        //DB에 기록 저장 후 유저가 소유한 코인 수 증가
+        coinChargeHistoryService.saveCoinChargeHistory(coinChargeCreateDto);
+
+        //응답
+        return ResponseEntity.ok("충전완료");
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryRepository.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.ham.netnovel.coinChargeHistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinChargeHistoryRepository extends JpaRepository<CoinChargeHistory,Long> {
+}

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/dto/CoinChargeCreateDto.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/dto/CoinChargeCreateDto.java
@@ -1,0 +1,30 @@
+package com.ham.netnovel.coinChargeHistory.dto;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.validator.constraints.Range;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoinChargeCreateDto {
+
+    private String providerId;
+
+    //충전한 코인수
+    //ToDo 적절한 코인수 설정 필요
+    @Range(max = 1000, min = 1,message = "충전 코인수가 올바르지 않습니다.")
+    private Integer coinAmount;
+
+    @NotNull
+    //지불금액 String으로 받아서 BigDecimal로 변환
+    private String payment;
+
+
+}

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryImpl.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryImpl.java
@@ -1,0 +1,108 @@
+package com.ham.netnovel.coinChargeHistory.service;
+
+import com.ham.netnovel.coinChargeHistory.CoinChargeHistory;
+import com.ham.netnovel.coinChargeHistory.CoinChargeHistoryRepository;
+import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.NoSuchElementException;
+
+@Service
+public class CoinChargeHistoryImpl implements CoinChargeHistoryService {
+
+    private final CoinChargeHistoryRepository coinChargeHistoryRepository;
+
+    private final MemberService memberService;
+
+    public CoinChargeHistoryImpl(CoinChargeHistoryRepository coinChargeHistoryRepository, MemberService memberService) {
+        this.coinChargeHistoryRepository = coinChargeHistoryRepository;
+        this.memberService = memberService;
+    }
+
+
+    @Override
+    @Transactional
+    public void saveCoinChargeHistory(CoinChargeCreateDto coinChargeCreateDto) {
+
+        //유저 정보 DB 존재유무 확인
+        Member member = memberService.getMember(coinChargeCreateDto.getProviderId())
+                .orElseThrow(() -> new NoSuchElementException("saveCoinChargeHistory 메서드 에러, 유저 정보 없음"));
+
+        //구매한 코인수 유효성 검사
+        int coinAmount = validateCoinAmount(coinChargeCreateDto.getCoinAmount());
+
+        //지불금액 유효성 검사
+        BigDecimal payment = validatePayment(coinChargeCreateDto.getPayment());
+
+        try {
+            //엔티티 생성
+             CoinChargeHistory coinChargeHistory = CoinChargeHistory.builder()
+                    .amount(coinAmount)
+                    .payment(payment)
+                    .member(member)
+                    .build();
+
+             //엔티티 저장
+            coinChargeHistoryRepository.save(coinChargeHistory);
+
+            //멤버 엔티티 코인 갯수 변경
+            memberService.increaseMemberCoins(member,coinAmount);
+
+
+        }catch (Exception ex) {
+            //그외 예외처리
+            throw new ServiceMethodException("saveCoinChargeHistory 메서드 에러 발생" + ex.getMessage()); // 예외 던지기
+        }
+
+
+
+    }
+
+    //구매한 코인 수 유효성 검사, null 또는 음수여서는 안됨
+    //ToDo 최대 코인 갯수 제한
+    private int validateCoinAmount(Integer coinAmount) {
+        if (coinAmount == null ){
+            throw new IllegalArgumentException("saveCoinChargeHistory 메서드 에러 발생, coinAmount 가 null 입니다.");
+        }else if (coinAmount <=0){
+            throw new IllegalArgumentException("saveCoinChargeHistory 메서드 에러 발생, coinAmount 가 음수 입니다.");
+        }
+        return coinAmount;
+    }
+
+    //지불금액 유효성검사, 소수점 2자리 정수부분은 8자리여야함
+    //ToDo 최대 결제 금액 제한
+    private BigDecimal validatePayment(String payment) {
+
+        //null 체크
+        if (payment == null) {
+            throw new IllegalArgumentException("payment 가 null 입니다.");
+        }
+        BigDecimal bigDecimalPayment = new BigDecimal(payment);
+
+        // 음수 값 체크
+        if (bigDecimalPayment.signum() == -1) {
+            throw new IllegalArgumentException("payment 값은 음수가 될 수 없습니다.");
+        }
+
+        // 소수점 이하 자릿수 확인 2자리까지 허용
+        if (bigDecimalPayment.scale() > 2) {
+            throw new IllegalArgumentException("payment 소수점 자리수가 올바르지 않습니다.");
+        }
+
+        // 소수점 자리수 제거
+        BigDecimal integerPart = bigDecimalPayment.setScale(0, RoundingMode.DOWN);
+        //정수 부분이 8자리인지 확인
+        if (!(integerPart.precision() <=8)){
+            throw new IllegalArgumentException("payment 정수 자리수가 올바르지 않습니다.");
+        }
+
+        //변환된 값 반환
+        return bigDecimalPayment;
+    }
+}

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryService.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryService.java
@@ -1,0 +1,15 @@
+package com.ham.netnovel.coinChargeHistory.service;
+
+import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
+
+public interface CoinChargeHistoryService {
+
+
+   /**
+    * 유저의 코인 충전 기록을 저장하고, 유저의 코인 갯수를 늘리는 메서드
+    * @param coinChargeCreateDto providerId(유저정보), amount(충전한 코인갯수), payment(충전금액) 멤버변수 가짐
+    */
+   void  saveCoinChargeHistory(CoinChargeCreateDto coinChargeCreateDto);
+
+
+}

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistory.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistory.java
@@ -5,20 +5,29 @@ import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class CoinUseHistory {
-
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)//auto_increment 자동생성
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "episode_id")
+    private Episode episode;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @NotNull
     //코인 사용갯수
@@ -30,12 +39,12 @@ public class CoinUseHistory {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @ManyToOne
-    @JoinColumn(name = "episode_id")
-    private Episode episode;
+    @Builder
+    public CoinUseHistory(Episode episode, Member member, Integer amount) {
+        this.episode = episode;
+        this.member = member;
+        this.amount = amount;
+    }
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
 
 }

--- a/src/main/java/com/ham/netnovel/coinUseHistory/dto/CoinUseCreateDto.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/dto/CoinUseCreateDto.java
@@ -1,0 +1,27 @@
+package com.ham.netnovel.coinUseHistory.dto;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Builder
+public class CoinUseCreateDto {
+
+    //에피소드 정보
+    @NotNull
+    private Long episodeId;
+
+    //유저 정보
+    private String providerId;
+
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/member/Member.java
+++ b/src/main/java/com/ham/netnovel/member/Member.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member;
 
 
+import com.ham.netnovel.coinUseHistory.CoinUseHistory;
 import com.ham.netnovel.episodeRating.EpisodeRating;
 import com.ham.netnovel.coinChargeHistory.CoinChargeHistory;
 import com.ham.netnovel.comment.Comment;
@@ -25,8 +26,7 @@ public class Member {
     private Long id;
 
 
-
-//  유저 email, naver는 설정값에 따라 도메인이 naver가 아닐수도 있음
+    //  유저 email, naver는 설정값에 따라 도메인이 naver가 아닐수도 있음
     @Column(unique = true)
     private String email;
 
@@ -53,7 +53,6 @@ public class Member {
     private Gender gender;
 
 
-
     //보유한 코인의 갯수
     private Integer coinCount;
     //junction table 연결, 관심 소설
@@ -69,12 +68,17 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<CoinChargeHistory> coinChargeHistories = new ArrayList<>();
 
+    //junction table 연결, 코인 사용 기록
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<CoinUseHistory> coinUseHistories = new ArrayList<>();
+
+
     //junction table 연결, 에피소드 댓글
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public Member(String email, OAuthProvider provider, String providerId, MemberRole role, String nickName, Gender gender,Integer coinCount) {
+    public Member(String email, OAuthProvider provider, String providerId, MemberRole role, String nickName, Gender gender, Integer coinCount) {
         this.email = email;
         this.provider = provider;
         this.providerId = providerId;
@@ -83,7 +87,28 @@ public class Member {
         this.gender = gender;
     }
 
-    public void changeNickName(String nickName){
+    public void changeNickName(String nickName) {
         this.nickName = nickName;
     }
+
+    /**
+     * Member 엔티티 코인 수를 감수시키는 메서드
+     * 파라미터 체크는 메서드를 사용하는 비즈니스 로직에서 진행
+     * @param coinCount
+     */
+    public void deductMemberCoins(int coinCount) {
+        Integer totalCoin = this.getCoinCount();
+        this.coinCount = totalCoin - coinCount;
+    }
+
+    /**
+     * Member 엔티티 코인 수를 증가 시키는 메서드
+     * 파라미터 체크는 메서드를 사용하는 비즈니스 로직에서 진행
+     * @param coinCount 증가시키려는 코인 수
+     */
+    public void increaseMemberCoins(int coinCount){
+        Integer totalCoin = this.getCoinCount();
+        this.coinCount = totalCoin + coinCount;
+    }
+
 }

--- a/src/main/java/com/ham/netnovel/member/service/MemberService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberService.java
@@ -48,6 +48,16 @@ public interface MemberService {
      */
     void deductMemberCoins(String providerId, Integer coinAmount);
 
+    /**
+     * 유저의 코인을 증가시키는 메서드
+     * 파라미터로 받는 member, coinAmount 유효성 검사는 이 메서드를 사용하는 메서드에서 진행 필
+     * @param member 코인을 증가시킬 유저 엔티티
+     * @param coinAmount 증가시킬 코인의 갯수
+     */
+    void increaseMemberCoins(Member member, int coinAmount);
+
+
+
 
 
 

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
@@ -134,7 +134,7 @@ class MemberServiceImpl implements MemberService {
 
         try {
             //엔티티의 coinAmount 차감
-            member.deductCoins(coinAmount);
+            member.deductMemberCoins(coinAmount);
             //엔티티 DB에 저장
             memberRepository.save(member);
         }catch (Exception ex){
@@ -142,6 +142,22 @@ class MemberServiceImpl implements MemberService {
         }
 
 
+
+
+
+    }
+
+    @Override
+    @Transactional
+    public void increaseMemberCoins(Member member, int coinAmount) {
+       try {
+           //멤버 엔티티 코인수 증가
+           member.increaseMemberCoins(coinAmount);
+           //엔티티 저장
+           memberRepository.save(member);
+       }catch (Exception ex){
+           throw new ServiceMethodException("increaseMemberCoins 메서드 에러 발생" + ex.getMessage());
+       }
 
 
 

--- a/src/test/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryImplTest.java
+++ b/src/test/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryImplTest.java
@@ -1,0 +1,52 @@
+package com.ham.netnovel.coinChargeHistory.service;
+
+import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CoinChargeHistoryImplTest {
+
+    private final CoinChargeHistoryService coinChargeHistoryService;
+
+    @Autowired
+    CoinChargeHistoryImplTest(CoinChargeHistoryService coinChargeHistoryService) {
+        this.coinChargeHistoryService = coinChargeHistoryService;
+    }
+
+    @Test
+    void saveCoinChargeHistory() {
+
+        CoinChargeCreateDto coinChargeCreateDto = new CoinChargeCreateDto();
+
+        coinChargeCreateDto.setCoinAmount(5);
+
+        //null 체크 테스트 IllegalArgumentException 던져짐
+//        coinChargeCreateDto.setCoinAmount(null);
+
+//        음수 테스트 IllegalArgumentException 던져짐
+//        coinChargeCreateDto.setCoinAmount(-1);
+
+
+      String payment = "5000.00";
+        //올바르지 않은 자리수 테스트, IllegalArgumentException 던져짐
+//        String payment =5000.000000000;
+
+
+        coinChargeCreateDto.setPayment(payment);
+
+
+        coinChargeCreateDto.setProviderId("test");
+
+        //존재하지않은 유저 테스트 NoSuchElementException 던져짐
+//        coinChargeCreateDto.setProviderId("error");
+
+        coinChargeHistoryService.saveCoinChargeHistory(coinChargeCreateDto);
+
+    }
+}


### PR DESCRIPTION
## Pull Request: 코인 충전 및 사용 기록 기능 추가 및 수정

### CoinChargeHistory 도메인 관련 기능 추가
#### CoinChargeHistoryController
- 유저의 코인 충전 요청을 처리하는 API 추가 (`chargeMemberCoins`)
  - 클라이언트로부터 충전할 코인 수와 결제 금액 정보를 수신
  - 유저 인증 정보에서 `providerId`를 받아 충전 진행

#### CoinChargeHistoryService
- 유저의 코인 충전 기록을 저장하고, 유저의 코인 수를 증가시키는 메서드 추가 (`saveCoinChargeHistory`)
  - `validateCoinAmount` 메서드로 코인 수 유효성 검사
  - `validatePayment` 메서드로 결제 금액 유효성 검사
  - `CoinChargeHistory` 엔티티 생성 및 DB 저장
  - `MemberService` 메서드를 사용해 `Member` 엔티티의 코인 수 증가 후 DB 저장
- `validateCoinAmount`
  - 충전할 코인 수 유효성 검사
  - null이거나 음수일 경우 예외 발생
- `validatePayment`
  - 결제 금액 유효성 검사
  - null이거나 음수, 소수점 자리수가 2자리 이상, 정수 부분이 8자리 이상일 경우 예외 발생

#### CoinChargeHistoryRepository
- Spring Data JPA를 상속받아 리포지토리 계층 생성

#### CoinChargeHistory
- 기본 생성자 추가
- `amount`, `payment`, `member`를 갖는 생성자 추가
- `payment` 컬럼을 BigDecimal 타입으로 변경 (8자리 정수, 소수점 2자리까지 허용)

#### CoinChargeCreateDto
- 코인 충전 기록 생성을 위한 DTO 추가
- `providerId`, `coinAmount`, `payment` 멤버 변수 추가
- `payment`는 String 타입으로, 서비스 계층에서 BigDecimal 타입으로 변환

#### CoinChargeHistoryImplTest
- `saveCoinChargeHistory` 테스트 추가 및 성공 확인

### CoinUseHistory 도메인 관련 기능 수정
#### CoinUseHistory
- 기본 생성자 추가
- `episode`, `member`, `amount` (코인 수) 멤버 변수를 갖는 생성자 추가
- `Episode` 엔티티와 ManyToOne 관계 추가
- `Member` 엔티티와 ManyToOne 관계 추가

#### CoinUseCreateDto
- 코인 사용 기록 저장을 위한 DTO 추가
- `episodeId`, `providerId` 멤버 변수 추가

### Member 도메인 Coin 관련 기능 추가
#### Member
- `CoinUseHistory` 엔티티와 OneToMany 관계 형성
- 코인 수 차감 메서드 추가 (`deductMemberCoins`)
- 코인 수 증가 메서드 추가 (`increaseMemberCoins`)

#### MemberService
- 유저 코인 수를 증가시키는 메서드 추가 (`increaseMemberCoins`)
- `Member` 엔티티의 코인 수 증가 후 리포지토리 메서드를 통해 DB 업데이트 진행
