### PR TITLE
소설 랭킹 정보를 Redis에 저장 및 조회하는 로직,  랭킹 순서로 소설 정보 전달하는 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -45,6 +45,18 @@ public class NovelController {
         return null;
     }
 
+    /**
+     * 주어진 랭킹 기간에 따라 소설 랭킹 정보를 조회하고 반환하는 API
+     * @param period 쿼리 파라미터로 랭킹 기간을 받음, (daily, weekly, monthly, all-time 중 하나)
+     * @return ResponseEntity<List<NovelInfoDto>> 소설 정보를 담은 객체 반환.
+     */
+    @GetMapping("/novels/ranking")
+    public ResponseEntity<List<NovelInfoDto>> getNovelsByRanking(@RequestParam("period") String period){
+        //유저가 요청한 랭킹 기간에 따라, 소설 정보를 랭킹 순서대로 정렬하여 List에 담음
+        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period);
+        return ResponseEntity.ok(rankedNovels);//소설 정보 전송
+    }
+
 
     /**
      * 유저가 생성한 소설(Novel) 서버에 저장하는 API
@@ -127,4 +139,8 @@ public class NovelController {
 
         return ResponseEntity.ok("작품 삭제 완료.");
     }
+
+
+
+
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -74,4 +74,13 @@ public interface NovelService {
     List<Long> getRatedNovelIds();
 
 
+    /**
+     *랭킹에 따른 소설 상세정보를 전달하는 메서드
+     * @param period 랭킹주기(daily,weekly,monthly,all-time 디폴트값은 daily)
+     * @return List<NovelInfoDto>
+     */
+    List<NovelInfoDto> getNovelsByRanking(String period);
+
+
+
 }

--- a/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface NovelRakingRepository extends JpaRepository<NovelRanking, Long> {
@@ -17,5 +18,18 @@ public interface NovelRakingRepository extends JpaRepository<NovelRanking, Long>
    Optional<NovelRanking> findByNovelIdAndRankingAndRankingPeriod(@Param("novelId")Long novelId,
                                                                       @Param("rankingDate") LocalDate rankingDate,
                                                                       @Param("rankingPeriod")RankingPeriod rankingPeriod);
+
+
+    /**
+     * 랭킹 기록 날짜와, 랭킹 기간으로 엔티티 List를 찾는 메서드
+     * @param rankingDate 랭킹이 기록된 날짜
+     * @param rankingPeriod 랭킹 기간(일간 주간 월간 전체)
+     * @return      List<NovelRanking>
+     */
+    @Query("select nr from NovelRanking nr " +
+            "where nr.rankingDate = :rankingDate " +
+            "and nr.rankingPeriod =:rankingPeriod")
+    List<NovelRanking> findByRankingDateAndRankingPeriod(@Param("rankingDate") LocalDate rankingDate,
+                                                    @Param("rankingPeriod")RankingPeriod rankingPeriod);
 
 }

