### PR TITLE
- feat: Member 마이페이지 정보 전송 기능 추가, Member 컨트롤러 엔드 포인트 수정

### DIFF
--- a/src/main/java/com/ham/netnovel/OAuth/OAuthLoginController.java
+++ b/src/main/java/com/ham/netnovel/OAuth/OAuthLoginController.java
@@ -1,0 +1,16 @@
+package com.ham.netnovel.OAuth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@Slf4j
+public class OAuthLoginController {
+
+
+    @GetMapping("/login")
+    public String showLoginPage() {
+        return "/member/login";
+    }
+}

--- a/src/main/java/com/ham/netnovel/member/dto/MemberMyPageDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberMyPageDto.java
@@ -1,0 +1,25 @@
+package com.ham.netnovel.member.dto;
+
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemberMyPageDto {
+
+    //닉네임
+    private String nickName;
+
+    //코인 갯수
+    private Integer coinCount;
+
+    //현재 로그인한 OAuth 이메일
+    private String email;
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/member/service/MemberService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
 import com.ham.netnovel.member.dto.MemberCreateDto;
 import com.ham.netnovel.member.dto.MemberLoginDto;
+import com.ham.netnovel.member.dto.MemberMyPageDto;
 
 import java.util.Optional;
 
@@ -12,10 +13,10 @@ public interface MemberService {
 
     /**
      * Member 엔티티를 조회하는 메서드, null체크는 해당 메서드를 사용하는 메서드에서 진행
-     * @param providerId
-     * @return Optional<Member>
+     * @param providerId 유저의 인증 정보
+     * @return Optional<Member> DB에서 찾은 유저 엔티티 객체
      */
-   Optional<Member> getMember(String providerId);
+    Optional<Member> getMember(String providerId);
 
 
     /**
@@ -51,14 +52,13 @@ public interface MemberService {
     /**
      * 유저의 코인을 증가시키는 메서드
      * 파라미터로 받는 member, coinAmount 유효성 검사는 이 메서드를 사용하는 메서드에서 진행 필
-     * @param member 코인을 증가시킬 유저 엔티티
+     * @param member     코인을 증가시킬 유저 엔티티
      * @param coinAmount 증가시킬 코인의 갯수
      */
     void increaseMemberCoins(Member member, int coinAmount);
 
 
-
-
+    MemberMyPageDto getMemberMyPageInfo(String providerId);
 
 
 }

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.ham.netnovel.common.exception.NotEnoughCoinsException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.MemberRepository;
+import com.ham.netnovel.member.dto.MemberMyPageDto;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
 import com.ham.netnovel.member.dto.MemberCreateDto;
@@ -19,7 +20,6 @@ import java.util.Optional;
 class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-
 
 
     public MemberServiceImpl(MemberRepository memberRepository) {
@@ -110,12 +110,12 @@ class MemberServiceImpl implements MemberService {
     public void deductMemberCoins(String providerId, Integer coinAmount) {
 
         //사용한 코인 수가 올바르지 않을때 예외로 던짐
-        if (coinAmount==null || coinAmount<0){
+        if (coinAmount == null || coinAmount < 0) {
             throw new IllegalArgumentException("deductMemberCoins 에러, coinAmount 값이 유효하지 않습니다.");
         }
 
         Optional<Member> optionalMember = getMember(providerId);
-        if (optionalMember.isEmpty()){
+        if (optionalMember.isEmpty()) {
             throw new NoSuchElementException("deductMemberCoins 에러, 유저 정보가 없습니다.");
         }
         //Optional 벗기기
@@ -125,10 +125,10 @@ class MemberServiceImpl implements MemberService {
         Integer totalCoin = member.getCoinCount();
 
         //유저의 코인이 null일경우 예외처리
-        if (totalCoin ==null){
+        if (totalCoin == null) {
             throw new NoSuchElementException("deductMemberCoins 에러, 유저 정보가 없습니다.");
-        //유저의 코인이 사용한 코인수보다 적을때 예외처리
-        } else if (totalCoin<coinAmount) {
+            //유저의 코인이 사용한 코인수보다 적을때 예외처리
+        } else if (totalCoin < coinAmount) {
             throw new NotEnoughCoinsException("deductMemberCoins 에러, 유저의 코인이 부족합니다.");
         }
 
@@ -137,12 +137,9 @@ class MemberServiceImpl implements MemberService {
             member.deductMemberCoins(coinAmount);
             //엔티티 DB에 저장
             memberRepository.save(member);
-        }catch (Exception ex){
+        } catch (Exception ex) {
             throw new ServiceMethodException("deductMemberCoins 메서드 에러 발생" + ex.getMessage());
         }
-
-
-
 
 
     }
@@ -150,15 +147,35 @@ class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void increaseMemberCoins(Member member, int coinAmount) {
-       try {
-           //멤버 엔티티 코인수 증가
-           member.increaseMemberCoins(coinAmount);
-           //엔티티 저장
-           memberRepository.save(member);
-       }catch (Exception ex){
-           throw new ServiceMethodException("increaseMemberCoins 메서드 에러 발생" + ex.getMessage());
-       }
+        try {
+            //멤버 엔티티 코인수 증가
+            member.increaseMemberCoins(coinAmount);
+            //엔티티 저장
+            memberRepository.save(member);
+        } catch (Exception ex) {
+            throw new ServiceMethodException("increaseMemberCoins 메서드 에러 발생" + ex.getMessage());
+        }
 
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberMyPageDto getMemberMyPageInfo(String providerId) {
+
+        //유저 정보가 없을경우 예외로 던짐
+        Member member = getMember(providerId)
+                .orElseThrow(() -> new NoSuchElementException("유저 정보 없음"));
+        try {
+            //유저 정보 DTO로 변환하여 반환
+            return MemberMyPageDto.builder()
+                    .email(member.getEmail())
+                    .coinCount(member.getCoinCount())
+                    .nickName(member.getNickName())
+                    .build();
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getMemberMyPageInfo 메서드 에러 발생" + ex.getMessage());
+        }
 
 
     }

--- a/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member.service;
 
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
+import com.ham.netnovel.member.dto.MemberMyPageDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +18,7 @@ class MemberServiceImplTest {
 
 
     @Test
-    public void updateMemberNickName(){
+    public void updateMemberNickName() {
 
         ChangeNickNameDto changeNickNameDto = new ChangeNickNameDto();
 //        changeNickNameDto.setNewNickName("변경테스트");
@@ -41,7 +42,7 @@ class MemberServiceImplTest {
 
     //테스트 완료
     @Test
-    public void deductMemberCoins(){
+    public void deductMemberCoins() {
 
 //        String providerId = "";
         //존재하지않은 사용자 테스트
@@ -54,9 +55,24 @@ class MemberServiceImplTest {
 //        Integer coinAmount = 0;
 
 
-        memberService.deductMemberCoins(providerId,coinAmount);
+        memberService.deductMemberCoins(providerId, coinAmount);
 
 
+    }
+
+    //테스트 성공
+    @Test
+    public void getMemberMyPageInfo() {
+
+        //테스트 유저
+//        String providerId = "test";
+
+        //존재하지않은 사용자 테스트
+        String providerId = "testtest";//NoSuchElementException로 던져짐
+
+
+        MemberMyPageDto memberMyPageInfo = memberService.getMemberMyPageInfo(providerId);
+        System.out.println(memberMyPageInfo.toString());
 
     }
 }


### PR DESCRIPTION
- MemberController
  - 기본 엔드포인트 /api/member로 변경
  - 로그인 API OAuthLoginController 로 이동
  - API 주석 설명 추가
  - 마이페이지 API 추가(showMyPage)
    - 유저 닉네임, 코인갯수, 이메일 정보 전송

- MemberMyPageDto
  - 마이페이지 접속시 유저정보를 전달할때 사용하는 DTO
  - nickName, coinCount, email 를 멤버변수로 가짐

- MemberService
  - 마이페이지 접속시 전달할 유저정보를 반환하는 메서드 추가(getMemberMyPageInfo)
  - 이메일, 코인갯수, 닉네임 정보 반환

- MemberServiceImplTest
  - getMemberMyPageInfo 테스트, 테스트 성공

- OAuthLoginController
  - OAuth 로그인 관련 API 용 컨트롤러 추가
  - 로그인 API 추가(showLoginPage)
    - MemberController 에서 이동