### PR TITLE
- feat : RecentRead(최근 읽은 에피소드) 관련 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/member/Member.java
+++ b/src/main/java/com/ham/netnovel/member/Member.java
@@ -8,6 +8,7 @@ import com.ham.netnovel.favoriteNovel.FavoriteNovel;
 import com.ham.netnovel.member.data.Gender;
 import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.novelRating.NovelRating;
+import com.ham.netnovel.recentRead.RecentRead;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,6 +77,10 @@ public class Member {
     //1:N 연결, 에피소드 댓글
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
+
+    //junction table 연결, 최근읽은 소설
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<RecentRead> recentReads = new ArrayList<>();
 
     @Builder
     public Member(String email, OAuthProvider provider, String providerId, MemberRole role, String nickName, Gender gender, Integer coinCount) {

--- a/src/main/java/com/ham/netnovel/recentRead/RecentRead.java
+++ b/src/main/java/com/ham/netnovel/recentRead/RecentRead.java
@@ -1,0 +1,61 @@
+package com.ham.netnovel.recentRead;
+
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.novel.Novel;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+public class RecentRead {
+
+    @EmbeddedId
+    private RecentReadId id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @MapsId("memberId")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id")
+    @MapsId("novelId")
+    private Novel novel;
+
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "episode_id")
+    private Episode episode;
+
+
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+
+    @Builder
+    public RecentRead(RecentReadId id, Member member, Novel novel, Episode episode) {
+        this.id = id;
+        this.member = member;
+        this.novel = novel;
+        this.episode = episode;
+    }
+
+    //최근 본 에피소드 업데이트
+    public void updateEpisodeInfo(Episode episode){
+      this.episode = episode;
+
+    };
+
+}

--- a/src/main/java/com/ham/netnovel/recentRead/RecentReadId.java
+++ b/src/main/java/com/ham/netnovel/recentRead/RecentReadId.java
@@ -1,0 +1,42 @@
+package com.ham.netnovel.recentRead;
+
+
+import com.ham.netnovel.commentLike.CommentLikeId;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecentReadId implements Serializable {
+
+    private Long novelId;
+    private Long memberId;
+
+
+    @Override
+    public boolean equals(Object o) {
+        //파라미터로 받은 객체와 자신을 비교, 동일한 객체일경우 true 반환
+        if (this == o) return true;
+        //파라미터로 받은 객체가 null 이거나, 현재 클래스와 다른 클래스일경우 false 반환
+        if (o == null || getClass() != o.getClass()) return false;
+        //타입 캐스팅
+        RecentReadId that = (RecentReadId) o;
+        //파라미터로 받은 객체와 현재 객체의 필드값 비교, 두 필드값이 모두 동일해야 true 반환
+        return Objects.equals(novelId, that.novelId) && Objects.equals(memberId, that.memberId);    }
+
+    //equals()가 true를 반환할때, 객체들이 도일한 해시 코드 값을 반환하도록 보장하는 메서드
+    @Override
+    public int hashCode() {
+        return Objects.hash(novelId, memberId);
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/recentRead/RecentReadRepository.java
+++ b/src/main/java/com/ham/netnovel/recentRead/RecentReadRepository.java
@@ -1,0 +1,10 @@
+package com.ham.netnovel.recentRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface RecentReadRepository extends JpaRepository<RecentRead,RecentReadId> {
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/recentRead/service/RecentReadService.java
+++ b/src/main/java/com/ham/netnovel/recentRead/service/RecentReadService.java
@@ -1,0 +1,31 @@
+package com.ham.netnovel.recentRead.service;
+
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.recentRead.RecentReadId;
+
+public interface RecentReadService {
+    /**
+     * 새로운 RecentRead 엔티티를 생성해 DB에 저장하는 매서드
+     * @param recentReadId memberId 와 novelId로 이루어진 EmbeddedId
+     * @param member 에피소드를 읽은 Member 엔티티 객체
+     * @param episode 유저가 읽은 Episode 엔티티 객체
+     * @param novel 에피소드가 속한 Novel 엔티티 객체
+     */
+    void createRecentRead(RecentReadId recentReadId, Member member, Episode episode, Novel novel);
+
+
+    /**
+     * RecentRead 엔티티를 업데이트하는 메서드
+     * 유저가 소설의 에피소드를 열람시 동작
+     * 유저가 해당 소설을 읽은 기록이 있으면 RecentRead 의 episode_id 업데이트
+     * 유저가 해상 소설을 읽은 기록이 없을경우 createRecentRead 호출하여 RecentRead 엔티티 생성하여 DB에 저장
+     * @param providerId 에피소드를 읽은 유저의 providerId값
+     * @param episodeId 유저가 읽은 에피소드의 Id
+     */
+    void updateRecentRead(String providerId, Long episodeId);
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
@@ -1,0 +1,92 @@
+package com.ham.netnovel.recentRead.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.episode.service.EpisodeService;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.recentRead.RecentRead;
+import com.ham.netnovel.recentRead.RecentReadId;
+import com.ham.netnovel.recentRead.RecentReadRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@Slf4j
+public class RecentReadServiceImpl implements RecentReadService {
+
+
+    private final RecentReadRepository recentReadRepository;
+
+    private final MemberService memberService;
+    private final EpisodeService episodeService;
+
+    public RecentReadServiceImpl(RecentReadRepository recentReadRepository, MemberService memberService, EpisodeService episodeService) {
+        this.recentReadRepository = recentReadRepository;
+        this.memberService = memberService;
+        this.episodeService = episodeService;
+    }
+
+    @Override
+    @Transactional
+    public void createRecentRead(RecentReadId recentReadId, Member member, Episode episode, Novel novel) {
+        try {
+            //새로운 엔티티 생성
+            RecentRead newRecentRead = RecentRead.builder()
+                    .id(recentReadId)
+                    .episode(episode)
+                    .member(member)
+                    .novel(novel)
+                    .build();
+            //엔티티 저장
+            recentReadRepository.save(newRecentRead);
+
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("createRecentRead 메서드 에러 발생: " + ex.getMessage(), ex);
+        }
+
+
+    }
+
+    @Override
+    @Transactional
+    public void updateRecentRead(String providerId, Long episodeId) {
+        //멤버 엔티티 객체에 저장
+        Member member = memberService.getMember(providerId)
+                .orElseThrow(() -> new NoSuchElementException("Member 가  엔티티가 null 입니다."));
+        //에피소드 엔티티 객체에 저장
+        Episode episode = episodeService.getEpisodeEntity(episodeId)
+                .orElseThrow(() -> new NoSuchElementException("Episode 가 엔티티가 null 입니다."));
+        //에피소드의 소설 엔티티 정보 객체에 저장
+        Novel novel = episode.getNovel();
+        //Novel 엔티티 null체크
+        if (novel == null) {
+            throw new NoSuchElementException("Novel 엔티티가 null 입니다.");
+        }
+        //RecentRead Embedded Id 객체 생성
+        RecentReadId recentReadId = new RecentReadId(novel.getId(), member.getId());
+        //Embedded Id 로 DB에서 유저가 해당 Novel을 열람한 기록이 있는지 확인
+        //열람한 기록이 없으면 createRecentRead 호출하여 새로운 엔티티 생성
+        //열함한 기록이 있을경우 RecentRead 엔티티 episode 필드값 업데이트
+        try {
+            recentReadRepository.findById(recentReadId)
+                    .ifPresentOrElse(recentRead -> {
+                                recentRead.updateEpisodeInfo(episode);//에피소드 필드 업데이트
+                                recentReadRepository.save(recentRead);//DB에 저장
+                            },
+                            () -> createRecentRead(recentReadId, member, episode, novel)//새로운 엔티티 생성후 저장
+                    );
+        } catch (Exception ex) {
+            throw new ServiceMethodException("updateRecentRead 메서드 에러 발생" + ex.getMessage(), ex);
+        }
+
+
+    }
+
+
+}

--- a/src/test/java/com/ham/netnovel/recentRead/service/RecentReadServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/recentRead/service/RecentReadServiceImplTest.java
@@ -1,0 +1,40 @@
+package com.ham.netnovel.recentRead.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class RecentReadServiceImplTest {
+
+    private final RecentReadService recentReadService;
+
+    @Autowired
+    RecentReadServiceImplTest(RecentReadService recentReadService) {
+        this.recentReadService = recentReadService;
+
+    }
+
+
+    @Test
+    void createRecentRead() {
+    }
+
+    //테스트 성공
+    @Test
+    void updateRecentRead() {
+        String providerId = "test";
+
+        //존재하지 않는 member 테스트, NoSuchElementException 던져짐
+
+//        String providerId = "ㅇㄹㅇㄴㄻㄴㅇㄹㄴㄹㅇ";
+
+        Long episodeId = 2309L;
+
+        //존재하지 않는 episode 테스트, NoSuchElementException 던져짐
+//        Long episodeId = 23232309L;
+        recentReadService.updateRecentRead(providerId, episodeId);
+    }
+}


### PR DESCRIPTION
- RecentRead
  - 엔티티 계층 추가
  - 멤버 변수로 member,novel,episode,createAt,updatedAt 가짐
  - memberId, novelId 로 Embedded Id 만들어 사용
  - 유저가 에피소드 열람시 episode FK만 변경

- RecentReadId
  - RecentRead Embedded Id class 추가
  - novelId, memberId 로 id 생성

- RecentReadRepository
  - 리포지토리 생성

- RecentReadService
  - 서비스계층 생성
  - 새로운 RecentRead 엔티를 생성하는 메서드 추가(createRecentRead)
    - 파라미터로 recentReadId(embeddedId), member, episode, novel 을 받음
  - RecentRead 업데이트 메서드 추가(updateRecentRead) - 유저가 소설의 에피소드를 열람시 동작 - 유저가 해당 소설을 읽은 기록이 있으면 RecentRead 의 episode_id 업데이트 - 유저가 해상 소설을 읽은 기록이 없을경우 createRecentRead 호출하여 RecentRead 엔티티 생성하여 DB에 저장

 - RecentReadServiceImplTest
   - 테스트 계층 추가
   - updateRecentRead 테스트 성공

- Member
  - RecentRead 와 OneToMany 관계 추가