--- a/src/main/java/com/ham/netnovel/novelRanking/RankingPeriod.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/RankingPeriod.java
@@ -2,7 +2,7 @@ package com.ham.netnovel.novelRanking;
 
 public enum RankingPeriod {
     DAILY,
-    WEEKLEY,
+    WEEKLY,
     MONTHLY,
     ALL_TIME
 

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
@@ -4,14 +4,17 @@ import com.ham.netnovel.novelRanking.NovelRanking;
 import com.ham.netnovel.novelRanking.RankingPeriod;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface NovelRankingService {
 
     /**
      * NovelRaking 엔티티를 찾아 반환하는 메서드
-     * @param novelId 소설의 ID 값
-     * @param rankingDate 랭킹이 기록된 날짜
+     *
+     * @param novelId       소설의 ID 값
+     * @param rankingDate   랭킹이 기록된 날짜
      * @param rankingPeriod 일간,주간,월간,전체 기간중 해당되는 값
      * @return Optional NovelRanking
      */
@@ -24,6 +27,7 @@ public interface NovelRankingService {
      * 기존 랭킹 데이터를 업데이트
      */
     void updateDailyRankings();
+
     /**
      * 소설의 주간 랭킹을 업데이트하는 메서드
      * 이 메서드는 지정된 기간(어제 기준 7일 전까지)의 조회수를 기반으로
@@ -32,6 +36,11 @@ public interface NovelRankingService {
     void updateWeeklyRankings();
 
     void updateMonthlyRankings();
+
+
+    void saveRankingToRedis(RankingPeriod rankingPeriod);
+
+    List<Map<String, Object>> getRankingFromRedis(String period);
 
 
 }

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
@@ -7,13 +7,16 @@ import com.ham.netnovel.novelRanking.NovelRanking;
 import com.ham.netnovel.novelRanking.RankingPeriod;
 import com.ham.netnovel.novelRanking.dto.NovelRankingUpdateDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.BoundZSetOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -23,10 +26,13 @@ public class NovelRankingServiceImpl implements NovelRankingService {
 
     private final EpisodeViewCountService episodeViewCountService;
 
-    public NovelRankingServiceImpl(NovelRakingRepository novelRakingRepository, EpisodeViewCountService episodeViewCountService) {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public NovelRankingServiceImpl(NovelRakingRepository novelRakingRepository, EpisodeViewCountService episodeViewCountService, RedisTemplate<String, String> redisTemplate) {
         this.novelRakingRepository = novelRakingRepository;
         this.episodeViewCountService = episodeViewCountService;
 
+        this.redisTemplate = redisTemplate;
     }
 
 
@@ -34,7 +40,7 @@ public class NovelRankingServiceImpl implements NovelRankingService {
     @Transactional(readOnly = true)
     public Optional<NovelRanking> getNovelRankingEntity(Long novelId, LocalDate rankingDate, RankingPeriod rankingPeriod) {
 
-        return novelRakingRepository.findByNovelIdAndRankingAndRankingPeriod(novelId,rankingDate,rankingPeriod);
+        return novelRakingRepository.findByNovelIdAndRankingAndRankingPeriod(novelId, rankingDate, rankingPeriod);
 
     }
 
@@ -52,13 +58,13 @@ public class NovelRankingServiceImpl implements NovelRankingService {
         for (NovelRankingUpdateDto updateDto : todayRanking) {
             Novel novel = updateDto.getNovel();
             Optional<NovelRanking> novelRankingEntity = getNovelRankingEntity(novel.getId(), todayDate, RankingPeriod.DAILY);
-            if (novelRankingEntity.isPresent()){
-                log.info("엔티티 Daily 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+            if (novelRankingEntity.isPresent()) {
+                log.info("엔티티 Daily 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ", updateDto.getNovel().getId(), updateDto.toString());
                 NovelRanking novelRanking = novelRankingEntity.get();
                 novelRanking.updateNovelRanking(updateDto.getRanking(), updateDto.getTotalViews());
                 rankingsToSave.add(novelRanking);
             } else {
-                log.info("엔티티 Daily 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                log.info("엔티티 Daily 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ", updateDto.getNovel().getId(), updateDto.toString());
                 NovelRanking newNovelRanking = NovelRanking.builder()
                         .rankingPeriod(RankingPeriod.DAILY)
                         .novel(updateDto.getNovel())
@@ -86,17 +92,17 @@ public class NovelRankingServiceImpl implements NovelRankingService {
 
         for (NovelRankingUpdateDto updateDto : weeklyRanking) {
             Novel novel = updateDto.getNovel();
-            Optional<NovelRanking> novelRankingEntity = getNovelRankingEntity(novel.getId(), todayDate, RankingPeriod.WEEKLEY);
+            Optional<NovelRanking> novelRankingEntity = getNovelRankingEntity(novel.getId(), todayDate, RankingPeriod.WEEKLY);
 
-            if (novelRankingEntity.isPresent()){
-                log.info("엔티티 Weekly 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+            if (novelRankingEntity.isPresent()) {
+                log.info("엔티티 Weekly 랭킹 기록 업데이트, Novel Id = {}, 상세정보 ={} ", updateDto.getNovel().getId(), updateDto.toString());
                 NovelRanking novelRanking = novelRankingEntity.get();
                 novelRanking.updateNovelRanking(updateDto.getRanking(), updateDto.getTotalViews());
                 rankingsToSave.add(novelRanking);
             } else {
-                log.info("엔티티 Weekly 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ",updateDto.getNovel().getId(),updateDto.toString());
+                log.info("엔티티 Weekly 랭킹 기록 생성, Novel Id = {}, 상세정보 ={} ", updateDto.getNovel().getId(), updateDto.toString());
                 NovelRanking newNovelRanking = NovelRanking.builder()
-                        .rankingPeriod(RankingPeriod.WEEKLEY)
+                        .rankingPeriod(RankingPeriod.WEEKLY)
                         .novel(updateDto.getNovel())
                         .totalViews(updateDto.getTotalViews())
                         .rankingDate(todayDate)
@@ -113,5 +119,75 @@ public class NovelRankingServiceImpl implements NovelRankingService {
     @Override
     public void updateMonthlyRankings() {
 
+
     }
+
+
+    @Override
+    public void saveRankingToRedis(RankingPeriod rankingPeriod) {
+
+        //메서드 실행일 연 월 일 객체에 저장
+        LocalDate todayDate = LocalDate.now();
+
+        String periodForKey = switch (rankingPeriod) {
+            case WEEKLY -> "weekly";
+            case MONTHLY -> "monthly";
+            case ALL_TIME -> "all_time";
+            default -> "daily";
+        };
+
+        //Redis key 생성
+        String key = periodForKey + "_rankings:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        //Redis에 저장할 데이터 객체 생성(정렬된 Set 타입)
+        BoundZSetOperations<String, String> zSetOps = redisTemplate.boundZSetOps(key);
+
+        List<NovelRanking> dailyRaking = novelRakingRepository.findByRankingDateAndRankingPeriod(todayDate, rankingPeriod);
+        for (NovelRanking novelRanking : dailyRaking) {
+            String novelId = novelRanking.getNovel().getId().toString();//novelId 문자열로 변환
+            Integer ranking = novelRanking.getRanking();//랭킹 점수 객체에 저장
+            redisTemplate.opsForZSet().add(key, novelId, ranking);//novelId 와 ranking 정보를 Redis에 저장
+        }
+        // redis에  데이터 만료 시간 설정, 1일로 설정
+        redisTemplate.expire(key, Duration.ofDays(1));
+
+
+    }
+
+    @Override
+    public List<Map<String, Object>> getRankingFromRedis(String period) {
+        // 오늘 날짜로 Redis 키 생성 (예: "daily_rankings:20240810")
+        String periodForKey = switch (period) {
+            case "daily" -> "daily";
+            case "weekly" -> "weekly";
+            case "monthly" -> "monthly";
+            default -> "all_time";
+        };
+        //Redis key 생성
+        String key = periodForKey + "_rankings:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+
+        // Redis에서 Sorted Set의 모든 데이터를 값과 점수와 함께 가져오기
+        Set<ZSetOperations.TypedTuple<String>> rankingSet = redisTemplate.opsForZSet().rangeWithScores(key, 0, -1);
+
+        // 결과를 저장할 리스트 초기화
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        // 결과가 null이 아닌 경우 처리
+        if (rankingSet != null) {
+            for (ZSetOperations.TypedTuple<String> item : rankingSet) {
+                // novelId와 ranking을 Map으로 저장
+                Map<String, Object> entry = new HashMap<>();//List에 저장할 Map 객체 생성
+                entry.put("novelId", Long.parseLong(Objects.requireNonNull(item.getValue()))); // novelId는 Long 으로 저장
+                entry.put("ranking", Objects.requireNonNull(item.getScore()).intValue()); // ranking은 int로 저장
+                result.add(entry);
+            }
+        }
+
+        //결과 반환
+        return result;
+
+    }
+
+
 }

--- a/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
@@ -46,7 +46,7 @@ class NovelServiceImplTest {
                 .description("Duis ea aliquip dolor sit dolore ut adipisicing eu tempor.")
                 .accessorProviderId(authorId)
                 .build();
-        log.info(createDto.toString());
+//        log.info(createDto.toString());
 
         // when
         novelService.createNovel(createDto);
@@ -67,7 +67,7 @@ class NovelServiceImplTest {
                 .accessorProviderId("test1")
                 .title("변경된 작품 소개")
                 .build();
-        log.info(updateDto.toString());
+//        log.info(updateDto.toString());
 
         //when
         novelService.updateNovel(updateDto);
@@ -85,7 +85,7 @@ class NovelServiceImplTest {
                 .novelId(id)
                 .accessorProviderId("test1")
                 .build();
-        log.info(deleteDto.toString());
+//        log.info(deleteDto.toString());
 
         //when
         novelService.deleteNovel(deleteDto);
@@ -130,6 +130,19 @@ class NovelServiceImplTest {
         List<Long> ratedNovelIds = novelService.getRatedNovelIds();
         for (Long ratedNovelId : ratedNovelIds) {
             System.out.println("novelId ="+ratedNovelId);
+
+        }
+
+    }
+
+    //테스트성공
+    @Test
+    public void getRankedNovels(){
+
+        String period = "daily";
+        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period);
+        for (NovelInfoDto rankedNovel : rankedNovels) {
+            System.out.println(rankedNovel.toString());
 
         }
 

--- a/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
@@ -45,4 +45,19 @@ class NovelRankingServiceImplTest {
     @Test
     void updateMonthlyRankings() {
     }
+
+    @Test
+    void saveRankingToRedis(){
+//        RankingPeriod period = RankingPeriod.DAILY;
+        RankingPeriod period = RankingPeriod.WEEKLY;
+        novelRankingService.saveRankingToRedis(period);
+
+    }
+    @Test
+    void getRankingFromRedis(){
+
+        String period = "daily";
+        novelRankingService.getRankingFromRedis(period);
+
+    }
 }


### PR DESCRIPTION
## 변경사항
### 소설 랭킹 정보를 Redis에 저장 및 조회하는 로직 추가
- NovelRankingService
  - saveRankingToRedis
    - 소설 랭킹 정보를 Redis에 저장하는 메서드
    - 파라미터로 rankingPeriod 을 받음
    - rankingPeriod 에 따라 일간, 주간, 월간, 전체 랭킹 정보 저장
    - 레코드는 랭킹 순서로 정렬된 SET 타입 레코드로 저장

  - getRankingFromRedis
    - 소설 랭킹 정보를 Redis 에서 불러오는 메서드
    - 파라미터로 String 타입의 period 을 받음
    - 반환은 List<Map<String, Object>> 형식이며, 첫번째 데이터는 novelid, 두번째는 ranking 을 저장하여 반환

- NovelRankingServiceImplTest
  - saveRankingToRedis, getRankingFromRedis 메서드 테스트, 테스트 성공

- NovelRakingRepository
  - findByRankingDateAndRankingPeriod
    - 랭킹 기록 날짜와, 랭킹 기간으로 엔티티 List를 찾는 메서드

- RankingPeriod
  - 상수 오타 수정 WEEKLEY - > WEEKLY

### 랭킹에 따른 소설 상세정보를 전달하는 로직 추가
- NovelController
  - getNovelsByRanking(GET 요청)
    - 주어진 랭킹 기간에 따라 소설 랭킹 정보를 조회하고 반환하는 API 추가
    - 쿼리 파라미터로 랭킹 주기(period) 를 받음

- NovelService
  - getNovelsByRanking
    - 랭킹에 따른 소설 상세정보를 전달하는 메서드 추가
    - 파라미터로 String 타입의 랭킹주기(period) 를 받음

- NovelServiceImplTest
  - getNovelsByRanking 메서드 테스트, 테스트 성공