### PR TITLE
Spring Session 라이브러리 추가로 DBMS 세션 스토리지 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
 
+    //Spring Session Library for JDBC
+    implementation 'org.springframework.session:spring-session-jdbc'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ham/netnovel/OAuth/CustomOAuth2User.java
+++ b/src/main/java/com/ham/netnovel/OAuth/CustomOAuth2User.java
@@ -6,18 +6,18 @@ import com.ham.netnovel.member.dto.MemberOAuthDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, Serializable {
 
     private final MemberOAuthDto memberOAuthDto;
 
     public CustomOAuth2User(MemberOAuthDto memberOAuthDto) {
         this.memberOAuthDto = memberOAuthDto;
     }
-
 
 
     //    제공자별로 형식이 다릅니다. 사용금지

--- a/src/main/java/com/ham/netnovel/member/dto/MemberOAuthDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberOAuthDto.java
@@ -8,11 +8,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MemberOAuthDto {
+public class MemberOAuthDto implements Serializable {
 
     //인증 제공자에서 지정한 유저 ID값
     private String providerId;


### PR DESCRIPTION
### 변경사항
- build.gradle
  - Spring Session 라이브러리 추가, JDBC 이용 (implementation 'org.springframework.session:spring-session-jdbc')

- CustomOAuth2User, MemberOAuthDto
  - Serializable 인터페이스 implements, (Spring Session은 직렬화된 데이터만 저장)