### PR TITLE
에피소드 조회수 저장 엔티티, 소설 랭킹 관련 엔티티 설계, 관련 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCount.java
+++ b/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCount.java
@@ -1,0 +1,59 @@
+package com.ham.netnovel.episodeViewCount;
+
+import com.ham.netnovel.episode.Episode;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+
+//에피소드 조회수를 count하기 위한 엔티티
+public class EpisodeViewCount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne
+    @JoinColumn(name = "episode_id", nullable = false)
+    private Episode episode;
+
+    private LocalDate viewDate;
+
+    private Integer viewCount;
+
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public EpisodeViewCount(Episode episode, LocalDate viewDate, Integer viewCount) {
+        this.episode = episode;
+        this.viewDate = viewDate;
+        this.viewCount = viewCount;
+    }
+
+    public EpisodeViewCount increaseViewCount() {
+        if (this.viewCount==null){
+            this.viewCount = 1;
+        }
+        else {
+            this.viewCount = this.getViewCount() + 1;
+        }
+
+        return this;
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountRepository.java
+++ b/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountRepository.java
@@ -1,0 +1,65 @@
+package com.ham.netnovel.episodeViewCount;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface EpisodeViewCountRepository extends JpaRepository<EpisodeViewCount,Long> {
+
+
+    /**
+     * 에피소드의 ID와 날짜로 엔티티를 찾는 메서드
+     * @param episodeId 에피소드 ID
+     * @param viewDate 날짜(연 월 일)
+     * @return Optional EpisodeViewCount
+     */
+    @Query("select ev from EpisodeViewCount ev " +
+            "where ev.episode.id = :episodeId " +
+            "and ev.viewDate = :viewDate")
+    Optional<EpisodeViewCount> findByEpisodeIdAndViewDate(@Param("episodeId") Long episodeId,
+                                                          @Param("viewDate")LocalDate viewDate);
+
+
+    /**
+     * 특정 날짜에 대한 조회수를 소설별로 그룹화하여 반환하는 메서드
+     * @param viewDate 메서드가 실행될 날짜
+     * @return List Novel 엔티티와 tatalView(소설 총 조회수) 를 Object[]에 담아 반환
+     *         각 배열의 첫 번째 요소는 소설 엔티티(Novel)이고, 두 번째 요소는 총 조회수
+     */
+    @Query("select n AS novel, " +
+            "sum(ev.viewCount)  As totalViews " +
+            "from Novel  n " +
+            "join n.episodes e " +
+            "join EpisodeViewCount ev On ev.episode = e " +
+            "where ev.viewDate =:viewDate " +
+            "group by n.id ")
+    List<Object[]> findTodayNovelTotalViews(@Param("viewDate") LocalDate viewDate);
+
+
+    /**
+     * 한주간 소설의 총 조회수를 조회하여 소설별로 그룹화하여 반환하는 메서드
+     * @param yesterday 메서드 실행 날짜로부터 하루전 연월일 정보
+     * @param startDate 메서드 실행 날짜로부터 7일전 연월일 정보
+     * @return
+     */
+    @Query("select n AS novel, " +
+            "sum(ev.viewCount)  As totalViews " +
+            "from Novel  n " +
+            "join n.episodes e " +
+            "join EpisodeViewCount ev On ev.episode = e " +
+            "where ev.viewDate between :startDate and :yesterday " +
+            "group by n.id ")
+    List<Object[]> findWeeklyNovelTotalViews(@Param("yesterday") LocalDate yesterday,
+                                             @Param("startDate") LocalDate startDate);
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountService.java
+++ b/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountService.java
@@ -1,0 +1,33 @@
+package com.ham.netnovel.episodeViewCount;
+
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.novelRanking.dto.NovelRankingUpdateDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EpisodeViewCountService {
+
+    /**
+     * 에피소드의 오늘 날짜 조회수를 증가시키는 메서드
+     * @param episode 조회수를 증가시킬 Episode 엔티티. null 체크 후 메서드 호출 필요
+     */
+    void increaseViewCount(Episode episode);
+
+
+    /**
+     * 특정 날짜의 소설 조회수로 랭킹을 계산해 반환하는 메서드
+     * @param todayDate 계산할 날짜
+     * @return List Novel 엔티티와 totalViews(총조회수) 를 DTO에 담아 List 형태로 반환
+     */
+    List<NovelRankingUpdateDto> getDaliyRanking(LocalDate todayDate);
+
+    /**
+     * 한주동안의 소설 조회수로 랭킹을 계산해 반환하는 메서드
+     * 파라미터로 입력되는 날짜 기준으로 7일전 ~ 1일전 까지의 조회수 계산
+     * @param todayDate 계산할 날짜
+     * @return List Novel 엔티티와 totalViews(총조회수) 를 DTO에 담아 List 형태로 반환
+     */
+    List<NovelRankingUpdateDto>  getWeeklyRanking(LocalDate todayDate);
+
+}

--- a/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episodeViewCount/EpisodeViewCountServiceImpl.java
@@ -1,0 +1,111 @@
+package com.ham.netnovel.episodeViewCount;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novelRanking.dto.NovelRankingUpdateDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class EpisodeViewCountServiceImpl implements EpisodeViewCountService {
+
+    private final EpisodeViewCountRepository episodeViewCountRepository;
+
+
+    public EpisodeViewCountServiceImpl(EpisodeViewCountRepository episodeViewCountRepository) {
+        this.episodeViewCountRepository = episodeViewCountRepository;
+    }
+
+    @Override
+    @Transactional
+    public void increaseViewCount(Episode episode) {
+        try {
+            LocalDate today = LocalDate.now();
+            //DB에서 엔티티 조회
+            EpisodeViewCount episodeViewCount = episodeViewCountRepository.findByEpisodeIdAndViewDate(episode.getId(), today)
+                    .map(EpisodeViewCount::increaseViewCount)//DB에 엔티티가 있으면, 조회수 1증가시킴
+                    .orElseGet(() -> {//DB에 엔티티가 없으면 엔티티를 새로 생성
+                        return EpisodeViewCount.builder()
+                                .viewDate(today)
+                                .episode(episode)
+                                .viewCount(1)//조회수 1로 설정
+                                .build();
+                    });
+
+            //엔티티 DB에 저장
+            episodeViewCountRepository.save(episodeViewCount);
+            log.info("에피소드 조회수 1 증가 성공, episodeId = {}", episode.getId());
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("에러" + ex.getMessage());
+        }
+
+
+    }
+
+    @Override
+    @Transactional
+    public List<NovelRankingUpdateDto> getDaliyRanking(LocalDate todayDate) {
+        try {
+            //해당 날짜의 Novel 총 조회수를 계산하여 DTO List 객체에 담음
+            List<NovelRankingUpdateDto> rankingUpdateDtos = episodeViewCountRepository.findTodayNovelTotalViews(todayDate)
+                    .stream()
+                    .map(objects -> {
+                        return NovelRankingUpdateDto.builder()
+                                .novel((Novel) objects[0])//0번인덱스 Novel 엔티티
+                                .totalViews((Long) objects[1])//1번 인덱스 총 조회수
+                                .build();
+                    })
+                    .sorted(Comparator.comparing(NovelRankingUpdateDto::getTotalViews).reversed())//조회수 기준으로 내림차순 정렬
+                    .toList();
+
+            //조회수 순서로 정렬된 DTO에 랭킹 정보 추가
+            for (int i = 0; i < rankingUpdateDtos.size(); i++) {
+                rankingUpdateDtos.get(i).setRanking(i + 1);
+            }
+            //반환
+            return rankingUpdateDtos;
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getDaliyRanking 메서드 에러 발생 내용 = " + ex.getMessage());
+        }
+
+    }
+
+    @Override
+    @Transactional
+    public List<NovelRankingUpdateDto> getWeeklyRanking(LocalDate todayDate) {
+        try {
+        LocalDate yesterday = todayDate.minusDays(1);//메서드 실행 날로부터 하루전 정보
+        LocalDate startDate = todayDate.minusDays(7);//메서드 실행 날로부터 일주일 전 정보
+        List<NovelRankingUpdateDto> rankingUpdateDtos = episodeViewCountRepository.findWeeklyNovelTotalViews(yesterday, startDate)
+                .stream()
+                .map(objects -> {
+                            return NovelRankingUpdateDto.builder()
+                                    .novel((Novel) objects[0])//0번인덱스 Novel 엔티티
+                                    .totalViews((Long) objects[1])//1번 인덱스 총 조회수
+                                    .build();
+                        }
+                ).sorted(Comparator.comparing(NovelRankingUpdateDto::getTotalViews).reversed())//조회수 기준으로 내림차순 정렬
+                .toList();
+
+        //조회수 순서로 정렬된 DTO에 랭킹 정보 추가
+        for (int i = 0; i < rankingUpdateDtos.size(); i++) {
+            rankingUpdateDtos.get(i).setRanking(i + 1);
+
+        }
+        return rankingUpdateDtos;
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getWeeklyRanking 메서드 에러 발생 내용 = " + ex.getMessage());
+        }
+
+    }
+};

--- a/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
@@ -1,0 +1,21 @@
+package com.ham.netnovel.novelRanking;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface NovelRakingRepository extends JpaRepository<NovelRanking, Long> {
+
+
+    @Query("select nr from NovelRanking nr " +
+            "where nr.novel.id = :novelId " +
+            "and nr.rankingDate = :rankingDate " +
+            "and nr.rankingPeriod =:rankingPeriod")
+   Optional<NovelRanking> findByNovelIdAndRankingAndRankingPeriod(@Param("novelId")Long novelId,
+                                                                      @Param("rankingDate") LocalDate rankingDate,
+                                                                      @Param("rankingPeriod")RankingPeriod rankingPeriod);
+
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/NovelRanking.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/NovelRanking.java
@@ -1,0 +1,74 @@
+package com.ham.netnovel.novelRanking;
+
+import com.ham.netnovel.novel.Novel;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "novel_ranking",
+        uniqueConstraints = @UniqueConstraint(columnNames = {
+                "novel_Id",
+                "ranking_date",
+                "ranking_period"}))//랭킹, 랭킹생성날짜, 랭킹 주기 3개는 compoiste key로 사용
+public class NovelRanking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+
+    //랭킹
+    private Integer ranking;
+
+    //랭킹 생성 날짜, 2024-08-08 형식
+    @Column(nullable = false)
+    private LocalDate rankingDate;
+
+    //랭킹 주기, 일간 주간 월간 전체 4가지 타입
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RankingPeriod rankingPeriod;
+
+    //해당 기간의 전체 조회수
+    private Long totalViews;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public NovelRanking(Novel novel, Integer ranking, LocalDate rankingDate, RankingPeriod rankingPeriod, Long totalViews) {
+        this.novel = novel;
+        this.ranking = ranking;
+        this.rankingDate = rankingDate;
+        this.rankingPeriod = rankingPeriod;
+        this.totalViews = totalViews;
+    }
+
+
+ //NovelRanking 엔티티의 랭킹(순위)와 총 조회수를 수정하는 메서드
+    public void updateNovelRanking(Integer ranking, Long totalViews){
+        this.ranking = ranking;
+        this.totalViews = totalViews;
+
+
+    }
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/RankingPeriod.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/RankingPeriod.java
@@ -1,0 +1,10 @@
+package com.ham.netnovel.novelRanking;
+
+public enum RankingPeriod {
+    DAILY,
+    WEEKLEY,
+    MONTHLY,
+    ALL_TIME
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/dto/NovelRankingUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/dto/NovelRankingUpdateDto.java
@@ -1,0 +1,25 @@
+package com.ham.netnovel.novelRanking.dto;
+
+import com.ham.netnovel.novel.Novel;
+import lombok.*;
+import org.springframework.stereotype.Service;
+
+@Getter
+@Setter
+@Service
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NovelRankingUpdateDto {
+
+    private Novel novel;
+
+    private Integer ranking;
+
+
+
+    private Long totalViews;
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
@@ -1,0 +1,37 @@
+package com.ham.netnovel.novelRanking.service;
+
+import com.ham.netnovel.novelRanking.NovelRanking;
+import com.ham.netnovel.novelRanking.RankingPeriod;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface NovelRankingService {
+
+    /**
+     * NovelRaking 엔티티를 찾아 반환하는 메서드
+     * @param novelId 소설의 ID 값
+     * @param rankingDate 랭킹이 기록된 날짜
+     * @param rankingPeriod 일간,주간,월간,전체 기간중 해당되는 값
+     * @return Optional NovelRanking
+     */
+    Optional<NovelRanking> getNovelRankingEntity(Long novelId, LocalDate rankingDate, RankingPeriod rankingPeriod);
+
+
+    /**
+     * 소설의 일일 랭킹을 업데이트하는 메서드
+     * 해당 날짜의 조회수를 기반으로 새로운 랭킹 데이터를 생성하거나
+     * 기존 랭킹 데이터를 업데이트
+     */
+    void updateDailyRankings();
+    /**
+     * 소설의 주간 랭킹을 업데이트하는 메서드
+     * 이 메서드는 지정된 기간(어제 기준 7일 전까지)의 조회수를 기반으로
+     * 주간 랭킹 데이터를 생성하거나 업데이트
+     */
+    void updateWeeklyRankings();
+
+    void updateMonthlyRankings();
+
+
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
@@ -1,0 +1,117 @@
+package com.ham.netnovel.novelRanking.service;
+
+import com.ham.netnovel.episodeViewCount.EpisodeViewCountService;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novelRanking.NovelRakingRepository;
+import com.ham.netnovel.novelRanking.NovelRanking;
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import com.ham.netnovel.novelRanking.dto.NovelRankingUpdateDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class NovelRankingServiceImpl implements NovelRankingService {
+
+    private final NovelRakingRepository novelRakingRepository;
+
+    private final EpisodeViewCountService episodeViewCountService;
+
+    public NovelRankingServiceImpl(NovelRakingRepository novelRakingRepository, EpisodeViewCountService episodeViewCountService) {
+        this.novelRakingRepository = novelRakingRepository;
+        this.episodeViewCountService = episodeViewCountService;
+
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<NovelRanking> getNovelRankingEntity(Long novelId, LocalDate rankingDate, RankingPeriod rankingPeriod) {
+
+        return novelRakingRepository.findByNovelIdAndRankingAndRankingPeriod(novelId,rankingDate,rankingPeriod);
+
+    }
+
+    @Override
+    @Transactional
+    public void updateDailyRankings() {
+        //메서드 실행시점 연 월 일 객체에 저장
+        LocalDate todayDate = LocalDate.now();
+
+        //오늘 날짜로 소설 조회수 랭킹 데이터 가져옴
+        List<NovelRankingUpdateDto> todayRanking = episodeViewCountService.getDaliyRanking(todayDate);
+        //DB에 저장할 사용할 List 객체 생성
+        List<NovelRanking> rankingsToSave = new ArrayList<>();
+
+        for (NovelRankingUpdateDto updateDto : todayRanking) {
+            Novel novel = updateDto.getNovel();
+            Optional<NovelRanking> novelRankingEntity = getNovelRankingEntity(novel.getId(), todayDate, RankingPeriod.DAILY);
+            if (novelRankingEntity.isPresent()){
+                log.info("엔티티 Daily 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                NovelRanking novelRanking = novelRankingEntity.get();
+                novelRanking.updateNovelRanking(updateDto.getRanking(), updateDto.getTotalViews());
+                rankingsToSave.add(novelRanking);
+            } else {
+                log.info("엔티티 Daily 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                NovelRanking newNovelRanking = NovelRanking.builder()
+                        .rankingPeriod(RankingPeriod.DAILY)
+                        .novel(updateDto.getNovel())
+                        .totalViews(updateDto.getTotalViews())
+                        .rankingDate(todayDate)
+                        .ranking(updateDto.getRanking())
+                        .build();
+                rankingsToSave.add(newNovelRanking);
+            }
+        }
+        novelRakingRepository.saveAll(rankingsToSave);
+
+
+    }
+
+    @Override
+    @Transactional
+    public void updateWeeklyRankings() {
+        //메서드 실행시점 연 월 일 객체에 저장
+        LocalDate todayDate = LocalDate.now();
+        //오늘 날짜로 소설 조회수 랭킹 데이터 가져옴
+        List<NovelRankingUpdateDto> weeklyRanking = episodeViewCountService.getWeeklyRanking(todayDate);
+        //DB에 저장할 사용할 List 객체 생성
+        List<NovelRanking> rankingsToSave = new ArrayList<>();
+
+        for (NovelRankingUpdateDto updateDto : weeklyRanking) {
+            Novel novel = updateDto.getNovel();
+            Optional<NovelRanking> novelRankingEntity = getNovelRankingEntity(novel.getId(), todayDate, RankingPeriod.WEEKLEY);
+
+            if (novelRankingEntity.isPresent()){
+                log.info("엔티티 Weekly 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                NovelRanking novelRanking = novelRankingEntity.get();
+                novelRanking.updateNovelRanking(updateDto.getRanking(), updateDto.getTotalViews());
+                rankingsToSave.add(novelRanking);
+            } else {
+                log.info("엔티티 Weekly 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                NovelRanking newNovelRanking = NovelRanking.builder()
+                        .rankingPeriod(RankingPeriod.WEEKLEY)
+                        .novel(updateDto.getNovel())
+                        .totalViews(updateDto.getTotalViews())
+                        .rankingDate(todayDate)
+                        .ranking(updateDto.getRanking())
+                        .build();
+                rankingsToSave.add(newNovelRanking);
+            }
+        }
+        novelRakingRepository.saveAll(rankingsToSave);
+
+
+    }
+
+    @Override
+    public void updateMonthlyRankings() {
+
+    }
+}

--- a/src/test/java/com/ham/netnovel/episode/service/EpisodeServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/episode/service/EpisodeServiceImplTest.java
@@ -52,7 +52,7 @@ class EpisodeServiceImplTest {
                 .build();
         //when
         service.createEpisode(createDto);
-        log.info(createDto.toString());
+//        log.info(createDto.toString());
 
         //then
         Episode getEntity = service.getEpisode(1L)

--- a/src/test/java/com/ham/netnovel/episodeViewCount/EpisodeEpisodeViewCountServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/episodeViewCount/EpisodeEpisodeViewCountServiceImplTest.java
@@ -1,0 +1,45 @@
+package com.ham.netnovel.episodeViewCount;
+
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.episode.service.EpisodeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@SpringBootTest
+class EpisodeEpisodeViewCountServiceImplTest {
+    private final EpisodeViewCountService episodeViewCountService;
+
+    private final EpisodeService episodeService;
+    @Autowired
+    EpisodeEpisodeViewCountServiceImplTest(EpisodeViewCountService episodeViewCountService, EpisodeService episodeService) {
+        this.episodeViewCountService = episodeViewCountService;
+        this.episodeService = episodeService;
+    }
+
+    @Test
+    void increaseViewCount() {
+        Long episodeId = 20L;
+        Optional<Episode> episode = episodeService.getEpisode(episodeId);
+        episodeViewCountService.increaseViewCount(episode.get());
+    }
+
+    @Test
+    void getTodayRanking(){
+        LocalDate todayDate = LocalDate.now();
+
+        episodeViewCountService.getDaliyRanking(todayDate);
+
+    }
+
+    @Test
+    void getWeeklyRanking(){
+        LocalDate todayDate = LocalDate.now();
+
+        episodeViewCountService.getWeeklyRanking(todayDate);
+
+    }
+}

--- a/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
@@ -1,0 +1,48 @@
+package com.ham.netnovel.novelRanking.service;
+
+import com.ham.netnovel.novelRanking.NovelRanking;
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class NovelRankingServiceImplTest {
+
+    private final NovelRankingService novelRankingService;
+
+    @Autowired
+    NovelRankingServiceImplTest(NovelRankingService novelRankingService) {
+        this.novelRankingService = novelRankingService;
+    }
+
+    @Test
+    void getNovelRankingEntity() {
+        Long novelId = 1L;
+        LocalDate todayDate = LocalDate.now();
+
+        Optional<NovelRanking> novelRankingEntity = novelRankingService.getNovelRankingEntity(novelId, todayDate, RankingPeriod.DAILY);
+        System.out.println(novelRankingEntity.get().getId());
+    }
+
+    @Test
+    void updateDailyRankings() {
+        novelRankingService.updateDailyRankings();
+    }
+
+    @Test
+    void updateWeeklyRankings() {
+        novelRankingService.updateWeeklyRankings();
+
+    }
+
+    @Test
+    void updateMonthlyRankings() {
+    }
+}


### PR DESCRIPTION
## 변경사항
### 에피소드 조회수 저장 엔티티 설계, 관련로직 추가
- EpisodeViewCount
  - 에피소드 조회수를 저장하기 위한 엔티티 생성

  - id,episode , viewDate(연 월 일), viewCount(조회수), createdAt, updatedAt 멤버변수로 가짐

  - 엔티티의 조회수를 1 증가시키는 메서드 추가(increaseViewCount)

- EpisodeViewCountRepository
  - EpisodeViewCount 리포지토리 계층 추가

  - 에피소드의 ID와 날짜로 EpisodeViewCount 엔티티를 찾는 메서드 추가(findByEpisodeIdAndViewDate)

  - 특정 날짜에 대한 조회수를 소설별로 그룹화하여 반환하는 메서드 추가(findTodayNovelTotalViews)
    - 배열의 첫번째 요소는 Novel 엔티티, 두번째 엔티티는 Novel의 총 조회수를담아 Objcet로 반환

  - 한주간 소설의 총 조회수를 조회하여 소설별로 그룹화하여 반환하는 메서드 추가(findWeeklyNovelTotalViews)
    - 배열의 첫번째 요소는 Novel 엔티티, 두번째 엔티티는 Novel의 총 조회수를담아 Objcet로 반환

- EpisodeEpisodeViewCountServiceImplTest
  - increaseViewCount, getTodayRanking, getWeeklyRanking 메서드 테스트, 테스트 성공

### 소설 랭킹 관련 엔티티 설계, 관련 로직 추가
- NovelRanking
 - 소설 랭킹 저장용 엔티티 추가

 - novel,ranking(순위), rankingDate(순위를 기록한 날짜) ,rankingPeriod(순위 주기, 일간 주간 월간 전체 4가지타입), totalViews(총조회수), createdAt, updatedAt 멤버변수로 가짐

 - novelId, rankingDate, rankingPeriod 는 composite key 로 3개의 필드값 조합은 유니크 해야함

 - 엔티티의 랭킹(ranking) 과 총조회수(totalView)를 수정하는 메서드 추가(updateNovelRanking)

- NovelRakingRepository
  - 리포지토리 계층 추가
  - NovelRaking 엔티티를 찾아 반환하는 메서드 추가(findByNovelIdAndRankingAndRankingPeriod)
    - 파라미터로 novelId, (소설의 ID 값), rankingDate(랭킹이 기록된 날짜) ,rankingPeriod(순위 주기, 일간 주간 월간 전체 4가지타입) 을 받음

- NovelRankingService
  - 서비스 계층 추가

  - NovelRaking 엔티티를 찾아 반환하는 메서드 추가(getNovelRankingEntity)
    - 파라미터로 novelId, (소설의 ID 값), rankingDate(랭킹이 기록된 날짜) ,rankingPeriod(순위 주기, 일간 주간 월간 전체 4가지타입) 을 받음

  - 총 조회수로 소설의 일일 랭킹을 업데이트하는 메서드 추가(updateDailyRankings)
    - 소설의 각 episode 조회수를 합하여 랭킹을 매김
    - 랭킹 기록이 있으면 업데이트, 없으면 새로생성

  - 총 조회수로 소설의 주간 랭킹을 업데이트하는 메서드 추가(updateWeeklyRankings)
    - 소설의 각 episode 조회수를 합하여 랭킹을 매김
    - 기간은 메서드 실행일로부터 7일전~1일전 으로 범위 설정
    - 랭킹 기록이 있으면 업데이트, 없으면 새로생성

- NovelRankingServiceImplTest
  - getNovelRankingEntity, updateDailyRankings, updateWeeklyRankings 메서드 테스트, 테스트 성공

- NovelRankingUpdateDto
  - 소설의 랭킹을 업데이트 하기위한 DTO 추가
  - novel, ranking, totalViews 를 멤버변수로 가짐

- RankingPeriod
  - 랭킹 주기 설정을 위한 enum 클래스 추가
  - DAILY, WEEKLEY, MONTHLY,  ALL_TIME 4가지 타입을 가짐