### PR TITLE
유저의 에피소드 결제 내역 유무를 반환하는 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistory.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistory.java
@@ -4,6 +4,7 @@ package com.ham.netnovel.coinUseHistory;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class CoinUseHistory {
     private Member member;
 
     @NotNull
+    @Min(0)
     //코인 사용갯수
     private Integer amount;
 

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory,Long> {
 
@@ -16,5 +17,14 @@ public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory,L
             "where c.member.providerId = :providerId " +
             "order by c.createdAt desc ")
     List<CoinUseHistory> findByMemberProviderId(@Param("providerId")String providerId, Pageable pageable);
+
+
+    @Query("select c from CoinUseHistory  c " +
+            "where c.episode.id = :episodeId " +
+            "and c.member.providerId = :providerId")
+    Optional<CoinUseHistory> findByMemberAndEpisode(@Param("providerId") String providerId,
+                                                    @Param("episodeId") Long episodeId);
+
+
 
 }

--- a/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
@@ -16,6 +16,15 @@ public interface CoinUseHistoryService {
    List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId, Pageable pageable);
 
 
+   /**
+    * 유저가 에피소드에 결제한 내역이 있는지 확인하는 메서드
+    * @param providerId 유저 정보
+    * @param episodeId 에피소드의 id
+    * @return 결제 내역이 있을 경우 true, 결제 내역이 없을경우 false 반환
+    */
+   boolean hasMemberUsedCoinsForEpisode(String providerId, Long episodeId);
+
+
 
 
 }

--- a/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImpl.java
@@ -4,6 +4,7 @@ import com.ham.netnovel.coinUseHistory.CoinUseHistory;
 import com.ham.netnovel.coinUseHistory.CoinUseHistoryRepository;
 import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
 import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.episode.service.EpisodeService;
 import com.ham.netnovel.member.Member;
@@ -64,7 +65,7 @@ public class CoinUseHistoryServiceImpl implements CoinUseHistoryService {
     @Transactional(readOnly = true)
     public List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId, Pageable pageable) {
         try {
-            return coinUseHistoryRepository.findByMemberProviderId(providerId,pageable)
+            return coinUseHistoryRepository.findByMemberProviderId(providerId, pageable)
                     .stream()//유저의 코인 사용 기록을 받아와 stream 생성
                     .map(coinUseHistory -> {//엔티티 정보 DTO에 바인딩
                                 Episode episode = coinUseHistory.getEpisode();
@@ -84,4 +85,28 @@ public class CoinUseHistoryServiceImpl implements CoinUseHistoryService {
 
 
     }
+
+    @Override
+    public boolean hasMemberUsedCoinsForEpisode(String providerId, Long episodeId) {
+
+        try {
+
+            return coinUseHistoryRepository.findByMemberAndEpisode(providerId, episodeId)
+                    .map(coinUseHistory -> {
+                        Integer coinAmount = coinUseHistory.getAmount();
+                        TypeValidationUtil.validateCoinAmount(coinAmount);//코인 수 유효성 검사,null이거나 음수면 예외로 던짐
+                        return true;//유효성 검사 통과시 true 반환(코인 사용 기록 있음)
+                    }).orElse(false);//DB에서 엔티티 검색에 실패한경우 false 반환(코인 사용 기록이 없음)
+
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("hasMemberUsedCoinsForEpisode 메서드 에러 발생" + ex.getMessage());
+
+
+        }
+
+
+    }
+
+
 }

--- a/src/main/java/com/ham/netnovel/common/utils/TypeValidationUtil.java
+++ b/src/main/java/com/ham/netnovel/common/utils/TypeValidationUtil.java
@@ -25,6 +25,7 @@ public class TypeValidationUtil {
 
     }
 
+    //Novel 별점 유효성 검사, null 이거나 음수 또는 10초과여서는 안됨
     public static void validateNovelRating(Integer rating) {
         //null 체크
         if (rating == null) {
@@ -33,6 +34,16 @@ public class TypeValidationUtil {
         // 범위 체크 (0~10)
         if (rating < 1 || rating > 10) {
             throw new IllegalArgumentException("validateNovelRating 에러: 파라미터가 1~10 범위를 벗어났습니다.");
+        }
+    }
+
+    //코인수 유효성 검사, null 이거나 음수일수 없음
+    public static void validateCoinAmount(Integer coinAmount){
+        if (coinAmount == null){
+
+            throw new IllegalArgumentException("validateCoinUseAmount 에러: 사용한 코인 갯수가 null 입니다");
+        } else if (coinAmount <0 ) {
+            throw new IllegalArgumentException("validateCoinUseAmount 에러: 사용한 코인 갯수가 음수입니다.");
         }
     }
 

--- a/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
@@ -60,7 +60,7 @@ public class RecentReadServiceImpl implements RecentReadService {
         Member member = memberService.getMember(providerId)
                 .orElseThrow(() -> new NoSuchElementException("Member 가  엔티티가 null 입니다."));
         //에피소드 엔티티 객체에 저장
-        Episode episode = episodeService.getEpisodeEntity(episodeId)
+        Episode episode = episodeService.getEpisode(episodeId)
                 .orElseThrow(() -> new NoSuchElementException("Episode 가 엔티티가 null 입니다."));
         //에피소드의 소설 엔티티 정보 객체에 저장
         Novel novel = episode.getNovel();


### PR DESCRIPTION
## 유저의 에피소드 결제 내역 유무를 반환하는 로직 추가

### 변경사항
- CoinUseHistoryRepository
  - 유저 정보와 에피소드 정보로 코인 사용 기록을 DB에서 찾는 메서드 추가(findByMemberAndEpisode)
    - 파라미터로 providerId, episodeId 받음

- CoinUseHistoryServiceImpl
  - 유저가 에피소드에 결제한 내역이 있는지 확인하는 메서드 추가(hasMemberUsedCoinsForEpisode)
    - 결제 내역이 있을 경우 true, 결제 내역이 없을경우 false 반환

- CoinUseHistoryServiceImplTest
  - hasMemberUsedCoinsForEpisode 메서드 테스트, 테스트 성공

- TypeValidationUtil
  - 코인수 유효성 검사 메서드 추가(validateCoinAmount)
    - Integer 타입으로 coinAmount 파라미터 받음
    - 파라미터가 음수이거나 null 일경우 IllegalArgumentException로 던짐