### PR TITLE
에피소드 상세 정보를 전달 로직, 결제내역 검증 로직  추가

### DIFF
--- a/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
@@ -1,0 +1,12 @@
+package com.ham.netnovel.common.exception;
+
+public class EpisodeNotPurchasedException extends RuntimeException{//에피소드 결제 내역이 없을때 예외처리
+
+    public EpisodeNotPurchasedException(String message) {
+        super(message);
+    }
+
+    public EpisodeNotPurchasedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeDetailDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeDetailDto.java
@@ -1,0 +1,25 @@
+package com.ham.netnovel.episode.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+@Builder
+@Setter
+@Getter
+@ToString
+public class EpisodeDetailDto {
+    @NotNull
+    private Long episodeId;
+
+    //제목
+    @NotNull
+    private String title;
+
+    //내용
+    @NotNull
+    private String content;
+}

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeDetailService.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeDetailService.java
@@ -1,0 +1,15 @@
+package com.ham.netnovel.episode.service;
+
+import com.ham.netnovel.episode.dto.EpisodeDetailDto;
+
+public interface EpisodeDetailService {
+
+
+    /**
+     *
+     * @param providerId
+     * @param episodeId
+     * @return
+     */
+    EpisodeDetailDto getEpisodeDetail(String providerId,Long episodeId);
+}

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeDetailServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeDetailServiceImpl.java
@@ -1,0 +1,59 @@
+package com.ham.netnovel.episode.service;
+
+import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
+import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.episode.dto.EpisodeDetailDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+public class EpisodeDetailServiceImpl implements EpisodeDetailService {
+
+    private final EpisodeService episodeService;
+    private final CoinUseHistoryService coinUseHistoryService;
+
+    public EpisodeDetailServiceImpl(EpisodeService episodeService, CoinUseHistoryService coinUseHistoryService) {
+        this.episodeService = episodeService;
+        this.coinUseHistoryService = coinUseHistoryService;
+    }
+
+
+    @Override
+    @Transactional
+    public EpisodeDetailDto getEpisodeDetail(String providerId, Long episodeId) {
+
+
+        //episode 엔티티 유무 확인, 없을경우 예외로 던짐
+        Episode episode = episodeService.getEpisode(episodeId)
+                .orElseThrow(() -> new NoSuchElementException("Episode 정보 없음"));
+
+        //에피소드의 coinCost 객체에 저장
+        Integer coinCost = episode.getCostPolicy().getCoinCost();
+        //coinCost 검증, null 이거나 음수면 예외로 던짐
+        TypeValidationUtil.validateCoinAmount(coinCost);
+
+        //에피소드가 유료일경우 처리 로직
+        if (coinCost > 0) {
+            //유저의 에피소드 결제 내역을 확인, 있을경우 true 없을경우 false 반환
+            boolean result = coinUseHistoryService.hasMemberUsedCoinsForEpisode(providerId, episodeId);
+            //결제 내역이 없을경우 EpisodeNotPurchasedException 로 던짐
+            if (!result) {
+                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId);
+            }
+        }
+
+        //에피소드 정보 DTO로 변환하여 반환
+        return EpisodeDetailDto.builder()
+                .episodeId(episodeId)
+                .content(episode.getContent())
+                .title(episode.getTitle())
+                .build();
+
+
+    }
+
+}

--- a/src/test/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.coinUseHistory.service;
 
+import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
 import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,23 @@ class CoinUseHistoryServiceImplTest {
     @Test
     void saveCoinUseHistory() {
 
-        String providerId = "";
-        Long episodeId = 2306L;
-        Integer amount = 2;
+        String providerId = "test";
+//        String providerId = "teㄷㄷㄷㄷst";//존재하지 않은 유저 테스트, NoSuchElementException로 던져짐
 
-//        new
-//        coinUseHistoryService.saveCoinUseHistory(providerId,episodeId,amount);
+//        Long episodeId = 3002L;
+        Long episodeId = 3002L;//존재하지 않는 에피소드 테스트, NoSuchElementException로 던져짐
+
+
+        Integer amount = 2;
+//        Integer amount = 200000;        //유저 코인수가 사용 코인수보다 적은경우 테스트 , NotEnoughCoinsException로 던져짐
+
+        CoinUseCreateDto dto = CoinUseCreateDto.builder()
+                .usedCoins(amount)
+                .episodeId(episodeId)
+                .providerId(providerId)
+                .build();
+
+        coinUseHistoryService.saveCoinUseHistory(dto);
 
 
     }

--- a/src/test/java/com/ham/netnovel/episode/service/EpisodeDetailServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/episode/service/EpisodeDetailServiceImplTest.java
@@ -1,0 +1,33 @@
+package com.ham.netnovel.episode.service;
+
+import com.ham.netnovel.episode.dto.EpisodeDetailDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class EpisodeDetailServiceImplTest {
+
+    private final EpisodeDetailService episodeDetailService;
+
+    @Autowired
+    EpisodeDetailServiceImplTest(EpisodeDetailService episodeDetailService) {
+        this.episodeDetailService = episodeDetailService;
+    }
+
+    //테스트 성공
+    @Test
+    void getEpisodeDetail() {
+
+
+        //결제 내역이 없으면 EpisodeNotPurchasedException로 던져짐
+        String providerId="test";
+
+        Long episodeId = 30001L;//존재하지 않는 Episode면 NoSuchElementException던져짐
+
+        EpisodeDetailDto episodeDetail = episodeDetailService.getEpisodeDetail(providerId, episodeId);
+        System.out.println(episodeDetail.toString());
+    }
+}


### PR DESCRIPTION
## 변경사항
### 에피소드 상세 정보를 전달하는 로직 추가
- EpisodeDetailDto
  - Episode 상세정보를 전송할때 사용하는 DTO 생성
  - episodeId, title, content 멤버변수로가짐

- EpisodeDetailService
  - Episode 상세 정보를 전송하기 위한 서비스 계층 추가
  - 에피소드 상제 정보를 반환하는 메서드 추가(getEpisodeDetail)
    - providerId와 episodeId를 파라미터로 받음
    - 유저의 에피소드 내역이 있을경우 에피소드 상세정보를 보냄
    - 결제내역이 없을경우 EpisodeNotPurchasedException 로 던짐(프론트에서 어떻게 받을지 논의 필요)

- EpisodeNotPurchasedException
  - 에피소드 결제 내역이 없을때 던질 예외 클래스 추가
  - RuntimeException 상속받아 정의

- GlobalExceptionAdvice
  - EpisodeNotPurchasedException 핸들러 추가

- EpisodeDetailServiceImplTest
  - getEpisodeDetail 테스트, 테스트 성공

### 유저가 에피소드 URI 로 Request 요청시, 결제내역 유무 확인하는 검증 로직 추가
- CoinUseHistoryServiceImpl
  - saveCoinUseHistory 메서드 검증 로직 추가
    - 유저가 에피소드 구매에 사용한 코인수 검증 로직 추가, null 이거나 음수면 예외로 던짐
    - 유저의 코인 수 차감 로직 추가
      - 유저의 코인 개수에서 결제한 코인수 차감
      - 유저의 코인 개수가 결제한 코인 수보다 적으면 예외로 던짐

- CoinUseHistoryServiceImplTest
  - saveCoinUseHistory 메서드 예외 처리 테스트, 테스트 성공