### PR TITLE
소설 평균 별점 관련 기능 추가, quartz 라이브러리로 스케줄러 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
+
+    //quartz library(Scheduler)
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ham/netnovel/common/config/QuartzConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/QuartzConfig.java
@@ -1,0 +1,34 @@
+package com.ham.netnovel.common.config;
+
+
+import com.ham.netnovel.novelAverageRating.NovelAverageRatingJob;
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuartzConfig {
+    // JobDetail을 정의하는 메서드
+    @Bean
+    public JobDetail novelAverageRatingJobDetail() {
+        return JobBuilder.newJob(NovelAverageRatingJob.class)
+                .withIdentity("novelAverageRatingJob")//식별자 설정
+                .withDescription("Novel 평균 점수 업데이트, 별점이 있는 Novel 만 진행")//설명추가
+                .storeDurably()
+                .build();
+    }
+
+    // 트리거를 정의하는 메서드
+    @Bean
+    public Trigger novelAverageRatingTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(novelAverageRatingJobDetail())//트리거와 novelAverageRatingJobDetail 연결
+                .withIdentity("novelAverageRatingTrigger")//트리거 식별자 설정
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()//단순 스케쥴 설정
+//                        .withIntervalInSeconds(5)//시간설정
+                        .withIntervalInHours(12)
+                        .repeatForever())//무한반복설정
+                .build();
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/novel/Novel.java
+++ b/src/main/java/com/ham/netnovel/novel/Novel.java
@@ -5,6 +5,7 @@ import com.ham.netnovel.member.Member;
 import com.ham.netnovel.novel.data.NovelStatus;
 import com.ham.netnovel.novel.dto.NovelResponseDto;
 import com.ham.netnovel.novel.dto.NovelUpdateDto;
