### PR TITLE
- feat : 유저의 코인 충전 기록을 반환하는 기능 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryRepository.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryRepository.java
@@ -1,6 +1,18 @@
 package com.ham.netnovel.coinChargeHistory;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CoinChargeHistoryRepository extends JpaRepository<CoinChargeHistory,Long> {
+
+
+    /**
+     *
+     * @param providerId
+     * @return
+     */
+    List<CoinChargeHistory> findByMemberProviderId(@Param("providerId") String providerId);
+
 }

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryService.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryService.java
@@ -1,6 +1,9 @@
 package com.ham.netnovel.coinChargeHistory.service;
 
 import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
+import com.ham.netnovel.member.dto.MemberCoinChargeDto;
+
+import java.util.List;
 
 public interface CoinChargeHistoryService {
 
@@ -10,6 +13,14 @@ public interface CoinChargeHistoryService {
     * @param coinChargeCreateDto providerId(유저정보), amount(충전한 코인갯수), payment(충전금액) 멤버변수 가짐
     */
    void  saveCoinChargeHistory(CoinChargeCreateDto coinChargeCreateDto);
+
+
+   /**
+    * 유저 정보로 CoinChargeHistory 엔티티를 찾아 DTO로 반환하는 메서드
+    * @param providerId 유저 정보
+    * @return List MemberCoinChargeDto 로 변환해서 반환
+    */
+   List<MemberCoinChargeDto> getCoinChargeHistoryByMember(String providerId);
 
 
 }

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -2,12 +2,9 @@ package com.ham.netnovel.member;
 
 
 import com.ham.netnovel.OAuth.CustomOAuth2User;
-import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
+import com.ham.netnovel.member.dto.*;
 import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.service.MemberService;
-import com.ham.netnovel.member.dto.ChangeNickNameDto;
-import com.ham.netnovel.member.dto.MemberCommentDto;
-import com.ham.netnovel.member.dto.MemberOAuthDto;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
 import jakarta.validation.Valid;
@@ -107,7 +104,6 @@ public class MemberController {
     /**
      * 유저가 작성한 댓글, 대댓글을 반환하는 API
      * API 요청시 인증 정보를 확인 한 후, 인증된 유저가 작성한 댓글,대댓글을 DTO 변환후 List 형태로 반환
-     *
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 댓글과 대댓글의 정보를 body에 담아 반환
      */
@@ -152,6 +148,12 @@ public class MemberController {
 
     }
 
+
+    /**
+     * 유저가 코인 사용 기록 열람을 요청하면, body에 담아 전송하는 API
+     * @param authentication 유저의 인정 정보
+     * @return ResponseEntity 데이터를 List에 담아 반환
+     */
     @PostMapping("/members/coin-use-history")
     public ResponseEntity<?> postMemberCoinUseHistory(Authentication authentication) {
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
@@ -162,6 +164,22 @@ public class MemberController {
 
         // 응답 반환
         return ResponseEntity.ok(coinUseHistory);
+
+    }
+
+    /**
+     * 유저가 코인 충전 기록 열람을 요청하면, body에 담아 전송하는 API
+     * @param authentication 유저의 인정 정보
+     * @return ResponseEntity 데이터를 List에 담아 반환
+     */
+    @PostMapping("/members/coin-charge-history")
+    public ResponseEntity<List<MemberCoinChargeDto>> postMemberCoinChargeHistory(Authentication authentication){
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+        //유저 코인 충전 기록 조회
+        List<MemberCoinChargeDto> memberCoinChargeHistory = memberMyPageService.getMemberCoinChargeHistory(principal.getName());
+        // 응답 반환
+        return ResponseEntity.ok(memberCoinChargeHistory);
 
     }
 

--- a/src/main/java/com/ham/netnovel/member/dto/MemberCoinChargeDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberCoinChargeDto.java
@@ -1,0 +1,31 @@
+package com.ham.netnovel.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberCoinChargeDto {
+
+
+    private String providerId;
+
+
+    @NotNull
+    private Integer coinAmount;
+
+    @NotNull
+    private LocalDateTime createdAt;
+
+
+    @NotNull
+    private BigDecimal payment;
+
+}

--- a/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member.service;
 
 
+import com.ham.netnovel.member.dto.MemberCoinChargeDto;
 import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
@@ -18,6 +19,15 @@ public interface MemberMyPageService {
 
 
     List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId);
+
+
+    /**
+     * 유저의 코인 충전 기록을 가져오는 메서드
+     * 최근 충전 기록이 index 앞에 위치
+     * @param providerId 유저 정보
+     * @return List MemberCoinChargeDto 형태로 변환해서 반환
+     */
+    List<MemberCoinChargeDto> getMemberCoinChargeHistory(String providerId);
 
 
 

--- a/src/test/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/coinChargeHistory/service/CoinChargeHistoryServiceImplTest.java
@@ -10,12 +10,12 @@ import java.math.BigDecimal;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-class CoinChargeHistoryImplTest {
+class CoinChargeHistoryServiceImplTest {
 
     private final CoinChargeHistoryService coinChargeHistoryService;
 
     @Autowired
-    CoinChargeHistoryImplTest(CoinChargeHistoryService coinChargeHistoryService) {
+    CoinChargeHistoryServiceImplTest(CoinChargeHistoryService coinChargeHistoryService) {
         this.coinChargeHistoryService = coinChargeHistoryService;
     }
 

--- a/src/test/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.member.service.impl;
 
+import com.ham.netnovel.member.dto.MemberCoinChargeDto;
 import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
@@ -41,16 +42,35 @@ class MemberMyPageServiceImplTest {
     @Test
     void getFavoriteNovelsByMember() {
         //테스트용 계정
-//                String providerId= "U";
+                String providerId= "test";
 
         //에러 테스트, IllegalArgumentException로 던져짐
-        String providerId = "";
+//        String providerId = "";
 
 
         List<NovelFavoriteDto> favoriteNovelsByMember = memberMyPageService.getFavoriteNovelsByMember(providerId);
         for (NovelFavoriteDto novelFavoriteDto : favoriteNovelsByMember) {
-            System.out.println("소설정보");
+            System.out.println("***** 소설정보 *****");
             System.out.println(novelFavoriteDto.toString());
+
+        }
+
+
+    }
+
+    //테스트 성공
+    @Test
+    void getMemberCoinChargeHistory(){
+        //테스트용 계정
+//                String providerId= "test";
+
+        //Null 테스트 IllegalArgumentException로 던져짐
+        String providerId = null;
+
+        List<MemberCoinChargeDto> memberCoinChargeHistory = memberMyPageService.getMemberCoinChargeHistory(providerId);
+        for (MemberCoinChargeDto memberCoinChargeDto : memberCoinChargeHistory) {
+            System.out.println("***** 코인 충전 기록 *****");
+            System.out.println(memberCoinChargeDto.toString());
 
         }
 


### PR DESCRIPTION
- CoinChargeHistoryRepository
  - 유저의 providerId로 CoinChargeHistory 레코드를 DB에서 찾아 List로 반환하는 메서드 추가(findByMemberProviderId)

-  CoinChargeHistoryService
  - 유저의 코인 사용 기록을 DTO List로 반환하는 메서드 추가(getCoinChargeHistoryByMember)
  - 파라미터로 providerId를 받음
  - DTO는 payment, coinAmount(충전한코인수), createdAt(충전시간) 멤버변수로 가짐

-  CoinChargeHistoryServiceImpl
  - 클래스 이름 리펙토링 - CoinChargeHistoryImpl -> CoinChargeHistoryServiceImpl

- CoinChargeHistoryServiceImplTest
  - 클래스 이름 리펙토링 - CoinChargeHistoryImplTest -> CoinChargeHistoryServiceImplTest

- MemberCoinChargeDto
  - 유저의 코인 사용 기록을 클라이언트에게 반환할때 사용하는 DTO 생성
  - providerId, coinAmount(충전한 코인 수), payment(지불금액) ,createdAt(충전시간) 멤버변수로 가짐

- MemberMyPageService
 - 유저의 코인 사용 기록 List를 최신순으로 정렬하여 반환하는 메서드 추가(getMemberCoinChargeHistory)
   - 코인 사용 기록은 CoinChargeHistoryImpl 클래스의 메서드 사용
   - providerId 유효성 검사 후 null이거나 비어있으면 예외로 던짐
  - 유저의 providerId값을 검증하는 메서드 추가(validateProviderId)
    - null 이거나 비어있으면 예외로 던짐

- MemberMyPageServiceImplTest
  - getMemberCoinChargeHistory 테스트, 테스트 성공

- MemberController
  - 유저가 코인 충전 기록을, body에 담아 전송하는 API 추가 - 유저 인증 정보로 코인 충전 기록을 body에 담아 클라이언트에게 전송