### PR TITLE
댓글 정렬 기능 수정(좋아요순, 최신순)

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/CommentRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentRepository.java
@@ -7,40 +7,75 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment,Long> {
-
-
-    @Query("select c from Comment c " +
-            "join fetch c.member m " +
-            "where c.episode.id =:episodeId")
-    List<Comment> findByEpisodeId(@Param("episodeId")Long episodeId,Pageable pageable);
-
+public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     /**
      * 유저가 작성한 댓글을 모두찾아 반환하는 메서드
+     *
      * @param providerId 유저의 providerId 값
      * @return List Comment 엔티티 List로 반환
      */
-    @Query("select c from Comment c " +
-            "join fetch c.member m " +
+    @Query("select c from Comment c " +//Episode 테이블과 join(N:1)
+            "join fetch c.member m " +//Member 테이블과 join(N:1)
             "where m.providerId =:providerId " +
-            "order by c.createdAt DESC ")//생성 날짜 내림차순 정렬(최신글이 위로오게설정)
-    List<Comment> findByMember(@Param("providerId")String providerId,Pageable pageable);
+            "order by c.createdAt DESC ")//생성 시간으로 내림차순 정렬
+//날짜순으로 역정렬, 최신순이 위로옴
+    List<Comment> findByMember(@Param("providerId") String providerId, Pageable pageable);
+
+
+    @Query("select c from Comment c " +
+            "join fetch c.member m " +//Member 테이블과 join(N:1)
+            "join fetch c.episode e " +//Episode 테이블과 join(N:1)
+            "where c.episode.id =:episodeId " +
+            "and c.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
+            "order by c.createdAt desc ")//생성 시간으로 내림차순 정렬
+//날짜순으로 역정렬, 최신순이 위로옴
+    List<Comment> findByEpisodeIdByCreatedAt(@Param("episodeId") Long episodeId, Pageable pageable);
+
+
+    @Query("select c from Comment c " +
+            "join fetch c.member m " +//Member 테이블과 join(N:1)
+            "join fetch c.episode e " +
+            "where c.episode.id =:episodeId " +
+            "and c.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
+            "order by (select count(cl) from CommentLike  cl " +//CommentLike 엔티티의 commentId 를 count
+            "where cl.comment.id = c.id) desc ")//좋아요 순으로 내림차순으로 정렬(좋아요 많은 댓글이 위로옴)
+//날짜순으로 역정렬, 최신순이 위로옴
+    List<Comment> findByEpisodeIdByCommentLikes(@Param("episodeId") Long episodeId, Pageable pageable);
 
 
     /**
      * 소설(novel)의 에피소드에 달린 댓글을 DB에서 찾는 메서드
+     *
      * @param novelId 소설의 PK
      * @return List<Comment>
      */
     @Query("select c from Comment c " +
             "join fetch c.episode e " +
-            "join fetch c.member m " +
-            "where e.novel.id = :novelId")
-    List<Comment> findByNovel(@Param("novelId")Long novelId, Pageable pageable);
+            "join fetch c.member m " +//Member 테이블과 join(N:1)
+            "where e.novel.id = :novelId " +
+            "and c.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
+            "order by c.createdAt desc ")//생성 시간으로 내림차순 정렬
+//댓글 생성시간으로 정렬
+//날짜순으로 역정렬, 최신순이 위로옴
+    List<Comment> findByNovelOrderByCreatedAt(@Param("novelId") Long novelId, Pageable pageable);
 
 
-
+    /**
+     * 소설(novel)의 에피소드에 달린 댓글을 DB에서 찾는 메서드
+     *
+     * @param novelId 소설의 PK
+     * @return List<Comment>
+     */
+    @Query("select c from Comment c " +
+            "join fetch c.episode e " +
+            "join fetch c.member m " +//Member 테이블과 join(N:1)
+            "where e.novel.id = :novelId " +
+            "and c.status = 'ACTIVE' " +  //ACTIVE 상태인 댓글만 가져옴
+            "order by (select count(cl) from CommentLike cl " + //CommentLike 엔티티의 commentId 를 count
+            "where cl.comment.id = c.id) desc ")//내림차순으로 정렬(좋아요 많은 댓글이 위로옴)
+//날짜순으로 역정렬, 최신순이 위로옴
+    List<Comment> findByNovelOrderByCommentLikes(@Param("novelId") Long novelId, Pageable pageable);
 
 
 }

