### PR TITLE
댓글 좋아요 기능 추가 및 댓글/유저 관련 클래스 수정

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/Comment.java
+++ b/src/main/java/com/ham/netnovel/comment/Comment.java
@@ -1,6 +1,8 @@
 package com.ham.netnovel.comment;
 
 
+import com.ham.netnovel.commentLike.CommentLike;
+import com.ham.netnovel.commentLike.LikeType;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.reComment.ReComment;
@@ -62,6 +64,10 @@ public class Comment {
     private Member member;
 
 
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private List<CommentLike> commentLikes= new ArrayList<>();
+
+
 
 
 
@@ -83,5 +89,24 @@ public class Comment {
    public  void changeStatus(CommentStatus status) {
         this.status = status;
     }
+
+
+
+    //좋아요 수를 반환하는 메서드
+    public int getTotalLikes(){
+        return (int) commentLikes.stream()
+                .filter(commentLike -> commentLike.getLikeType() == LikeType.LIKE)
+                .count();
+
+    }
+    //싫어요 수를 반환하는 메서드
+    public int getTotalDisLikes(){
+        return (int) commentLikes.stream()
+                .filter(commentLike -> commentLike.getLikeType() == LikeType.DISLIKE)
+                .count();
+
+    }
+
+
 
 }

--- a/src/main/java/com/ham/netnovel/comment/CommentRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentRepository.java
@@ -10,6 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 
 
     @Query("select c from Comment c " +
+            "join fetch c.member m " +
             "where c.episode.id =:episodeId")
     List<Comment> findByEpisodeId(@Param("episodeId")Long episodeId);
 
@@ -20,7 +21,8 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
      * @return List Comment 엔티티 List로 반환
      */
     @Query("select c from Comment c " +
-            "where c.member.providerId =:providerId " +
+            "join fetch c.member m " +
+            "where m.providerId =:providerId " +
             "order by c.createdAt DESC ")//생성 날짜 내림차순 정렬(최신글이 위로오게설정)
     List<Comment> findByMember(@Param("providerId")String providerId);
 

--- a/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
+++ b/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.comment.dto;
 
 import com.ham.netnovel.reComment.dto.ReCommentListDto;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,16 +15,28 @@ import java.util.List;
 public class CommentEpisodeListDto {//뷰에 반환할때 사용하는 DTO
 
 
+    //댓글 PK
     private Long commentId;
 
+    //댓글내용
     private String content;
 
     //작성자 닉네임
     private String nickName;
 
+    //생성시간
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    @Min(0)
+    //좋아요 수
+    private int likes;
+    @Min(0)
+    //싫어요 수
+    private int disLikes;
+
+    //댓글에 달린 대댓글 목록
 
     private List<ReCommentListDto> reCommentList;
 

--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -203,17 +203,21 @@ public class CommentServiceImpl implements CommentService {
     /**
      * Comment 엔티티를 CommentEpisodeListDto로 convert하는 메서드
      * 댓글(Comment)에 달린 대댓글(reComment) 정보도 List로 포함됨
-     * @param comment
-     * @return
+     *
+     * @param comment 파라미터로 받을 댓글 엔티티
+     * @return CommentEpisodeListDto DTO로 변환하여 반환
      */
 
     private CommentEpisodeListDto convertToCommentEpisodeListDto(Comment comment) {
+
         return CommentEpisodeListDto.builder()
-                .nickName(comment.getMember().getNickName())
+                .nickName(comment.getMember().getNickName())//작성자 닉네임
                 .content(comment.getContent())
                 .commentId(comment.getId())
                 .updatedAt(comment.getUpdatedAt())
                 .createdAt(comment.getCreatedAt())
+                .likes(comment.getTotalLikes())//댓글에 달린  좋아요 수
+                .disLikes(comment.getTotalDisLikes())//댓글에 달린 싫어요 수
                 .reCommentList(Optional.ofNullable(comment.getReComments())//대댓글 null 체크
                         .orElse(Collections.emptyList()) // null일 경우 빈 리스트 반환
                         .stream()//연관된 대댓글 엔티티를 DTO 형태로 변환하여 List로 반환
@@ -227,7 +231,6 @@ public class CommentServiceImpl implements CommentService {
                         .collect(Collectors.toList())) // List로 변환
                 .build();
     }
-
 
 
 }

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
@@ -1,0 +1,46 @@
+package com.ham.netnovel.commentLike;
+
+
+import com.ham.netnovel.comment.Comment;
+import com.ham.netnovel.member.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CommentLike {
+
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)//auto_increment 자동생성
+//    private Long id;
+
+    @EmbeddedId
+    private CommentLikeKey id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("memberId") // 복합 키의 memberId 필드와 매핑
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("commentId") // 복합 키의 commentId 필드와 매핑
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    //LIKE, DISLIKE 두가지 타입
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType;
+
+    @Builder
+    public CommentLike(CommentLikeKey id, Member member, Comment comment, LikeType likeType) {
+        this.id = id;
+        this.member = member;
+        this.comment = comment;
+        this.likeType = likeType;
+    }
+}

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLikeController.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLikeController.java
@@ -1,0 +1,78 @@
+package com.ham.netnovel.commentLike;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+import com.ham.netnovel.commentLike.service.CommentLikeService;
+import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.ValidationErrorHandler;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequestMapping("/api/comment-likes")
+public class CommentLikeController {
+
+    private final CommentLikeService commentLikeService;
+
+    private final Authenticator authenticator;
+
+    public CommentLikeController(CommentLikeService commentLikeService, Authenticator authenticator) {
+        this.commentLikeService = commentLikeService;
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * 댓글 좋아요 요청을 받아 처리하는 API
+     * 댓글에 좋아요를 누른 기록이 없으면, 해당 내용 DB에 저장
+     * 댓글에 좋아요를 누른 기록이 있으면 기록 삭제
+     * @param commentLikeToggleDto commentId, providerId(유저 정보), likeType(좋아요,싫어요 정보) 담는 DTO
+     * @param bindingResult DTO 유효성 검사 결과
+     * @param authentication 유저 인증 정보
+     * @return ResponseEntity body에 내용 담아 전달
+     */
+    @PostMapping
+    public ResponseEntity<?> toggleCommentLikeStatus(@Valid @RequestBody CommentLikeToggleDto commentLikeToggleDto,
+                                                     BindingResult bindingResult,
+                                                     Authentication authentication) {
+
+        //클라이언트에서 보낸 데이터 유효성 검사, 에러가 있을경우 에러메시지 전송
+        if (bindingResult.hasErrors()){
+            //에러 메시지들 List에 담음
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrors(bindingResult);
+            //서버에 로그 출력
+            log.error("toggleCommentLikeStatus API 에러발생 ={}",errorMessages);
+            //에러 메시지 body에 담아 전송
+            return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
+        }
+
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //DTO에 유저 인증 정보 저장
+        commentLikeToggleDto.setProviderId(principal.getName());
+
+        //유저가 댓글에 좋아요 누른 기록이 있으면 삭제후 false 반환, 없으면 DB에 저장후 true 반환
+        boolean result = commentLikeService.toggleCommentLikeStatus(commentLikeToggleDto);
+
+        //결과 검증
+        if(result){
+            return ResponseEntity.ok("좋아요 등록 완료");
+        }else {
+            return ResponseEntity.ok("좋아요 삭제 완료");
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLikeKey.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLikeKey.java
@@ -1,0 +1,38 @@
+package com.ham.netnovel.commentLike;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CommentLikeKey implements Serializable {//composite PK 정의 class
+    private Long commentId;
+    private Long memberId;
+
+    //객체 동등성 판단
+    @Override
+    public boolean equals(Object o) {
+        //파라미터로 받은 객체와 자신을 비교, 동일한 객체일경우 true 반환
+        if (this == o) return true;
+        //파라미터로 받은 객체가 null 이거나, 현재 클래스와 다른 클래스일경우 false 반환
+        if (o == null || getClass() != o.getClass()) return false;
+        //타입 캐스팅
+        CommentLikeKey that = (CommentLikeKey) o;
+        //파라미터로 받은 객체와 현재 객체의 필드값 비교, 두 필드값이 모두 동일해야 true 반환
+        return Objects.equals(commentId, that.commentId) && Objects.equals(memberId, that.memberId);    }
+
+    //equals()가 true를 반환할때, 객체들이 도일한 해시 코드 값을 반환하도록 보장하는 메서드
+    @Override
+    public int hashCode() {
+        return Objects.hash(commentId, memberId);
+    }
+}

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLikeRepository.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package com.ham.netnovel.commentLike;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
+
+
+    Optional<CommentLike> findById(CommentLikeKey id);
+}

--- a/src/main/java/com/ham/netnovel/commentLike/LikeType.java
+++ b/src/main/java/com/ham/netnovel/commentLike/LikeType.java
@@ -1,0 +1,7 @@
+package com.ham.netnovel.commentLike;
+
+public enum LikeType {//좋아요 타입
+    LIKE,//좋아요
+    DISLIKE//싫어요
+
+}

--- a/src/main/java/com/ham/netnovel/commentLike/dto/CommentLikeToggleDto.java
+++ b/src/main/java/com/ham/netnovel/commentLike/dto/CommentLikeToggleDto.java
@@ -1,0 +1,25 @@
+package com.ham.netnovel.commentLike.dto;
+
+import com.ham.netnovel.commentLike.LikeType;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentLikeToggleDto {
+
+
+    private String providerId;//유저정보
+
+
+    @NotNull(message = "좋아요 정보가 없습니다.")
+    private LikeType likeType;//좋아요/싫어요 선택 정보
+
+    @NotNull(message = "댓글 정보가 없습니다.")
+    private Long commentId;//좋아요 누른 댓글의 PK 정보
+
+
+}

--- a/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
+++ b/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
@@ -1,0 +1,27 @@
+package com.ham.netnovel.commentLike.service;
+
+import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+
+public interface CommentLikeService {
+
+
+    /**
+     * 댓글의 좋아요 상태를 저장하는 메서드
+     * 좋아요 누른 기록이 없으면, 새로운 엔티티를 만들어 DB에 저장 후 true 반환
+     * 좋아요 누른 기록이 있으면, DB에서 정보 삭제 후 false 반환
+     * @param providerId 유저 정보
+     * @param commentId 댓글의 Pk
+     * @return boolean 상태 저장 성공 여부
+     */
+
+    /**
+     * 댓글의 좋아요 상태를 저장하는 메서드
+     * 좋아요 누른 기록이 없으면, 새로운 엔티티를 만들어 DB에 저장 후 true 반환
+     * 좋아요 누른 기록이 있으면, DB에서 정보 삭제 후 false 반환
+     * @param commentLikeToggleDto 유저 정보, 댓글정보, 좋아요타입을 멤버변수로 갖는 DTO
+     * @return boolean 좋아요 상태 저장시 true, 삭제시 false 반환
+     */
+    boolean toggleCommentLikeStatus(CommentLikeToggleDto commentLikeToggleDto);
+
+}

--- a/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImpl.java
@@ -1,0 +1,75 @@
+package com.ham.netnovel.commentLike.service;
+
+import com.ham.netnovel.comment.Comment;
+import com.ham.netnovel.comment.service.CommentService;
+import com.ham.netnovel.commentLike.CommentLike;
+import com.ham.netnovel.commentLike.CommentLikeKey;
+import com.ham.netnovel.commentLike.CommentLikeRepository;
+import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+
+@Service
+public class CommentLikeServiceImpl implements CommentLikeService {
+
+    private final MemberService memberService;
+    private final CommentLikeRepository commentLikeRepository;
+
+    private final CommentService commentService;
+
+    public CommentLikeServiceImpl(MemberService memberService, CommentLikeRepository commentLikeRepository, CommentService commentService) {
+        this.memberService = memberService;
+        this.commentLikeRepository = commentLikeRepository;
+        this.commentService = commentService;
+    }
+
+    @Override
+    @Transactional
+    public boolean toggleCommentLikeStatus(CommentLikeToggleDto commentLikeToggleDto) {
+
+        //멤버 엔티티 조회, 없을경우 예외로 던짐
+        Member member = memberService.getMember(commentLikeToggleDto.getProviderId())
+                .orElseThrow(() -> new NoSuchElementException("saveCommentLikeStatus 메서드 에러, 유저 정보가 null입니다. providerId=" + commentLikeToggleDto.getProviderId()));
+
+        //댓글 엔티티 조회, 없을경우 예외로 던짐
+        Comment comment = commentService.getComment(commentLikeToggleDto.getCommentId())
+                .orElseThrow(() -> new NoSuchElementException("saveCommentLikeStatus 메서드 에러, 댓글 정보가 null입니다. commentId=" + commentLikeToggleDto.getCommentId()));
+
+        try {
+            //CommentLike 엔티티 조회를 위한 composite key 생성
+            CommentLikeKey commentLikeKey = new CommentLikeKey(comment.getId(), member.getId());
+
+            //DB에서 엔티티 찾아서 반환
+            Optional<CommentLike> commentLike = commentLikeRepository.findById(commentLikeKey);
+
+            //찾은 값이 없으면(좋아요 누른 기록이 없음), 새로운 엔티티 만들어 DB에 저장 후 true 반환
+            if (commentLike.isEmpty()) {
+
+                CommentLike newCommentLike = new CommentLike(commentLikeKey, member, comment, commentLikeToggleDto.getLikeType());
+
+                commentLikeRepository.save(newCommentLike);
+
+                return true;
+            } else {
+                //찾은 값이 있으면(좋아요 누른 기록이 있음) 좋아요 기록 삭제, false 반환
+                commentLikeRepository.delete(commentLike.get());
+
+                return false;
+            }
+
+        } catch (Exception ex) {
+            // 그 외의 예외는 ServiceMethodException으로 래핑하여 던짐
+            throw new ServiceMethodException("saveCommentLikeStatus 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/common/utils/TypeValidationUtil.java
+++ b/src/main/java/com/ham/netnovel/common/utils/TypeValidationUtil.java
@@ -1,0 +1,28 @@
+package com.ham.netnovel.common.utils;
+
+public class TypeValidationUtil {
+
+
+    /**
+     * String 타입으로 받은 파라미터를 Long 타입으로 변환하는 메서드
+     * Long 타입이 아니거나 null일경우 예외로 던짐
+     * @param value value 검증할 문자열
+     * @return Long 타입으로 파싱후 변환된 문자열
+     * @throws IllegalArgumentException 유효하지 않은 파라미터일경우 던져질 예외
+     */
+    public static Long validateLong(String value){
+        //null 체크
+        if (value==null){
+            throw new IllegalArgumentException("validateLong 에러, 파라미터가 null 입니다");
+        }
+        try {
+            return Long.parseLong(value);
+        }catch (NumberFormatException  ex){
+            throw new IllegalArgumentException("validateLong 에러, 파라미터가 Long 타입이 아닙니다");
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/member/Member.java
+++ b/src/main/java/com/ham/netnovel/member/Member.java
@@ -60,7 +60,7 @@ public class Member {
     private List<FavoriteNovel> favoriteNovels = new ArrayList<>();
 
 
-    //junction table 연결,별 점준 에피소드
+    //1:N 연결,,별 점준 에피소드
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<EpisodeRating> episodeRatings = new ArrayList<>();
 
@@ -73,7 +73,7 @@ public class Member {
     private List<CoinUseHistory> coinUseHistories = new ArrayList<>();
 
 
-    //junction table 연결, 에피소드 댓글
+    //1:N 연결, 에피소드 댓글
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/ham/netnovel/member/MemberRepository.java
+++ b/src/main/java/com/ham/netnovel/member/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -13,6 +14,9 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
      * @param providerId 유저의 providerId값
      * @return Optional 형태로 반환
      */
+
+    @Query("select m from Member m " +
+            "where m.providerId =:providerId")
     Optional<Member> findByProviderId(@Param("providerId")String providerId);
 
 

--- a/src/test/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImplTest.java
@@ -1,0 +1,50 @@
+package com.ham.netnovel.commentLike.service;
+
+import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CommentLikeServiceImplTest {
+
+
+    private final CommentLikeService commentLikeService;
+
+    @Autowired
+    CommentLikeServiceImplTest(CommentLikeService commentLikeService) {
+        this.commentLikeService = commentLikeService;
+    }
+
+
+    @Test
+    void toggleCommentLikeStatus() {
+
+        String providerId = "test";
+
+//        존재하지 않는 사용자 테스트 NoSuchElementException 던져짐
+//        String providerId = "ccc";
+
+
+
+//        Long commentId = 14L;
+        //존재하지 않는 댓글 테스트 NoSuchElementException 던져짐
+        Long commentId = 56445646L;
+
+
+        LikeType like = LikeType.LIKE;
+
+        CommentLikeToggleDto build = CommentLikeToggleDto.builder()
+                .providerId(providerId)
+                .likeType(like)
+                .commentId(commentId)
+                .build();
+
+
+        boolean result = commentLikeService.toggleCommentLikeStatus(build);
+
+        System.out.println(result);
+
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항

#### 1. 댓글 좋아요 기능 구현

- **CommentLike 엔티티 추가**
  - `CommentLike`: 댓글 좋아요 엔티티로, `memberId`와 `commentId`로 구성된 `EmbeddedId`(복합 기본 키)를 사용합니다.
  - `LikeType`: `LIKE`와 `DISLIKE` 상태를 가지는 enum 타입 멤버 변수를 추가합니다.

- **LikeType enum 클래스 추가**
  - 댓글 좋아요 타입을 지정하기 위한 enum 클래스입니다.
  - `LIKE`, `DISLIKE` 두 가지 상태를 가집니다.

- **CommentLikeKey 클래스 추가**
  - `CommentLike`의 `EmbeddedId` 정의 클래스로, `memberId`와 `commentId`로 키를 생성합니다.

- **CommentLikeRepository 추가**
  - `CommentLike` 리포지토리 계층을 추가하고, `EmbeddedId`로 엔티티를 찾는 메서드(`findById`)를 추가합니다.
  - `CommentLikeKey` 타입을 사용합니다.

- **CommentLikeService 추가**
  - 댓글의 좋아요 상태를 토글하는 메서드(`toggleCommentLikeStatus`)를 추가합니다.
  - `commentId`와 `memberId`의 `EmbeddedId`로 `CommentLike` 테이블을 조회하여, 값이 있으면 레코드를 삭제하고 `false`를 반환하며, 값이 없으면 DB에 저장하고 `true`를 반환합니다.
  - 에러 발생 시 예외를 던집니다.

- **CommentLikeServiceImplTest 추가**
  - `toggleCommentLikeStatus` 메서드의 테스트를 추가하고, 테스트가 성공했음을 확인합니다.

- **CommentLikeController 추가**
  - 댓글 좋아요 요청을 받아 처리하는 API를 추가합니다.
  - 댓글에 좋아요를 누른 기록이 없으면, 해당 내용을 DB에 저장하고, 댓글에 좋아요를 누른 기록이 있으면 기록을 삭제합니다.

- **CommentLikeToggleDto 추가**
  - 클라이언트에서 보낸 정보를 담는 DTO로, `providerId`(유저정보), `likeType`(좋아요, 싫어요 정보), `commentId`(댓글 pk)를 멤버 변수로 가집니다.

#### 2. 댓글 관련 클래스 및 메서드 수정

- **Comment 클래스 수정**
  - `CommentLike`와의 `OneToMany` 관계를 추가합니다.

- **CommentServiceImpl 수정**
  - `convertToCommentEpisodeListDto` 메서드 로직을 수정하여, 댓글 DTO에 좋아요, 싫어요 정보를 멤버 변수에 담는 로직을 추가합니다.

- **CommentRepository 최적화**
  - JPQL 구문을 최적화하고, N:1 관계에 있는 테이블에 `join fetch`를 적용합니다.

- **CommentEpisodeListDto 수정**
  - 좋아요 수와 싫어요 수를 저장하는 멤버 변수를 추가합니다(`likes`, `disLikes`).
  - `int` 타입을 사용합니다.

- **CommentController 수정**
  - API에서 `Long` 타입 파라미터 유효성 검사 메서드를 추출하여, `TypeValidationUtil.validateLong`으로 유효성 검사를 진행합니다.

- **TypeValidationUtil 추가**
  - 파라미터 타입 유효성 검사 유틸리티 클래스를 추가합니다.
  - `Long` 타입 검사 메서드를 추가하여, 문자열 매개변수를 받아 null 체크 후 `Long` 타입으로 파싱하고, null이거나 파싱 에러가 발생하면 예외를 던지며, 이상 없으면 `Long` 타입으로 파싱한 값을 반환합니다.

#### 3. 유저 관련 클래스 및 메서드 수정

- **Member 클래스 수정**
  - 주석을 수정합니다.

- **MemberRepository 수정**
  - `findByProviderId` 메서드를 JPQL로 변경합니다.