+import com.ham.netnovel.novelAverageRating.NovelAverageRating;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -39,6 +40,9 @@ public class Novel {
 
     @OneToMany(mappedBy = "novel")
     private List<Episode> episodes = new ArrayList<>();
+
+    @OneToOne(mappedBy = "novel")
+    private NovelAverageRating novelAverageRating;
 
     @Builder
     public Novel(String title, String description, NovelStatus status, Member author) {

--- a/src/main/java/com/ham/netnovel/novel/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelRepository.java
@@ -16,4 +16,15 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
             "where fn.member.providerId =:providerId)")
     List<Novel> findFavoriteNovelsByMember(@Param("providerId") String providerId);
 
+
+
+
+    @Query("select distinct n " +
+            "from Novel n " +
+            "where n in " +
+            "(select r.novel from NovelRating r " +
+            "where r.rating is not null)")
+    List<Novel> findByNovelRating();
+
+
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -26,4 +26,12 @@ public interface NovelService {
     NovelResponseDto deleteNovel(NovelDeleteDto novelDeleteDto);
 
     List<Novel> getFavoriteNovels(String providerId);
+
+    /**
+     * 별점 점수가 있는 Novel의 id값들을 List로 반환하는 메서드
+     * @return List Long 타입으로 반환
+     */
+    List<Long> getRatedNovelIds();
+
+
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -19,6 +19,7 @@ import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -154,7 +155,26 @@ public class NovelServiceImpl implements NovelService {
 
 
         } catch (Exception ex) {//예외 발생시 처리
-            throw new ServiceMethodException("getMemberFavoriteNovels Error");
+            throw new ServiceMethodException("getFavoriteNovels 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Long> getRatedNovelIds() {
+
+
+        try {
+            return novelRepository.findByNovelRating()
+                    .stream()
+                    .map(Novel::getId)
+                    .collect(Collectors.toList());
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getRatedNovelIds 메서드 에러 발생" + ex.getMessage());
+
         }
 
 

--- a/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRating.java
+++ b/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRating.java
@@ -1,0 +1,57 @@
+package com.ham.netnovel.novelAverageRating;
+
+import com.ham.netnovel.novel.Novel;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class NovelAverageRating {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)//auto_increment 자동생성
+    private Long id;
+
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id")
+    private Novel novel;
+
+    //평균별점
+    private BigDecimal averageRating;
+
+    //별점갯수
+    private int ratingCount;
+
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+
+    @Builder
+    public NovelAverageRating(Novel novel, BigDecimal averageRating, int ratingCount) {
+        this.novel = novel;
+        this.averageRating = averageRating;
+        this.ratingCount = ratingCount;
+    }
+
+
+    //엔티티 업데이트 메서드, 평균 별점과 등록된 별점 엔티티 수 업데이트
+    public void updateNovelAverageRating(BigDecimal averageRating, int ratingCount){
+        this.averageRating = averageRating;
+        this.ratingCount = ratingCount;
+
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRatingJob.java
+++ b/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRatingJob.java
@@ -1,0 +1,28 @@
+package com.ham.netnovel.novelAverageRating;
+
+import com.ham.netnovel.novelAverageRating.service.NovelAverageRatingService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class NovelAverageRatingJob implements Job {
+
+
+
+    private final NovelAverageRatingService novelAverageRatingService;
+    @Autowired
+    public NovelAverageRatingJob(NovelAverageRatingService novelAverageRatingService) {
+        this.novelAverageRatingService = novelAverageRatingService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+//        log.info("Novel 평균 별점 업데이트 시작");
+//        novelAverageRatingService.updateAverageRatingForAllRatedNovels();
+    }
+}

--- a/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRatingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelAverageRating/NovelAverageRatingRepository.java
@@ -1,0 +1,19 @@
+package com.ham.netnovel.novelAverageRating;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface NovelAverageRatingRepository extends JpaRepository<NovelAverageRating,Long> {
+
+
+
+    @Query("select na from NovelAverageRating na " +
+            "where na.novel.id = :novelId")
+    Optional<NovelAverageRating> findByNovelId(@Param("novelId") Long novelId);
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingService.java
+++ b/src/main/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingService.java
@@ -1,0 +1,42 @@
+package com.ham.netnovel.novelAverageRating.service;
+
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novelAverageRating.NovelAverageRating;
+
+import java.math.BigDecimal;
+
+public interface NovelAverageRatingService {
+
+    /**
+     * 특정 Novel의 평균 점수를 업데이트하는 메서드
+     * @param novelId 평균 점수를 업데이트할 Novel 의 FK
+     */
+
+    void updateNovelAverageRating(Long novelId);
+
+
+    /**
+     * 별점 점수가 있는 모든 Novel의 평균 점수를 업데이트하는 메서드
+     * 이 메서드는 스케줄러에 의해 특정 시간마다 실행
+     */
+    void updateAverageRatingForAllRatedNovels();
+
+
+    /**
+     * 새로운 NovelAverageRating 엔티티를 생성하여 DB에 저장하는 메서드
+     * @param novel 평균 평점이 생성될 Novel 엔티티
+     * @param averageValue 평균 별점
+     * @param listSize 평균 평점을 계산하는 데 사용된 평점의 개수
+     */
+    void createNovelAverageRating( Novel novel,BigDecimal averageValue,int listSize);
+
+    /**
+     * NovelAverageRating 엔티티를 업데이트하는 메서드
+     * @param novelAverageRating 업데이트할 NovelAverageRating 엔티티
+     * @param averageValue 평균 별점
+     * @param listSize 평균 평점을 계산하는 데 사용된 평점의 개수
+     */
+    void updateNovelAverageRating(NovelAverageRating novelAverageRating, BigDecimal averageValue, int listSize);
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingServiceImpl.java
@@ -1,0 +1,151 @@
+package com.ham.netnovel.novelAverageRating.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.service.NovelService;
+import com.ham.netnovel.novelAverageRating.NovelAverageRating;
+import com.ham.netnovel.novelAverageRating.NovelAverageRatingRepository;
+import com.ham.netnovel.novelRating.dto.NovelRatingInfoDto;
+import com.ham.netnovel.novelRating.service.NovelRatingService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+@Service
+@Slf4j
+public class NovelAverageRatingServiceImpl implements NovelAverageRatingService {
+
+    private final NovelAverageRatingRepository novelAverageRatingRepository;
+
+    private final NovelRatingService novelRatingService;
+
+    private final NovelService novelService;
+
+    public NovelAverageRatingServiceImpl(NovelAverageRatingRepository novelAverageRatingRepository, NovelRatingService novelRatingService, NovelService novelService) {
+        this.novelAverageRatingRepository = novelAverageRatingRepository;
+        this.novelRatingService = novelRatingService;
+        this.novelService = novelService;
+    }
+
+
+    @Override
+    @Transactional
+    public void updateNovelAverageRating(Long novelId) {
+
+        //novel 엔티티 조회, 없으면 예외로 던짐
+        Novel novel = novelService.getNovelEntity(novelId)
+                .orElseThrow(() -> new NoSuchElementException("updateNovelAverageRating 에러, Novel 정보가 없습니다, novelId = " + novelId));
+
+
+        //소설에 등록된 별점 엔티티들을 받아와 DTO로 변환하여 List 객체에 담음
+        List<NovelRatingInfoDto> novelRatingList = novelRatingService.getNovelRatingList(novelId);
+        //등록된 별점의 평균을 계산하여 객체에 저장
+        OptionalDouble average = novelRatingList.stream()
+                .mapToDouble(NovelRatingInfoDto::getRating)
+                .average();
+
+        // 평균값이 존재하지 않거나, 등록된 별점이 없으면 메서드 종료
+        if (average.isEmpty() || novelRatingList.isEmpty()) {
+            log.info("등록된 Novel 별점이 없습니다. updateNovelAverageRating 메서드 종료");
+            return;
+        }
+
+        //Novel 에 등록된 별점 수를 객체에 저장
+        int listSize = novelRatingList.size();
+        //평균 별점 소수점 셋째자리에서 반올림하여 객체에 저장
+        BigDecimal averageValue = BigDecimal.valueOf(average.getAsDouble()).setScale(2, RoundingMode.HALF_UP);
+        try {
+            /*
+        novel 평균 별점 엔티티가 DB에 저장되어 있는지 조회
+        엔티티가 있을경우 내용 업데이트
+        없을경우 엔티티 새로 만들어 DB에 저장
+         */
+            Optional<NovelAverageRating> optional = novelAverageRatingRepository.findByNovelId(novelId);
+            if (optional.isEmpty()) {
+                //새로운 엔티티 만들어 DB에 저장
+                createNovelAverageRating(novel, averageValue, listSize);
+                log.info("NovelAverageRating 생성 완료, novelId =" + novelId);
+            } else {
+                //조회된 엔티티 Optional 벗김
+                NovelAverageRating novelAverageRating = optional.get();
+                //엔티티 업데이트 후 DB에 저장
+                updateNovelAverageRating(novelAverageRating, averageValue, listSize);
+                log.info("NovelAverageRating 갱신 완료, novelId =" + novelId);
+            }
+        } catch (Exception ex) {
+            //나머지 예외처리
+            throw new ServiceMethodException("updateNovelAverageRating 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+    }
+
+    @Override
+    @Transactional
+    public void updateAverageRatingForAllRatedNovels() {
+        try {
+            //별점이 등록되어있는 Novel 의 FK 값을 List로 받아옴
+            List<Long> ratedNovelIds = novelService.getRatedNovelIds();
+            // 별점이 등록되어 있는 Novel 의 평균 별점 업데이트
+            for (Long ratedNovelId : ratedNovelIds) {
+                updateNovelAverageRating(ratedNovelId);
+            }
+        } catch (Exception ex) {
+            //나머지 예외처리
+            throw new ServiceMethodException("updateAverageRatingForAllRatedNovels 메서드 에러 발생" + ex.getMessage());
+        }
+
+    }
+
+    @Override
+    @Transactional
+    public void createNovelAverageRating(Novel novel, BigDecimal averageValue, int listSize) {
+
+        try {
+            NovelAverageRating newNovelAverageRating = NovelAverageRating.builder()
+                    .averageRating(averageValue)
+                    .novel(novel)
+                    .ratingCount(listSize)
+                    .build();
+            //DB에 엔티티 저장
+            novelAverageRatingRepository.save(newNovelAverageRating);
+
+
+        } catch (Exception ex) {
+            //나머지 예외처리
+            throw new ServiceMethodException("createNovelAverageRating 메서드 에러 발생" + ex.getMessage());
+        }
+        //새로운 엔티티 생성
+
+    }
+
+    @Override
+    @Transactional
+    public void updateNovelAverageRating(NovelAverageRating novelAverageRating,
+                                         BigDecimal averageValue,
+                                         int listSize) {
+
+        try {
+            //엔티티 내용 변경
+            novelAverageRating.updateNovelAverageRating(averageValue, listSize);
+            //DB에 엔티티 저장
+            novelAverageRatingRepository.save(novelAverageRating);
+
+        } catch (Exception ex) {
+            //나머지 예외처리
+            throw new ServiceMethodException("updateNovelAverageRating 메서드 에러 발생" + ex.getMessage());
+        }
+
+
+
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRating/NovelRatingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelRating/NovelRatingRepository.java
@@ -1,11 +1,19 @@
 package com.ham.netnovel.novelRating;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NovelRatingRepository extends JpaRepository<NovelRating,Long> {
     Optional<NovelRating> findById(NovelRatingId novelRatingId);
 
+    List<NovelRating> findByNovelId(@Param("novelId") Long novelId);
+
+
+
 
 }
+
+

--- a/src/main/java/com/ham/netnovel/novelRating/dto/NovelRatingInfoDto.java
+++ b/src/main/java/com/ham/netnovel/novelRating/dto/NovelRatingInfoDto.java
@@ -1,0 +1,24 @@
+package com.ham.netnovel.novelRating.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class NovelRatingInfoDto {
+
+    //점수
+    private Integer rating;
+
+    //수정날짜
+    private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRating/service/NovelRatingService.java
+++ b/src/main/java/com/ham/netnovel/novelRating/service/NovelRatingService.java
@@ -1,9 +1,30 @@
 package com.ham.netnovel.novelRating.service;
 
+import com.ham.netnovel.novelRating.dto.NovelRatingInfoDto;
 import com.ham.netnovel.novelRating.dto.NovelRatingSaveDto;
+
+import java.util.List;
 
 public interface NovelRatingService {
 
+    /**
+     * 유저가 소설(Novel)에 별점을 등록했을때 이를 DB에 저장하는 메서드
+     * @param novelRatingSaveDto 유저정보, 소설정보, 별점점수를 저장하는 메서드
+     */
     void saveNovelRating(NovelRatingSaveDto novelRatingSaveDto);
+
+
+    /**
+     * 주어진 소설 ID에 대한 별점 정보를 조회하여 리스트로 반환하는 메서드
+     * @param novelId Novel 엔티티 primary key
+     * @return List NovelRatingInfoDto 형태의 List 반환
+     */
+    List<NovelRatingInfoDto> getNovelRatingList(Long novelId);
+
+
+
+
+
+
 
 }

--- a/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/member/service/MemberServiceImplTest.java
@@ -1,6 +1,10 @@
 package com.ham.netnovel.member.service;
 
+import com.ham.netnovel.member.OAuthProvider;
+import com.ham.netnovel.member.data.Gender;
+import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
+import com.ham.netnovel.member.dto.MemberCreateDto;
 import com.ham.netnovel.member.dto.MemberMyPageDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +38,7 @@ class MemberServiceImplTest {
         changeNickNameDto.setNewNickName("변경@테스트");
 
 
-        changeNickNameDto.setProviderId("UEqG1Al3FwPQTqDy6tfFb2MGZyEUd-weiJUzyxnkJhM");
+        changeNickNameDto.setProviderId("test1");
         memberService.updateMemberNickName(changeNickNameDto);
 
 
@@ -75,4 +79,38 @@ class MemberServiceImplTest {
         System.out.println(memberMyPageInfo.toString());
 
     }
+
+
+    //유저 생성 테스트
+    //테스트 성공
+    @Test
+    public void createNewMember(){
+
+        String email = "test";
+        String nickName = "testName";
+        String providerId = "test";
+
+
+        //100명 유저 생성 테스트
+        for (int i = 100; i<=200; i++){
+
+            MemberCreateDto build = MemberCreateDto.builder()
+                    .email(email + i + "@naver.com")
+                    .role(MemberRole.READER)
+                    .gender(Gender.MALE)
+                    .nickName(nickName + i)
+                    .providerId(providerId + i)
+                    .provider(OAuthProvider.NAVER)
+                    .build();
+
+            memberService.createNewMember(build);
+
+        }
+
+
+
+
+
+    }
+
 }

--- a/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
@@ -90,4 +90,15 @@ class NovelServiceImplTest {
 
 
     }
+
+
+    @Test
+    public void getRatedNovelIds(){
+        List<Long> ratedNovelIds = novelService.getRatedNovelIds();
+        for (Long ratedNovelId : ratedNovelIds) {
+            System.out.println("novelId ="+ratedNovelId);
+
+        }
+
+    }
 }

--- a/src/test/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelAverageRating/service/NovelAverageRatingServiceImplTest.java
@@ -1,0 +1,39 @@
+package com.ham.netnovel.novelAverageRating.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+class NovelAverageRatingServiceImplTest {
+
+   private final NovelAverageRatingService novelAverageRatingService;
+
+   @Autowired
+    NovelAverageRatingServiceImplTest(NovelAverageRatingService novelAverageRatingService) {
+        this.novelAverageRatingService = novelAverageRatingService;
+    }
+
+    //테스트 성공
+    @Test
+    void updateNovelAverageRating() {
+       //평균 별점을 업데이트할 novelId
+       Long novelId = 1L;
+
+       //
+       novelAverageRatingService.updateNovelAverageRating(novelId);
+    }
+
+
+    //테스트 성공
+    @Test
+    void updateAverageRatingForAllRatedNovels(){
+
+       //별점이 기록된 novel 엔티티들의 평균 별점 최신화
+       novelAverageRatingService.updateAverageRatingForAllRatedNovels();
+
+
+   }
+
+}

--- a/src/test/java/com/ham/netnovel/novelRating/service/NovelRatingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRating/service/NovelRatingServiceImplTest.java
@@ -1,9 +1,12 @@
 package com.ham.netnovel.novelRating.service;
 
+import com.ham.netnovel.novelRating.dto.NovelRatingInfoDto;
 import com.ham.netnovel.novelRating.dto.NovelRatingSaveDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
 
 @SpringBootTest
 class NovelRatingServiceImplTest {
@@ -20,7 +23,7 @@ class NovelRatingServiceImplTest {
 
 
     @Test
-    void saveEpisodeRating() {
+    void saveNovelRating() {
         //테스트 계정
         String providerId = "test";
 
@@ -48,4 +51,59 @@ class NovelRatingServiceImplTest {
 
         novelRatingService.saveNovelRating(build);
     }
+
+    //테스트 성공
+    @Test
+    void getNovelRatingList(){
+        //불러올 소설 Id
+        Long novelId = 1L;
+
+        List<NovelRatingInfoDto> novelRatingList = novelRatingService.getNovelRatingList(novelId);
+        for (NovelRatingInfoDto novelRatingInfoDto : novelRatingList) {
+
+            System.out.println(novelRatingInfoDto.toString());
+
+        }
+
+    }
+
+
+
+
+
+
+
+
+    //NovelRating 테스트용 엔티티 생성 메서드
+    //테스트 유저 엔티티로 별점 생성
+    @Test
+    void ratingTest(){
+        String providerId = "test";
+        Long novelId = 4L;
+
+
+        for (int i=100; i<=200; i++){
+
+            int randomNumber = (int) (Math.random() * 10) + 1; // 0부터 9까지의 숫자 생성 후 +1
+
+            NovelRatingSaveDto build = NovelRatingSaveDto.builder()
+                    .providerId(providerId+i)
+                    .novelId(novelId)
+                    .rating(randomNumber)
+                    .build();
+
+            novelRatingService.saveNovelRating(build);
+
+
+        }
+
+
+
+
+
+
+    }
+
+
+
 }


### PR DESCRIPTION

## 소설 평균 별점 엔티티 관련 기능 추가

### 변경 사항

- **NovelAverageRating**
  - 소설(Novel)의 평균 별점을 저장하는 엔티티 추가
  - Novel과 1:1 관계에서 FK를 NovelAverageRating이 소유
  - `averageRating`, `ratingCount`, `createdAt`, `updatedAt` 멤버변수 추가

- **NovelAverageRatingRepository**
  - NovelAverageRating 리포지토리 계층 생성
  - Spring Data JPA를 상속하여 사용
  - `findByNovelId` 메서드로 소설에 등록된 평균 별점(NovelAverageRating) 엔티티 반환

- **NovelAverageRatingService**
  - NovelAverageRating 서비스 계층 생성
  - `updateNovelAverageRating` 메서드로 특정 Novel의 평균 별점 업데이트
    - 파라미터로 `novelId`를 받아 로직 실행
    - 존재할 경우 `updateNovelAverageRating` 호출, 없을 경우 `createNovelAverageRating` 호출
  - `updateAverageRatingForAllRatedNovels` 메서드로 별점이 있는 모든 Novel의 평균 별점 업데이트
    - `NovelService`의 `getRatedNovelIds` 메서드로 별점이 있는 Novel의 ID 리스트를 불러옴
    - `updateNovelAverageRating` 메서드 호출
  - 새로운 NovelAverageRating 엔티티 생성 및 저장 메서드 추가 (`createNovelAverageRating`)
  - NovelAverageRating 엔티티 업데이트 메서드 추가 (`updateNovelAverageRating`)

- **NovelAverageRatingServiceImplTest**
  - `updateNovelAverageRating` 및 `updateAverageRatingForAllRatedNovels` 테스트 완료

- **Novel**
  - NovelAverageRating과 1:1 관계 추가

- **NovelRatingRepository**
  - Novel에 달린 별점(NovelRating)을 반환하는 `findByNovelId` 메서드 추가
  - 평균 별점 계산에 사용

- **NovelRatingInfoDto**
  - 별점 정보를 전달하기 위한 DTO 추가
  - `rating`, `updatedAt` 멤버변수 포함

- **NovelRatingService**
  - 주어진 소설 ID에 대한 별점 정보를 리스트로 반환하는 `getNovelRatingList` 메서드 추가

- **NovelRatingServiceImplTest**
  - `getNovelRatingList` 테스트 완료

- **NovelRepository**
  - 별점이 달린 Novel 엔티티들을 리스트로 반환하는 `findByNovelRating` 메서드 추가

- **NovelService**
  - 별점이 있는 Novel의 ID 값을 리스트로 반환하는 `getRatedNovelIds` 메서드 추가
  - 평균 별점 업데이트 시 사용

## quartz 라이브러리로 스케줄러 기능 추가
### 변경 사항
- **build.gradle**
  - quartz 라이브러리 의존관계 추가

- **NovelAverageRatingJob**
  - 소설 평균 점수 계산 로직을 스케줄러에 등록하기 위한 Job 클래스 추가
  - 현재 로직 주석처리, 배포시 사용

- **QuartzConfig**
  - quartz 라이브러리 스케줄 정의를 위한 config 클래스 추가
  - 소설 평균점수 계산을 위한 JobDetail  ` novelAverageRatingJobDetail` 메서드 추가
  - 소설 평균점수 계산 `novelAverageRatingTrigger` 트리거 추가
    - 실행주기 12시간 설정

