### PR TITLE
대댓글 좋아요 기능 구현 및 관련 클래스, 메서드 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -135,6 +135,8 @@ public class CommentServiceImpl implements CommentService {
 
     }
 
+    //ToDo 댓글 좋아요 순서로 정렬
+    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<CommentEpisodeListDto> getEpisodeCommentList(Long episodeId) {
@@ -156,6 +158,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
 
+    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<MemberCommentDto> getMemberCommentList(String providerId) {
@@ -181,6 +184,8 @@ public class CommentServiceImpl implements CommentService {
 
     }
 
+    //ToDo 댓글 좋아요 순서로 정렬
+    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<CommentEpisodeListDto> getNovelCommentList(Long novelId) {
@@ -227,6 +232,8 @@ public class CommentServiceImpl implements CommentService {
                                 .reCommentId(reComment.getComment().getId())
                                 .createdAt(reComment.getCreatedAt())
                                 .updatedAt(reComment.getUpdatedAt())
+                                .likes(reComment.getTotalLikes())//댓글에 달린 싫어요 수
+                                .disLikes(reComment.getTotalDisLikes())//대댓글에 달린 싫어요 수
                                 .build())
                         .collect(Collectors.toList())) // List로 변환
                 .build();

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
@@ -13,10 +13,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentLike {
 
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)//auto_increment 자동생성
-//    private Long id;
-
     @EmbeddedId
     private CommentLikeKey id;
 

--- a/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
+++ b/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
@@ -6,14 +6,6 @@ import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
 public interface CommentLikeService {
 
 
-    /**
-     * 댓글의 좋아요 상태를 저장하는 메서드
-     * 좋아요 누른 기록이 없으면, 새로운 엔티티를 만들어 DB에 저장 후 true 반환
-     * 좋아요 누른 기록이 있으면, DB에서 정보 삭제 후 false 반환
-     * @param providerId 유저 정보
-     * @param commentId 댓글의 Pk
-     * @return boolean 상태 저장 성공 여부
-     */
 
     /**
      * 댓글의 좋아요 상태를 저장하는 메서드

--- a/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeServiceImpl.java
@@ -37,11 +37,11 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
         //멤버 엔티티 조회, 없을경우 예외로 던짐
         Member member = memberService.getMember(commentLikeToggleDto.getProviderId())
-                .orElseThrow(() -> new NoSuchElementException("saveCommentLikeStatus 메서드 에러, 유저 정보가 null입니다. providerId=" + commentLikeToggleDto.getProviderId()));
+                .orElseThrow(() -> new NoSuchElementException("toggleCommentLikeStatus 메서드 에러, 유저 정보가 null입니다. providerId=" + commentLikeToggleDto.getProviderId()));
 
         //댓글 엔티티 조회, 없을경우 예외로 던짐
         Comment comment = commentService.getComment(commentLikeToggleDto.getCommentId())
-                .orElseThrow(() -> new NoSuchElementException("saveCommentLikeStatus 메서드 에러, 댓글 정보가 null입니다. commentId=" + commentLikeToggleDto.getCommentId()));
+                .orElseThrow(() -> new NoSuchElementException("toggleCommentLikeStatus 메서드 에러, 댓글 정보가 null입니다. commentId=" + commentLikeToggleDto.getCommentId()));
 
         try {
             //CommentLike 엔티티 조회를 위한 composite key 생성
@@ -67,7 +67,7 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
         } catch (Exception ex) {
             // 그 외의 예외는 ServiceMethodException으로 래핑하여 던짐
-            throw new ServiceMethodException("saveCommentLikeStatus 메서드 에러 발생" + ex.getMessage());
+            throw new ServiceMethodException("toggleCommentLikeStatus 메서드 에러 발생" + ex.getMessage());
         }
 
 

--- a/src/main/java/com/ham/netnovel/reComment/ReComment.java
+++ b/src/main/java/com/ham/netnovel/reComment/ReComment.java
@@ -3,6 +3,7 @@ package com.ham.netnovel.reComment;
 
 import com.ham.netnovel.comment.Comment;
 import com.ham.netnovel.comment.CommentStatus;
+import com.ham.netnovel.commentLike.LikeType;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -12,6 +13,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -48,6 +51,8 @@ public class ReComment {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "reComment", fetch = FetchType.LAZY)
+    private List<ReCommentLike>  reCommentLikes =new ArrayList<>();
 
     @Builder
     public ReComment(String content, Comment comment, Member member) {
@@ -65,6 +70,22 @@ public class ReComment {
     public  void changeReStatus(CommentStatus status) {
         this.status = status;
     }
+
+    //좋아요 수를 반환하는 메서드
+    public int getTotalLikes(){
+        return (int) reCommentLikes.stream()
+                .filter(commentLike -> commentLike.getLikeType() == LikeType.LIKE)
+                .count();
+
+    }
+    //싫어요 수를 반환하는 메서드
+    public int getTotalDisLikes(){
+        return (int) reCommentLikes.stream()
+                .filter(commentLike -> commentLike.getLikeType() == LikeType.DISLIKE)
+                .count();
+
+    }
+
 
 
 

--- a/src/main/java/com/ham/netnovel/reComment/ReCommentLike.java
+++ b/src/main/java/com/ham/netnovel/reComment/ReCommentLike.java
@@ -1,0 +1,41 @@
+package com.ham.netnovel.reComment;
+
+import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.reCommentLike.ReCommentLikeKey;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ReCommentLike {
+
+    @EmbeddedId
+    private ReCommentLikeKey id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("memberId") // 복합 키의 memberId 필드와 매핑
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("reCommentId")// 복합 키의 reCommentId 필드와 매핑
+    @JoinColumn(name="re_comment_id")
+    private ReComment reComment;
+
+    //LIKE, DISLIKE 두가지 타입
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType;
+
+    @Builder
+    public ReCommentLike(ReCommentLikeKey id, Member member, ReComment reComment, LikeType likeType) {
+        this.id = id;
+        this.member = member;
+        this.reComment = reComment;
+        this.likeType = likeType;
+    }
+}

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.reComment.dto;
 
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -18,6 +19,14 @@ public class ReCommentListDto {
 
     //작성자 닉네임
     private String nickName;
+
+
+    @Min(0)
+    //좋아요 수
+    private int likes;
+    @Min(0)
+    //싫어요 수
+    private int disLikes;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeController.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeController.java
@@ -1,0 +1,75 @@
+package com.ham.netnovel.reCommentLike;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.ValidationErrorHandler;
+import com.ham.netnovel.reCommentLike.service.ReCommentLikeService;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequestMapping("/api/re-comment-likes")
+public class ReCommentLikeController {
+
+    private final ReCommentLikeService reCommentLikeService;
+
+    private final Authenticator authenticator;
+
+    public ReCommentLikeController(ReCommentLikeService reCommentLikeService, Authenticator authenticator) {
+        this.reCommentLikeService = reCommentLikeService;
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * 대댓글 좋아요 요청을 받아 처리하는 API
+     * 대댓글 좋아요를 누른 기록이 없으면, 해당 내용 DB에 저장
+     * 대댓글 좋아요를 누른 기록이 있으면 기록 삭제
+     * @param reCommentLikeToggleDto reCommentId, providerId(유저 정보), likeType(좋아요,싫어요 정보) 담는 DTO
+     * @param bindingResult DTO 유효성 검사 결과
+     * @param authentication 유저 인증 정보
+     * @return ResponseEntity body에 내용 담아 전달
+     */
+    @PostMapping
+    public ResponseEntity<?> toggleReCommentLikeStatus(@Valid @RequestBody ReCommentLikeToggleDto reCommentLikeToggleDto,
+                                                     BindingResult bindingResult,
+                                                     Authentication authentication) {
+
+        //클라이언트에서 보낸 데이터 유효성 검사, 에러가 있을경우 에러메시지 전송
+        if (bindingResult.hasErrors()){
+            //에러 메시지들 List에 담음
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrors(bindingResult);
+            //서버에 로그 출력
+            log.error("toggleReCommentLikeStatus API 에러발생 ={}",errorMessages);
+            //에러 메시지 body에 담아 전송
+            return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
+        }
+
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //DTO에 유저 인증 정보 저장
+        reCommentLikeToggleDto.setProviderId(principal.getName());
+
+        //유저가 댓글에 좋아요 누른 기록이 있으면 삭제후 false 반환, 없으면 DB에 저장후 true 반환
+        boolean result = reCommentLikeService.toggleReCommentLikeStatus(reCommentLikeToggleDto);
+
+        //결과 검증
+        if(result){
+            return ResponseEntity.ok("좋아요 등록 완료");
+        }else {
+            return ResponseEntity.ok("좋아요 삭제 완료");
+        }
+
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeKey.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeKey.java
@@ -1,0 +1,39 @@
+package com.ham.netnovel.reCommentLike;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ReCommentLikeKey implements Serializable {
+
+    private Long reCommentId;
+    private Long memberId;
+
+
+    @Override
+    public boolean equals(Object o) {
+        //파라미터로 받은 객체와 자신을 비교, 동일한 객체일경우 true 반환
+        if (this==o) return true;
+        //파라미터로 받은 객체가 null 이거나, 현재 클래스와 다른 클래스일경우 false 반환
+        if (o==null || getClass() !=o.getClass()) return false;
+        //타입 캐스팅
+        ReCommentLikeKey that = (ReCommentLikeKey) o;
+        //파라미터로 받은 객체와 현재 객체의 필드값 비교, 두 필드값이 모두 동일해야 true 반환
+        return Objects.equals(reCommentId,that.reCommentId) && Objects.equals(memberId,that.memberId);
+    }
+    //equals()가 true를 반환할때, 객체들이 도일한 해시 코드 값을 반환하도록 보장하는 메서드
+    @Override
+    public int hashCode() {
+        return Objects.hash(reCommentId, memberId);
+    }
+}

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeRepository.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeRepository.java
@@ -1,0 +1,13 @@
+package com.ham.netnovel.reCommentLike;
+
+
+import com.ham.netnovel.reComment.ReCommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReCommentLikeRepository extends JpaRepository<ReCommentLike,Long> {
+    Optional<ReCommentLike> findById(ReCommentLikeKey id);
+
+
+}

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeToggleDto.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeToggleDto.java
@@ -1,0 +1,22 @@
+package com.ham.netnovel.reCommentLike;
+
+
+import com.ham.netnovel.commentLike.LikeType;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReCommentLikeToggleDto {
+    private String providerId;//유저정보
+
+
+    @NotNull(message = "좋아요 정보가 없습니다.")
+    private LikeType likeType;//좋아요/싫어요 선택 정보
+
+    @NotNull(message = "댓글 정보가 없습니다.")
+    private Long reCommentId;//좋아요 누른 대댓글의 PK 정보
+}

--- a/src/main/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeService.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeService.java
@@ -1,0 +1,11 @@
+package com.ham.netnovel.reCommentLike.service;
+
+import com.ham.netnovel.reCommentLike.ReCommentLikeToggleDto;
+
+public interface ReCommentLikeService {
+
+
+
+    boolean toggleReCommentLikeStatus(ReCommentLikeToggleDto reCommentLikeToggleDto);
+
+}

--- a/src/main/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeServiceImpl.java
@@ -1,0 +1,69 @@
+package com.ham.netnovel.reCommentLike.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.reComment.ReComment;
+import com.ham.netnovel.reComment.ReCommentLike;
+import com.ham.netnovel.reComment.service.ReCommentService;
+import com.ham.netnovel.reCommentLike.ReCommentLikeKey;
+import com.ham.netnovel.reCommentLike.ReCommentLikeRepository;
+import com.ham.netnovel.reCommentLike.ReCommentLikeToggleDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+public class ReCommentLikeServiceImpl implements ReCommentLikeService {
+    private final MemberService memberService;
+
+    private final ReCommentService reCommentService ;
+    private final ReCommentLikeRepository reCommentLikeRepository;
+
+    public ReCommentLikeServiceImpl(MemberService memberService, ReCommentService reCommentService, ReCommentLikeRepository reCommentLikeRepository) {
+        this.memberService = memberService;
+        this.reCommentService = reCommentService;
+        this.reCommentLikeRepository = reCommentLikeRepository;
+    }
+
+    @Override
+    @Transactional
+    public boolean toggleReCommentLikeStatus(ReCommentLikeToggleDto dto) {
+        //멤버 엔티티 조회, 없을경우 예외로 던짐
+        Member member = memberService.getMember(dto.getProviderId())
+                .orElseThrow(() -> new NoSuchElementException("toggleReCommentLikeStatus 메서드 에러, 유저 정보가 null입니다. providerId=" + dto.getProviderId()));
+
+
+        ReComment reComment = reCommentService.getReComment(dto.getReCommentId())
+                .orElseThrow(() -> new NoSuchElementException("toggleReCommentLikeStatus 메서드 에러, 댓글 정보가 null입니다. commentId=" + dto.getReCommentId()));
+
+        try {
+            //ReCommentLike 엔티티 조회를 위한 composite key 생성
+            ReCommentLikeKey reCommentLikeKey = new ReCommentLikeKey(reComment.getId(), member.getId());
+            //DB에서 엔티티 찾아서 반환
+            Optional<ReCommentLike> reCommentLike = reCommentLikeRepository.findById(reCommentLikeKey);
+
+            //찾은 값이 없으면(좋아요 누른 기록이 없음), 새로운 엔티티 만들어 DB에 저장 후 true 반환
+            if (reCommentLike.isEmpty()){
+                ReCommentLike newRecommentLike = new ReCommentLike(reCommentLikeKey, member, reComment, dto.getLikeType());
+
+                reCommentLikeRepository.save(newRecommentLike);
+
+                return true;
+
+            }else {
+                //찾은 값이 있으면(좋아요 누른 기록이 있음) 좋아요 기록 삭제, false 반환
+                reCommentLikeRepository.delete(reCommentLike.get());
+                return false;
+
+            }
+
+
+        }catch (Exception ex) {
+            // 그 외의 예외는 ServiceMethodException으로 래핑하여 던짐
+            throw new ServiceMethodException("toggleReCommentLikeStatus 메서드 에러 발생" + ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.comment.service;
 
+import com.ham.netnovel.comment.Comment;
 import com.ham.netnovel.comment.dto.CommentCreateDto;
 import com.ham.netnovel.comment.dto.CommentDeleteDto;
 import com.ham.netnovel.comment.dto.CommentEpisodeListDto;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @SpringBootTest
@@ -24,7 +26,6 @@ class CommentServiceImplTest {
         this.commentService = commentService;
     }
 
-
     //2024-07-18 테스트 성공
     @Test
     public void createCommentTest() {
@@ -33,7 +34,7 @@ class CommentServiceImplTest {
         CommentCreateDto build = CommentCreateDto.builder()
                 .episodeId(2306L)//테스트용 episdoe
                 .content("테스트 댓글")
-                .providerId("UEqG1Al3FwPQTqDy6tfFb2MGZyEUd-weiJUzyxnkJhM")//테스트용 유저
+                .providerId("")//테스트용 유저
                 .build();
 
         commentService.createComment(build);
@@ -53,7 +54,7 @@ class CommentServiceImplTest {
         CommentUpdateDto build = CommentUpdateDto.builder()
                 .content("수정 테스트")
                 .episodeId(2306L)//테스트용 episdoe
-                .providerId("UEqG1Al3FwPQTqDy6tfFb2MGZyEUd-weiJUzyxnkJhM")//테스트용 유저
+                .providerId("")//테스트용 유저
                 .commentId(16L)
                 .build();
         commentService.updateComment(build);
@@ -68,7 +69,7 @@ class CommentServiceImplTest {
         System.out.println("삭제 상태 변경 테스트");
         CommentDeleteDto build = CommentDeleteDto.builder()
                 .episodeId(2306L)//테스트용 episdoe
-                .providerId("UEqG1Al3FwPQTqDy6tfFb2MGZyEUd-weiJUzyxnkJhM")//테스트용 유저
+                .providerId("")//테스트용 유저
                 .commentId(16L)
                 .build();
         commentService.deleteComment(build);
@@ -81,31 +82,36 @@ class CommentServiceImplTest {
     테스트 성공
      */
     @Test
-    public void getCommentListTest(){
+    public void getEpisodeCommentList(){
         System.out.println("댓글 불러오기 테스트");
 
-        List<CommentEpisodeListDto> commentList = commentService.getEpisodeCommentList(2306L);
+        List<CommentEpisodeListDto> commentList = commentService.getEpisodeCommentList(2309L);
 //        List<CommentEpisodeListDto> commentList = commentService.getCommentList(909090909L);//존재하지 않는 에피소드 테스트, 빈리스트 반환됨
 
-
         for (CommentEpisodeListDto commentEpisodeListDto : commentList) {
-            System.out.println("댓글정보");
+
+            System.out.println("*****댓글 정보******");
+            System.out.println("작성자 닉네임= "+commentEpisodeListDto.getNickName());
+            System.out.println("댓글내용 = "+commentEpisodeListDto.getContent());
+            System.out.println("댓글 작성시간= "+commentEpisodeListDto.getCreatedAt());
+            System.out.println("좋아요 수 ="+commentEpisodeListDto.getLikes());
+            System.out.println("싫어요 수 ="+commentEpisodeListDto.getDisLikes());
 
             List<ReCommentListDto> reCommentList = commentEpisodeListDto.getReCommentList();
-            System.out.println(commentEpisodeListDto.toString());
-
-
-            //대댓글 정보 출력
-            System.out.println("대댓글 정보");
             for (ReCommentListDto reCommentListDto : reCommentList) {
-
-                System.out.println(reCommentListDto.toString());
-
+                System.out.println("******대댓글 정보*******");
+                System.out.println("작성자 닉네임="+reCommentListDto.getNickName());
+                System.out.println("댓글내용 = "+reCommentListDto.getContent());
+                System.out.println("댓글 작성시간= "+reCommentListDto.getCreatedAt());
+                System.out.println("좋아요 수 ="+reCommentListDto.getLikes());
+                System.out.println("싫어요 수 ="+reCommentListDto.getDisLikes());
             }
 
 
-
         }
+
+
+
 
 
     }
@@ -118,7 +124,7 @@ class CommentServiceImplTest {
     public void getMemberCommentList(){
 
 
-        String providerId= "UEqG1Al3FwPQTqDy6tfFb2MGZyEUd-weiJUzyxnkJhM";
+        String providerId= "";
         //댓글을 작성한적이 없는 유저 테스트
 //        String providerId= "ttt";
 
@@ -142,22 +148,26 @@ class CommentServiceImplTest {
     //테스트 성공
     @Test
     public void getNovelCommentList(){
-//        Long novelId =8L;
-        Long novelId =7L;
+        Long novelId =1L;
+//        Long novelId =7L;
         List<CommentEpisodeListDto> novelCommentList = commentService.getNovelCommentList(novelId);
         for (CommentEpisodeListDto commentEpisodeListDto : novelCommentList) {
+
             System.out.println("*****댓글 정보******");
-            System.out.println(commentEpisodeListDto.getNickName());
-            System.out.println(commentEpisodeListDto.getContent());
-            System.out.println(commentEpisodeListDto.getCreatedAt());
+            System.out.println("작성자 닉네임= "+commentEpisodeListDto.getNickName());
+            System.out.println("댓글내용 = "+commentEpisodeListDto.getContent());
+            System.out.println("댓글 작성시간= "+commentEpisodeListDto.getCreatedAt());
+            System.out.println("좋아요 수 ="+commentEpisodeListDto.getLikes());
+            System.out.println("싫어요 수 ="+commentEpisodeListDto.getDisLikes());
 
             List<ReCommentListDto> reCommentList = commentEpisodeListDto.getReCommentList();
             for (ReCommentListDto reCommentListDto : reCommentList) {
                 System.out.println("******대댓글 정보*******");
-                System.out.println(reCommentListDto.getNickName());
-                System.out.println(reCommentListDto.getContent());
-                System.out.println(reCommentListDto.getCreatedAt());
-
+                System.out.println("작성자 닉네임="+reCommentListDto.getNickName());
+                System.out.println("댓글내용 = "+reCommentListDto.getContent());
+                System.out.println("댓글 작성시간= "+reCommentListDto.getCreatedAt());
+                System.out.println("좋아요 수 ="+reCommentListDto.getLikes());
+                System.out.println("싫어요 수 ="+reCommentListDto.getDisLikes());
             }
 
 

--- a/src/test/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/reCommentLike/service/ReCommentLikeServiceImplTest.java
@@ -1,0 +1,49 @@
+package com.ham.netnovel.reCommentLike.service;
+
+import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+import com.ham.netnovel.reCommentLike.ReCommentLikeToggleDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class ReCommentLikeServiceImplTest {
+
+    private final ReCommentLikeService reCommentLikeService;
+
+    @Autowired
+    ReCommentLikeServiceImplTest(ReCommentLikeService reCommentLikeService) {
+        this.reCommentLikeService = reCommentLikeService;
+    }
+
+    //테스트성공
+    @Test
+    void toggleReCommentLikeStatus() {
+        String providerId = "test";
+
+//        존재하지 않는 사용자 테스트 NoSuchElementException 던져짐
+//        String providerId = "ccc";
+
+
+
+        Long reCommentId = 151L;
+        //존재하지 않는 댓글 테스트 NoSuchElementException 던져짐
+//        Long reCommentId = 56445646L;
+
+
+        LikeType like = LikeType.LIKE;
+
+        ReCommentLikeToggleDto build = ReCommentLikeToggleDto.builder()
+                .providerId(providerId)
+                .likeType(like)
+                .reCommentId(reCommentId)
+                .build();
+
+        boolean result = reCommentLikeService.toggleReCommentLikeStatus(build);
+
+        System.out.println(result);
+
+    }
+}


### PR DESCRIPTION
### 개요
대댓글에 좋아요 기능을 추가하고, 관련된 여러 클래스를 수정 및 최적화했습니다. 이 변경은 사용자 경험을 향상시키고, 코드의 유지보수성을 높이기 위해 수행되었습니다.

### 주요 변경 사항

#### 1. 대댓글 좋아요 기능 구현

- **ReCommentLike 엔티티 추가**
  - `ReCommentLike`: 대댓글 좋아요 엔티티로, `memberId`와 `reCommentId`로 구성된 `EmbeddedId`(복합 기본 키)를 사용합니다.
  - `LikeType`: `LIKE`와 `DISLIKE` 상태를 가지는 enum 타입 멤버 변수를 추가합니다.

- **ReCommentLikeKey 클래스 추가**
  - `ReCommentLike`의 `EmbeddedId` 정의 클래스로, `memberId`와 `reCommentId`로 키를 생성합니다.

- **ReCommentLikeRepository 추가**
  - `ReCommentLike` 리포지토리 계층을 추가하고, `EmbeddedId`로 엔티티를 찾는 메서드(`findById`)를 추가합니다.
  - `ReCommentLikeKey` 타입을 사용합니다.

- **ReCommentLikeService 추가**
  - 대댓글의 좋아요 상태를 토글하는 메서드(`toggleReCommentLikeStatus`)를 추가합니다.
  - `reCommentId`와 `memberId`의 `EmbeddedId`로 `ReCommentLike` 테이블을 조회하여, 값이 있으면 레코드를 삭제하고 `false`를 반환하며, 값이 없으면 DB에 저장하고 `true`를 반환합니다.
  - 에러 발생 시 예외를 던집니다.

- **ReCommentLikeServiceImplTest 추가**
  - `toggleReCommentLikeStatus` 메서드의 테스트를 추가하고, 테스트가 성공했음을 확인합니다.

- **ReCommentLikeController 추가**
  - 대댓글 좋아요 요청을 받아 처리하는 API를 추가합니다.
  - 대댓글에 좋아요를 누른 기록이 없으면, 해당 내용을 DB에 저장하고, 대댓글에 좋아요를 누른 기록이 있으면 기록을 삭제합니다.

- **ReCommentLikeToggleDto 추가**
  - 클라이언트에서 보낸 정보를 담는 DTO로, `providerId`(유저정보), `likeType`(좋아요, 싫어요 정보), `reCommentId`(대댓글 pk)를 멤버 변수로 가집니다.

#### 2. 대댓글 관련 클래스 및 메서드 수정

- **ReComment 클래스 수정**
  - `ReCommentLike`와의 `OneToMany` 관계를 추가합니다.
  - 좋아요 수를 반환하는 메서드(`getTotalLikes`)와 싫어요 수를 반환하는 메서드(`getTotalDisLikes`)를 추가합니다.

- **CommentServiceImpl 수정**
  - `convertToCommentEpisodeListDto` 메서드 로직을 수정하여, 대댓글 DTO에 좋아요, 싫어요 정보를 멤버 변수에 담는 로직을 추가합니다.

- **CommentServiceImplTest 수정**
  - `getEpisodeCommentList`와 `getNovelCommentList` 테스트의 출력값을 수정하여, 좋아요와 싫어요 수도 출력하도록 변경합니다.

#### 3. ReCommentListDto 클래스 수정

- **ReCommentListDto**
  - 좋아요 수와 싫어요 수를 저장하는 멤버 변수를 추가합니다(`likes`, `disLikes`).
  - `int` 타입을 사용합니다.

