### PR TITLE
엔드포인트 통신 관련 Refactoring 작업

### DIFF
--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Controller
 @Slf4j
-@RequestMapping("/api/coin-charge-history")
+@RequestMapping("/api")
 public class CoinChargeHistoryController {
 
     private final CoinChargeHistoryService coinChargeHistoryService;
@@ -30,7 +30,7 @@ public class CoinChargeHistoryController {
         this.authenticator = authenticator;
     }
 
-    @PostMapping
+    @PostMapping("/coin-charge-history")
     public ResponseEntity<?> chargeMemberCoins(@Valid @RequestBody CoinChargeCreateDto coinChargeCreateDto,
                                                BindingResult bindingResult,
                                                Authentication authentication){

--- a/src/main/java/com/ham/netnovel/comment/CommentController.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentController.java
@@ -108,13 +108,6 @@ public class CommentController {
         //DTO에 유저 정보(providerId) 값 저장
         commentUpdateDto.setProviderId(principal.getName());
 
-        //URL의 commentId와 RequestBody의 commentlId가 같은지 검증
-        if (!urlCommentId.equals(commentUpdateDto.getCommentId())) {
-            String errorMessage = "deleteComment API Error = 'Path Variable Id != Message Body Id'";
-            log.error(errorMessage);
-            return ResponseEntity.badRequest().body(errorMessage);
-        }
-
         commentService.updateComment(commentUpdateDto);
 
         return ResponseEntity.ok("댓글 수정 완료");
@@ -151,13 +144,6 @@ public class CommentController {
 
         //DTO에 유저 정보 할당
         commentDeleteDto.setProviderId(principal.getName());
-
-        //URL의 commentId와 RequestBody의 commentlId가 같은지 검증
-        if (!urlCommentId.equals(commentDeleteDto.getCommentId())) {
-            String errorMessage = "deleteComment API Error = 'Path Variable Id != Message Body Id'";
-            log.error(errorMessage);
-            return ResponseEntity.badRequest().body(errorMessage);
-        }
 
         //댓글의 상태를 삭제 상태로 변경
         commentService.deleteComment(commentDeleteDto);

--- a/src/main/java/com/ham/netnovel/comment/CommentController.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentController.java
@@ -9,7 +9,6 @@ import com.ham.netnovel.comment.dto.CommentUpdateDto;
 import com.ham.netnovel.comment.service.CommentService;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.PageableUtil;
-import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +25,7 @@ import java.util.Map;
 
 @Controller
 @Slf4j
-@RequestMapping("/api/comments")
+@RequestMapping("/api")
 public class CommentController {
 
 
@@ -50,7 +49,7 @@ public class CommentController {
      * @param authentication   유저의 인증정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @PostMapping
+    @PostMapping("/comments")
     public ResponseEntity<String> createComment(@Valid @RequestBody CommentCreateDto commentCreateDto,
                                                 BindingResult bindingResult,
                                                 Authentication authentication) {
@@ -86,10 +85,13 @@ public class CommentController {
      * @param authentication   유저의 인증 정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @PatchMapping
-    public ResponseEntity<String> updateComment(@Valid @RequestBody CommentUpdateDto commentUpdateDto,
-                                                BindingResult bindingResult,
-                                                Authentication authentication) {
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<String> updateComment(
+            @PathVariable(name = "commentId") Long urlCommentId,
+            @Valid @RequestBody CommentUpdateDto commentUpdateDto,
+            BindingResult bindingResult,
+            Authentication authentication
+    ) {
 
         //CommentUpdateDto Validation 에러가 있을경우 badRequest 전송
         if (bindingResult.hasErrors()) {
@@ -106,7 +108,13 @@ public class CommentController {
         //DTO에 유저 정보(providerId) 값 저장
         commentUpdateDto.setProviderId(principal.getName());
 
-        //
+        //URL의 commentId와 RequestBody의 commentlId가 같은지 검증
+        if (!urlCommentId.equals(commentUpdateDto.getCommentId())) {
+            String errorMessage = "deleteComment API Error = 'Path Variable Id != Message Body Id'";
+            log.error(errorMessage);
+            return ResponseEntity.badRequest().body(errorMessage);
+        }
+
         commentService.updateComment(commentUpdateDto);
 
         return ResponseEntity.ok("댓글 수정 완료");
@@ -122,11 +130,12 @@ public class CommentController {
      * @param authentication   유저의 인증 정보
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
-    @DeleteMapping
-    public ResponseEntity<String> deleteComment(@Valid @RequestBody CommentDeleteDto commentDeleteDto,
-                                                BindingResult bindingResult,
-                                                Authentication authentication) {
-
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<String> deleteComment(
+            @PathVariable(name = "commentId") Long urlCommentId,
+            @Valid @RequestBody CommentDeleteDto commentDeleteDto,
+            BindingResult bindingResult,
+            Authentication authentication) {
 
         //CommentUpdateDto Validation 에러가 있을경우 badRequest 전송
         if (bindingResult.hasErrors()) {
@@ -143,6 +152,13 @@ public class CommentController {
         //DTO에 유저 정보 할당
         commentDeleteDto.setProviderId(principal.getName());
 
+        //URL의 commentId와 RequestBody의 commentlId가 같은지 검증
+        if (!urlCommentId.equals(commentDeleteDto.getCommentId())) {
+            String errorMessage = "deleteComment API Error = 'Path Variable Id != Message Body Id'";
+            log.error(errorMessage);
+            return ResponseEntity.badRequest().body(errorMessage);
+        }
+
         //댓글의 상태를 삭제 상태로 변경
         commentService.deleteComment(commentDeleteDto);
 
@@ -157,12 +173,12 @@ public class CommentController {
      * 댓글과 대댓글 DTO는 엔티티PK, content(내용), nickName(작성자닉네임), updatedAt(마지막으로 업데이트한 시각)을 멤버변수로 가짐
      * @return ResponseEntity 댓글 내용을 CommentListDto의 List 형태로 반환
      */
-    @GetMapping("/episode{episodeId}/{sortBy}")
+    @GetMapping("/episode/{episodeId}/comments")
     public ResponseEntity<?> getEpisodeComments(
             @PathVariable(name = "episodeId") Long episodeId,
-            @PathVariable(name = "sortBy") String sortBy,
-            @RequestParam(name = "pageNumber",defaultValue = "0") int pageNumber,
-            @RequestParam(name = "pageSize",defaultValue = "10") int pageSize){
+            @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
+            @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize){
 
         //Pageable 객체 생성, null 이거나 음수면 예외로 던짐
         Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
@@ -186,12 +202,12 @@ public class CommentController {
      * 댓글은 최신 순으로 정렬
      * @return CommentEpisodeListDto 댓글과 대댓글 정보를 담는 객체
      */
-    @GetMapping("/novel{novelId}/{sortBy}")
+    @GetMapping("/novel/{novelId}/comments")
     public ResponseEntity<List<CommentEpisodeListDto>> getNovelComments(
             @PathVariable(name = "novelId") Long novelId,
-            @PathVariable(name = "sortBy") String sortBy,
-            @RequestParam(name = "pageNumber",defaultValue = "0") int pageNumber,
-            @RequestParam(name = "pageSize",defaultValue = "10") int pageSize
+            @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
+            @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
     ) {
 
         //Pageable 객체 생성, null 이거나 음수면 예외로 던짐
@@ -207,7 +223,7 @@ public class CommentController {
         }
         else {
             //정렬 값이 없으면 예외 발생
-            throw new IllegalArgumentException("postNovelComments: invalid sortBy option");
+            throw new IllegalArgumentException("getNovelComments: invalid sortBy option");
         }
     }
 

--- a/src/main/java/com/ham/netnovel/episode/Episode.java
+++ b/src/main/java/com/ham/netnovel/episode/Episode.java
@@ -54,6 +54,7 @@ public class Episode {
     private LocalDateTime updatedAt;
 
     //활성, 삭제 처리 상태
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private EpisodeStatus status = EpisodeStatus.ACTIVE;
 

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/episode")
+@RequestMapping("/api")
 @Slf4j
 public class EpisodeController {
     private final EpisodeService episodeService;
@@ -22,9 +22,9 @@ public class EpisodeController {
         this.episodeService = episodeService;
     }
 
-    @GetMapping
+    @GetMapping("/novels/{novelId}/episodes")
     public ResponseEntity<List<EpisodeListItemDto>> getEpisodesByNovel(
-            @RequestParam(name = "novelId", required = true) Long novelId,
+            @PathVariable(name = "novelId") Long novelId,
             @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
@@ -40,7 +40,6 @@ public class EpisodeController {
         } else {
             //정렬 값이 없으면 예외 발생
             throw new IllegalArgumentException("getEpisodesByNovel: invalid sortBy option");
-
         }
     }
 }

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -1,11 +1,11 @@
 package com.ham.netnovel.episode;
 
-import com.ham.netnovel.episode.dto.EpisodeCreateDto;
+import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.episode.dto.EpisodeListItemDto;
 import com.ham.netnovel.episode.service.EpisodeService;
-import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,15 +23,24 @@ public class EpisodeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<EpisodeListItemDto>> getEpisodeListByNovel(@RequestParam("novelId") Long novelId) {
-        List<EpisodeListItemDto> episodesByNovel = episodeService.getEpisodesByNovel(novelId);
-        return ResponseEntity.ok(episodesByNovel);
-    }
+    public ResponseEntity<List<EpisodeListItemDto>> getEpisodesByNovel(
+            @RequestParam(name = "novelId", required = true) Long novelId,
+            @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
+            @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
+    ) {
 
-    @PostMapping
-    public ResponseEntity<String> createEpisode(@Valid @RequestBody EpisodeCreateDto reqBody) {
-        episodeService.createEpisode(reqBody);
-        return ResponseEntity.ok("Episode Create Execution");
-    }
+        //Pageable 객체 생성. null or 음수이면 예외 발생
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
 
+        if (sortBy.equals("recent")) {
+            return ResponseEntity.ok(episodeService.getEpisodesByNovelSortByRecent(novelId, pageable));
+        } else if (sortBy.equals("initial")) {
+            return ResponseEntity.ok(episodeService.getEpisodesByNovelSortByInitial(novelId, pageable));
+        } else {
+            //정렬 값이 없으면 예외 발생
+            throw new IllegalArgumentException("getEpisodesByNovel: invalid sortBy option");
+
+        }
+    }
 }

--- a/src/main/java/com/ham/netnovel/episode/EpisodeRepository.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeRepository.java
@@ -1,17 +1,40 @@
 package com.ham.netnovel.episode;
 
-
-import com.ham.netnovel.episode.Episode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface EpisodeRepository extends JpaRepository<Episode,Long> {
 
+//    @Query("select c from Comment c " +
+//            "join fetch c.member m " +//Member 테이블과 join(N:1)
+//            "join fetch c.episode e " +//Episode 테이블과 join(N:1)
+//            "where c.episode.id =:episodeId " +
+//            "and c.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
+//            "order by c.createdAt desc ")//생성 시간으로 내림차순 정렬
 
     @Query("select e from Episode e " +
-            "where e.novel.id =:novelId")
-    List<Episode> findByNovel(@Param("novelId")Long novelId);
+            "join fetch e.novel n " +
+            "where n.id = :novelId " +
+            "and e.status = 'ACTIVE' ") //ACTIVE 상태인 댓글만 가져옴
+    List<Episode> findByNovel(@Param("novelId") Long novelId);
+
+
+    @Query("select e from Episode e " +
+            "join fetch e.novel n " +
+            "where n.id = :novelId " +
+            "and e.status = 'ACTIVE' " //ACTIVE 상태인 댓글만 가져옴
+            +"order by e.createdAt desc") //최신순
+    List<Episode> findByNovelOrderByCreatedAtDesc(@Param("novelId") Long novelId, Pageable pageable);
+
+    @Query("select e from Episode e " +
+            "join fetch e.novel n " +
+            "where n.id = :novelId " +
+            "and e.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
+            "order by e.createdAt asc") //최초순
+    List<Episode> findByNovelOrderByCreatedAtAsc(@Param("novelId") Long novelId, Pageable pageable);
+
 }

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeService.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeService.java
@@ -5,6 +5,7 @@ import com.ham.netnovel.episode.dto.EpisodeCreateDto;
 import com.ham.netnovel.episode.dto.EpisodeListItemDto;
 import com.ham.netnovel.episode.dto.EpisodeDeleteDto;
 import com.ham.netnovel.episode.dto.EpisodeUpdateDto;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,7 +35,26 @@ public interface EpisodeService {
 
     /**
      * 해당 Novel에 속한 모든 Episodes List 데이터를 가져오는 메서드
+     * @param novelId 소설 id
      * @return List<EpisodeDataDto>
      */
     List<EpisodeListItemDto> getEpisodesByNovel(Long novelId);
+
+    /**
+     * 해당 Novel에 속한 모든 Episodes List dto를 최신순으로 가져오는 메서드.
+     * 페이지 단위로 일부만 가져옴.
+     * @param novelId 소설 id
+     * @param pageable 페이지 정보.
+     * @return List<EpisodeDataDto>
+     */
+    List<EpisodeListItemDto> getEpisodesByNovelSortByRecent(Long novelId, Pageable pageable);
+
+    /**
+     * 해당 Novel에 속한 모든 Episodes List dto를 최초순으로 가져오는 메서드.
+     * 페이지 단위로 일부만 가져옴.
+     * @param novelId 소설 id
+     * @param pageable 페이지 정보.
+     * @return List<EpisodeDataDto>
+     */
+    List<EpisodeListItemDto> getEpisodesByNovelSortByInitial(Long novelId, Pageable pageable);
 }

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 @Controller
 @Slf4j
-@RequestMapping("/api/member")
+@RequestMapping("/api")
 public class MemberController {
 
     private final Authenticator authenticator;
@@ -47,17 +47,17 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 유저 정보 담은 응답 객체
      */
-    @GetMapping("/mypage")
+    @GetMapping("/members/mypage")
     @ResponseBody
     public ResponseEntity<?> showMyPage(
             Authentication authentication
     ) {
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
-        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+//        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
 
         //유저 정보 DB에서 찾아 반환, 닉네임, 코인갯수, 이메일 정보 포함
-        MemberMyPageDto memberMyPageInfo = memberService.getMemberMyPageInfo(principal.getName());
-//        MemberMyPageDto memberMyPageInfo = memberService.getMemberMyPageInfo("test");
+//        MemberMyPageDto memberMyPageInfo = memberService.getMemberMyPageInfo(principal.getName());
+        MemberMyPageDto memberMyPageInfo = memberService.getMemberMyPageInfo("test1");
 
         //유저 정보 전
         return ResponseEntity.ok(memberMyPageInfo);
@@ -71,7 +71,8 @@ public class MemberController {
      * @param authentication    유저의 인증 정보
      * @return ResponseEntity 요청 결과를 담은 응답 객체
      */
-    @PatchMapping("/nickname")
+    //Todo 송민규: Edit Profile 페이지를 구성하여 Nickname, Email, Gender을 일괄적으로 수정할 수 있도록 기능을 확장하는 건 어떨까요?
+    @PatchMapping("/members/nickname")
     public ResponseEntity<?> updateNickname(@Valid @RequestBody ChangeNickNameDto changeNickNameDto,
                                             BindingResult bindingResult,
                                             Authentication authentication) {
@@ -124,7 +125,7 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 댓글과 대댓글의 정보 리스트를 담은 응답 객체
      */
-    @GetMapping("/comment")
+    @GetMapping("/members/comments")
     public ResponseEntity<?> getMemberCommentList(Authentication authentication,
                                                    @RequestParam(defaultValue = "0") int pageNumber,
                                                    @RequestParam(defaultValue = "10") int pageSize) {

--- a/src/main/java/com/ham/netnovel/novel/Novel.java
+++ b/src/main/java/com/ham/netnovel/novel/Novel.java
@@ -1,6 +1,5 @@
 package com.ham.netnovel.novel;
 
-import com.ham.netnovel.comment.CommentStatus;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.novel.data.NovelStatus;

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("api/novel")
+@RequestMapping("/api")
 public class NovelController {
     private final NovelService novelService;
     private final Authenticator authenticator;
@@ -35,9 +35,8 @@ public class NovelController {
      * @param novelId novelId를 담은 url path variable
      * @return ResponseEntity NovelResponseDto로 Novel 데이터 반환.
      */
-    @GetMapping("/{novelId}")
+    @GetMapping("/novels/{novelId}")
     public ResponseEntity<NovelResponseDto> getNovel(@PathVariable("novelId") Long novelId) {
-
         return ResponseEntity.ok(novelService.getNovel(novelId));
     }
 
@@ -84,8 +83,8 @@ public class NovelController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
-    @PutMapping("/{novelId}")
-    public ResponseEntity<String> updateNovel(@PathVariable("novelId") Long pathNovelId,
+    @PutMapping("/novels/{novelId}")
+    public ResponseEntity<String> updateNovel(@PathVariable("novelId") Long urlNovelId,
                                                         @Valid @RequestBody NovelUpdateDto reqBody,
                                                         BindingResult bindingResult,
                                                         Authentication authentication) {
@@ -103,7 +102,7 @@ public class NovelController {
         reqBody.setAccessorProviderId(principal.getName());
 
         //url의 novelId와 reqBody의 novelId가 같은지 검증
-        if (!pathNovelId.equals(reqBody.getNovelId())) {
+        if (!urlNovelId.equals(reqBody.getNovelId())) {
             String errorMessage = "updateNovel API Error = 'Path Variable Id != Message Body Id'";
             log.error(errorMessage);
             return ResponseEntity.badRequest().body(errorMessage);
@@ -120,8 +119,8 @@ public class NovelController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
-    @DeleteMapping("/{novelId}")
-    public ResponseEntity<String> deleteNovel(@PathVariable("novelId") Long pathNovelId,
+    @DeleteMapping("/novels/{novelId}")
+    public ResponseEntity<String> deleteNovel(@PathVariable("novelId") Long urlNovelId,
                                                         @Valid @RequestBody NovelDeleteDto reqBody,
                                                         BindingResult bindingResult,
                                                         Authentication authentication) {
@@ -139,7 +138,7 @@ public class NovelController {
         reqBody.setAccessorProviderId(principal.getName());
 
         //url의 novelId와 reqBody의 novelId가 같은지 검증
-        if (!pathNovelId.equals(reqBody.getNovelId())) {
+        if (!urlNovelId.equals(reqBody.getNovelId())) {
             String errorMessage = "deleteNovel API Error = 'Path Variable Id != Message Body Id'";
             log.error(errorMessage);
             return ResponseEntity.badRequest().body(errorMessage);

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -101,13 +101,6 @@ public class NovelController {
         //DTO에 유저 정보(providerId) 값 저장
         reqBody.setAccessorProviderId(principal.getName());
 
-        //url의 novelId와 reqBody의 novelId가 같은지 검증
-        if (!urlNovelId.equals(reqBody.getNovelId())) {
-            String errorMessage = "updateNovel API Error = 'Path Variable Id != Message Body Id'";
-            log.error(errorMessage);
-            return ResponseEntity.badRequest().body(errorMessage);
-        }
-
         NovelResponseDto result = novelService.updateNovel(reqBody);
         return ResponseEntity.ok("updateNovel: " + result.toString());
     }
@@ -136,13 +129,6 @@ public class NovelController {
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
         //DTO에 유저 정보(providerId) 값 저장
         reqBody.setAccessorProviderId(principal.getName());
-
-        //url의 novelId와 reqBody의 novelId가 같은지 검증
-        if (!urlNovelId.equals(reqBody.getNovelId())) {
-            String errorMessage = "deleteNovel API Error = 'Path Variable Id != Message Body Id'";
-            log.error(errorMessage);
-            return ResponseEntity.badRequest().body(errorMessage);
-        }
 
         NovelResponseDto result = novelService.deleteNovel(reqBody);
         return ResponseEntity.ok("deleteNovel: " + result.toString());

--- a/src/test/java/com/ham/netnovel/MakeTestRecord.java
+++ b/src/test/java/com/ham/netnovel/MakeTestRecord.java
@@ -71,11 +71,11 @@ public class MakeTestRecord {
     @Test
     void makeTestItems() {
         //DB records 전부 삭제
+        commentLikeRepository.deleteAll();
         commentRepository.deleteAll();
         episodeRepository.deleteAll();
         costPolicyRepository.deleteAll();
         novelRepository.deleteAll();
-        commentLikeRepository.deleteAll();
         memberRepository.deleteAll();
 
         //auto_increment id를 1부터 초기화.
@@ -140,8 +140,8 @@ public class MakeTestRecord {
             }
             CommentLikeToggleDto commentLikeToggleDto = CommentLikeToggleDto.builder()
                     .likeType(LikeType.LIKE)
-                    .providerId("test" + j)
-                    .commentId((long) i)
+                    .providerId("test" + i)
+                    .commentId((long) j)
                     .build();
             commentLikeService.toggleCommentLikeStatus(commentLikeToggleDto);
         });


### PR DESCRIPTION
[feat: Episode getEpisodeByNovel Pageable 적용](https://github.com/Ham-Novel/netnovel/commit/41eae52809e8dca078bbdbb570d5a248375bafd7) 
- 페이지 단위로 데이터 배열의 일부만 나눠서 불어올 수 있음.
- 최신순, 최초순으로 정렬 가능. 에피소드 목록에서 최신화부터 or 첫화부터 정렬할 때 사용.
- 그 외에도 sortBy path variable을 query string으로 변경. (Comment 도메인에도 적용)

[refactor: controller url RestFul하게 변경](https://github.com/Ham-Novel/netnovel/commit/1468df48bb30d2bbfa0639cf2ee42e28360b7c7f) 
- Novel, Episode, Comment, CoinChargeHistory, CommentLike에 적용.
- Member는 보안상 제외. 'members/me'로 대체하는 방법 사용.

refactor: CommentController, NovelController path variable 검증 로직 제거