--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -170,14 +170,13 @@ public class CommentServiceImpl implements CommentService {
     public List<CommentEpisodeListDto> getEpisodeCommentListByRecent(Long episodeId,Pageable pageable) {
 
         try {
-            return commentRepository.findByEpisodeId(episodeId,pageable)
+            return commentRepository.findByEpisodeIdByCreatedAt(episodeId,pageable)
                     .stream()
                     //엔티티 DTO로 convert
                     .map(this::convertToCommentEpisodeListDto)
                     //생성시간 역순으로 정렬(최신 댓글이 먼저 나오도록)
                     .sorted(Comparator.comparing(CommentEpisodeListDto::getCreatedAt).reversed())
                     .collect(Collectors.toList()); // List로 변환
-
         } catch (Exception e) {
             throw new ServiceMethodException("getReCommentList 메서드 에러 발생"); // 예외 던지기
         }
@@ -189,7 +188,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional(readOnly = true)
     public List<CommentEpisodeListDto> getEpisodeCommentListByLikes(Long episodeId,Pageable pageable) {
         try {
-            return commentRepository.findByEpisodeId(episodeId,pageable)
+            return commentRepository.findByEpisodeIdByCommentLikes(episodeId,pageable)
                     .stream()
                     //엔티티 DTO로 convert
                     .map(this::convertToCommentEpisodeListDto)
@@ -204,30 +203,27 @@ public class CommentServiceImpl implements CommentService {
 
 
 
-    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<CommentEpisodeListDto> getNovelCommentListByRecent(Long novelId,Pageable pageable) {
         try {
-            return commentRepository.findByNovel(novelId,pageable).stream()
+            return commentRepository.findByNovelOrderByCreatedAt(novelId,pageable).stream()
                 //엔티티 DTO로 convert
                 .map(this::convertToCommentEpisodeListDto)
                 //생성시간 역순으로 정렬(최신 댓글이 먼저 나오도록)
                 .sorted(Comparator.comparing(CommentEpisodeListDto::getCreatedAt).reversed())
                 .collect(Collectors.toList());
-
         }catch (Exception e) {
             throw new ServiceMethodException("getMemberCommentList 메서드 에러 발생"); // 예외 던지기
         }
 
     }
 
-    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<CommentEpisodeListDto> getNovelCommentListByLikes(Long novelId, Pageable pageable) {
         try {
-            return commentRepository.findByNovel(novelId,pageable).stream()
+            return commentRepository.findByNovelOrderByCommentLikes(novelId,pageable).stream()
                     //엔티티 DTO로 convert
                     .map(this::convertToCommentEpisodeListDto)
                     //좋아요 순으로 정렬, 기본값은 오름차순 정렬이므로 reversed 추가

--- a/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/comment/service/CommentServiceImplTest.java
@@ -82,9 +82,10 @@ class CommentServiceImplTest {
     @Test
     public void getEpisodeCommentListByRecent() {
         System.out.println("댓글 불러오기 테스트");
-        Pageable pageable = PageRequest.of(1, 10);
+        Long episodeId = 3008L;
+        Pageable pageable = PageRequest.of(1, 3);
 
-        List<CommentEpisodeListDto> commentList = commentService.getEpisodeCommentListByRecent(2310L,pageable);
+        List<CommentEpisodeListDto> commentList = commentService.getEpisodeCommentListByRecent(episodeId,pageable);
 //        List<CommentEpisodeListDto> commentList = commentService.getCommentList(909090909L);//존재하지 않는 에피소드 테스트, 빈리스트 반환됨
 
         printCommentAndReCommentInfo(commentList);
@@ -95,8 +96,9 @@ class CommentServiceImplTest {
     //테스트 성공 ,좋아요 순서로 정렬
     @Test
     void getEpisodeCommentListByLikes() {
-        Long episodeId = 2310L;
-        Pageable pageable = PageRequest.of(0, 10);
+        System.out.println("댓글 불러오기 테스트");
+        Long episodeId = 3008L;
+        Pageable pageable = PageRequest.of(1, 3);
         List<CommentEpisodeListDto> episodeCommentListByLikes = commentService.getEpisodeCommentListByLikes(episodeId,pageable);
 
         //출력 테스트
@@ -114,7 +116,7 @@ class CommentServiceImplTest {
         //댓글을 작성한적이 없는 유저 테스트
 //        String providerId= "ttt";
 
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 3);
 
         List<MemberCommentDto> memberCommentList = commentService.getMemberCommentList(providerId,pageable);
 
@@ -125,8 +127,6 @@ class CommentServiceImplTest {
         for (MemberCommentDto memberCommentDto : memberCommentList) {
             System.out.println("댓글");
             System.out.println(memberCommentDto.toString());
-
-
         }
 
 
@@ -135,7 +135,7 @@ class CommentServiceImplTest {
     //테스트 성공
     @Test
     public void getNovelCommentListRecent() {
-        Long novelId = 1L;
+        Long novelId = 10L;
 //        Long novelId =7L;
         Pageable pageable = PageRequest.of(0, 10);
 
@@ -148,10 +148,10 @@ class CommentServiceImplTest {
     //에피소드 상관 없이, 좋아요 순서대로 댓글 정렬됨
     @Test
     void getNovelCommentListByLikes() {
-        Long novelId = 1L;
+        Long novelId = 10L;
 //        Long novelId =7L;
 
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(1, 6);
 
         List<CommentEpisodeListDto> novelCommentListByLikes = commentService.getNovelCommentListByLikes(novelId,pageable);
 


### PR DESCRIPTION
## 변경사항

### CommentRepository
- findByEpisodeIdByCreatedAt
  - findByEpisodeId 에서 메서드명 변경
  - 댓글 status 가 ACTIVE 인 댓글만 찾도록 쿼리문 추가
  - createdAt 으로 정렬되도록 ORDER BY 문 추가

- findByNovelOrderByCreatedAt
  - findByNovel 에서 메서드명 변경
  - 댓글 status 가 ACTIVE 인 댓글만 찾도록 쿼리문 추가
  - createdAt 으로 정렬되도록 ORDER BY 문 추가

- findByEpisodeIdByCommentLikes
   - 에피소드에 달린 댓글을 좋아요순으로 찾는 메서드 추가
   - COUNT 함수로 CommentLIke 테이블에서 댓글에 달린 좋아요수 계산

- findByNovelOrderByCommentLikes
   - 소설에 달린 댓글을 좋아요순으로 찾는 메서드 추가
   - COUNT 함수로 CommentLIke 테이블에서 댓글에 달린 좋아요수 계산
 

### CommentServiceImpl
  - 리포지토리 계층 메서드명 변경

### CommentServiceImplTest
  - getEpisodeCommentListByRecent, getEpisodeCommentListByLikes, getNovelCommentListByLikes, getNovelCommentListRecent 테스트 재진행, 테스트 성공