### PR TITLE
Browse, Library 관련 api 통신 작업

### DIFF
--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovel.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovel.java
@@ -3,23 +3,33 @@ package com.ham.netnovel.favoriteNovel;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.novel.Novel;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class FavoriteNovel {
 
+    //member_id와 novel_id로 구성된 composite PK
+    @EmbeddedId
+    private FavoriteNovelId id;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)//auto_increment 자동생성
-    private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("memberId")
     @JoinColumn(name = "member_id")
     private Member member;
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("novelId")
     @JoinColumn(name = "novel_id")
     private Novel novel;
 
-
-
+    @Builder
+    public FavoriteNovel(FavoriteNovelId id, Member member, Novel novel) {
+        this.id = id;
+        this.member = member;
+        this.novel = novel;
+    }
 }

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
@@ -1,0 +1,65 @@
+package com.ham.netnovel.favoriteNovel;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.favoriteNovel.service.FavoriteNovelService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class FavoriteNovelController {
+
+    private final Authenticator authenticator;
+    private final FavoriteNovelService favoriteNovelService;
+
+    @Autowired
+    public FavoriteNovelController(FavoriteNovelService favoriteNovelService, Authenticator authenticator) {
+        this.favoriteNovelService = favoriteNovelService;
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * 해당 작품이 선호작이 되어 있는지 확인하는 api
+     * @param authentication 유저 인증 보안
+     * @param novelId 작품 PK id
+     * @return ResponseEntity true, false 리턴
+     */
+    @GetMapping("/members/me/favorites/check")
+    public ResponseEntity<Boolean> checkIfFavorite(
+            Authentication authentication,
+            @RequestParam(name = "novelId") Long novelId
+    ) {
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //유저가 좋아요 누른 소설 반환
+        Boolean isFavorite = favoriteNovelService.checkFavorite(principal.getName(), novelId);
+//        Boolean isFavorite = favoriteNovelService.checkFavorite("test1", novelId);
+        return ResponseEntity.ok(isFavorite);
+    }
+
+    /**
+     * 해당 작품의 선호작 여부를 바꾸는 api
+     * @param authentication 유저 인증 보안
+     * @param novelId 작품 PK id
+     * @return ResponseEntity true, false 리턴
+     */
+    @PostMapping("/members/me/favorites/{novelId}")
+    public ResponseEntity<Boolean> toggleFavorite(
+            Authentication authentication,
+            @PathVariable(name = "novelId") Long novelId
+    ) {
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //유저가 좋아요 누른 소설 반환
+        Boolean isFavorite = favoriteNovelService.toggleFavoriteNovel(principal.getName(), novelId);
+//        Boolean isFavorite = favoriteNovelService.toggleFavoriteNovel("test1", novelId);
+        return ResponseEntity.ok(isFavorite);
+    }
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelId.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelId.java
@@ -1,0 +1,33 @@
+package com.ham.netnovel.favoriteNovel;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteNovelId {
+    private Long memberId;
+    private Long novelId;
+
+    @Override
+    public boolean equals(Object o) {
+        //동일한 객체 참조일 경우 true
+        if (this == o) return true;
+        //비교 대상 객체가 null 이거나, 서로 다른 클래스 타입이면 false
+        if (o == null || getClass() != o.getClass()) return false;
+        //비교 대상 객체와 내부 프로퍼티 값이 같으면 true
+        FavoriteNovelId that = (FavoriteNovelId) o;
+        return  Objects.equals(this.memberId, that.memberId) && Objects.equals(this.novelId, that.novelId);
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(memberId, novelId);}
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelRepository.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelRepository.java
@@ -1,0 +1,12 @@
+package com.ham.netnovel.favoriteNovel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FavoriteNovelRepository extends JpaRepository<FavoriteNovel, FavoriteNovelId> {
+
+    List<FavoriteNovel> findByMemberId(Long memberId);
+    
+    List<FavoriteNovel> findByNovelId(Long novelId);
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/dto/FavoriteNovelInfoDto.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/dto/FavoriteNovelInfoDto.java
@@ -1,0 +1,28 @@
+package com.ham.netnovel.favoriteNovel.dto;
+
+import com.ham.netnovel.tag.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteNovelInfoDto {
+    @NotNull
+    private Long novelId;
+
+    @NotBlank
+    private String novelTitle;
+
+    @NotBlank
+    private String authorName;
+
+    @NotNull
+    private List<Tag> tags;
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
@@ -1,0 +1,14 @@
+package com.ham.netnovel.favoriteNovel.service;
+
+import com.ham.netnovel.favoriteNovel.FavoriteNovelId;
+
+public interface FavoriteNovelService {
+
+    /**
+     * 유저 인증 키와 작품 id를 받아서 선호작을 등록하고 삭제하는 메서드. 레코드가 없다면 새로 생성하고 이미 있다면 삭제한다.
+     * @param providerId OAuth2.0 유저 인증 키
+     * @param novelId  작품 PK 값
+     * @return FavoriteNovelId (생성한/삭제한) 레코드 PK 값
+     */
+    FavoriteNovelId toggleFavoriteNovel(String providerId, Long novelId);
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
@@ -10,5 +10,7 @@ public interface FavoriteNovelService {
      * @param novelId  작품 PK 값
      * @return FavoriteNovelId (생성한/삭제한) 레코드 PK 값
      */
-    FavoriteNovelId toggleFavoriteNovel(String providerId, Long novelId);
+    Boolean toggleFavoriteNovel(String providerId, Long novelId);
+
+    Boolean checkFavorite(String providerId, Long novelId);
 }

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
@@ -33,7 +33,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
 
     @Override
     @Transactional
-    public FavoriteNovelId toggleFavoriteNovel(String providerId, Long novelId) {
+    public Boolean toggleFavoriteNovel(String providerId, Long novelId) {
         //유저, 작품 레코드 DB 검증
         Member member = memberService.getMember(providerId)
                 .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Member 입니다."));
@@ -48,7 +48,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
             //이미 레코드가 있으면 삭제
             if (record.isPresent()) {
                 favoriteNovelRepository.delete(record.get());
-                return record.get().getId();
+                return true;
             }
             //레코드가 없으면 새로 생성
             else {
@@ -58,10 +58,27 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
                         .novel(novel)
                         .build();
                 FavoriteNovel save = favoriteNovelRepository.save(newRecord);
-                return save.getId();
+                return false;
             }
         } catch (Exception ex) {
             throw new ServiceMethodException("toggleFavoriteNovel() Error : "  + ex.getMessage());
+        }
+    }
+
+    @Override
+    public Boolean checkFavorite(String providerId, Long novelId) {
+        //유저, 작품 레코드 DB 검증
+        Member member = memberService.getMember(providerId)
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Member 입니다."));
+        Novel novel = novelService.getNovel(novelId)
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Novel 입니다."));
+
+        try {
+            FavoriteNovelId id = new FavoriteNovelId(member.getId(), novel.getId());
+            Optional<FavoriteNovel> record = favoriteNovelRepository.findById(id);
+            return record.isPresent();
+        } catch (Exception ex) {
+            throw new ServiceMethodException("checkFavorite() Error : "  + ex.getMessage());
         }
     }
 }

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
@@ -1,0 +1,67 @@
+package com.ham.netnovel.favoriteNovel.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.favoriteNovel.FavoriteNovel;
+import com.ham.netnovel.favoriteNovel.FavoriteNovelId;
+import com.ham.netnovel.favoriteNovel.FavoriteNovelRepository;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.service.NovelService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class FavoriteNovelServiceImpl implements FavoriteNovelService{
+
+    private final FavoriteNovelRepository favoriteNovelRepository;
+    private final MemberService memberService;
+    private final NovelService novelService;
+
+    @Autowired
+    public FavoriteNovelServiceImpl(FavoriteNovelRepository favoriteNovelRepository, MemberService memberService, NovelService novelService) {
+        this.favoriteNovelRepository = favoriteNovelRepository;
+        this.memberService = memberService;
+        this.novelService = novelService;
+    }
+
+    @Override
+    @Transactional
+    public FavoriteNovelId toggleFavoriteNovel(String providerId, Long novelId) {
+        //유저, 작품 레코드 DB 검증
+        Member member = memberService.getMember(providerId)
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Member 입니다."));
+        Novel novel = novelService.getNovel(novelId)
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Novel 입니다."));
+
+        try {
+            FavoriteNovelId id = new FavoriteNovelId(member.getId(), novel.getId());
+            Optional<FavoriteNovel> record = favoriteNovelRepository.findById(id);
+
+
+            //이미 레코드가 있으면 삭제
+            if (record.isPresent()) {
+                favoriteNovelRepository.delete(record.get());
+                return record.get().getId();
+            }
+            //레코드가 없으면 새로 생성
+            else {
+                FavoriteNovel newRecord = FavoriteNovel.builder()
+                        .id(id)
+                        .member(member)
+                        .novel(novel)
+                        .build();
+                FavoriteNovel save = favoriteNovelRepository.save(newRecord);
+                return save.getId();
+            }
+        } catch (Exception ex) {
+            throw new ServiceMethodException("toggleFavoriteNovel() Error : "  + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
@@ -48,7 +48,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
             //이미 레코드가 있으면 삭제
             if (record.isPresent()) {
                 favoriteNovelRepository.delete(record.get());
-                return true;
+                return false; // 이제 레코드 없음
             }
             //레코드가 없으면 새로 생성
             else {
@@ -58,7 +58,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
                         .novel(novel)
                         .build();
                 FavoriteNovel save = favoriteNovelRepository.save(newRecord);
-                return false;
+                return true; // 이제 레코드 있음
             }
         } catch (Exception ex) {
             throw new ServiceMethodException("toggleFavoriteNovel() Error : "  + ex.getMessage());

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 유저 정보 담은 응답 객체
      */
-    @GetMapping("/members/mypage")
+    @GetMapping("/members/me/mypage")
     @ResponseBody
     public ResponseEntity<?> showMyPage(
             Authentication authentication
@@ -72,7 +72,7 @@ public class MemberController {
      * @return ResponseEntity 요청 결과를 담은 응답 객체
      */
     //Todo 송민규: Edit Profile 페이지를 구성하여 Nickname, Email, Gender을 일괄적으로 수정할 수 있도록 기능을 확장하는 건 어떨까요?
-    @PatchMapping("/members/nickname")
+    @PatchMapping("/members/me/nickname")
     public ResponseEntity<?> updateNickname(@Valid @RequestBody ChangeNickNameDto changeNickNameDto,
                                             BindingResult bindingResult,
                                             Authentication authentication) {
@@ -125,7 +125,7 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 댓글과 대댓글의 정보 리스트를 담은 응답 객체
      */
-    @GetMapping("/members/comments")
+    @GetMapping("/members/me/comments")
     public ResponseEntity<?> getMemberCommentList(Authentication authentication,
                                                    @RequestParam(defaultValue = "0") int pageNumber,
                                                    @RequestParam(defaultValue = "10") int pageSize) {
@@ -151,7 +151,7 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 유저가 좋아요를 누른 소설 리스트를 담은 응답 객체
      */
-    @GetMapping("/novel")
+    @GetMapping("/members/me/favorites")
     public ResponseEntity<?> getFavoriteNovels(Authentication authentication) {
 
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
@@ -172,7 +172,7 @@ public class MemberController {
      * @param authentication 유저의 인정 정보
      * @return ResponseEntity 데이터를 List에 담아 반환
      */
-    @GetMapping("/coin-use-history")
+    @GetMapping("/members/me/coin-use-history")
     public ResponseEntity<?> getMemberCoinUseHistory(Authentication authentication,
                                                       @RequestParam(defaultValue = "0") int pageNumber,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
@@ -196,7 +196,7 @@ public class MemberController {
      * @param authentication 유저의 인정 정보
      * @return ResponseEntity 데이터를 List에 담아 반환
      */
-    @GetMapping("/coin-charge-history")
+    @GetMapping("/members/me/coin-charge-history")
     public ResponseEntity<List<MemberCoinChargeDto>> getMemberCoinChargeHistory(Authentication authentication,
                                                                                  @RequestParam(defaultValue = "0") int pageNumber,
                                                                                  @RequestParam(defaultValue = "10") int pageSize) {
@@ -218,7 +218,7 @@ public class MemberController {
      * @param pageSize
      * @return
      */
-    @GetMapping("/recent-read")
+    @GetMapping("/members/me/recent-read")
     public ResponseEntity<List<MemberRecentReadDto>> getMemberRecentRead(Authentication authentication,
                                                   @RequestParam(defaultValue = "0") int pageNumber,
                                                   @RequestParam(defaultValue = "10") int pageSize){

--- a/src/main/java/com/ham/netnovel/novel/Novel.java
+++ b/src/main/java/com/ham/netnovel/novel/Novel.java
@@ -1,10 +1,12 @@
 package com.ham.netnovel.novel;
 
 import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.favoriteNovel.FavoriteNovel;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.novel.data.NovelStatus;
 import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.novelAverageRating.NovelAverageRating;
+import com.ham.netnovel.novelTag.NovelTag;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -44,6 +46,14 @@ public class Novel {
     //작품 에피소드들
     @OneToMany(mappedBy = "novel")
     private List<Episode> episodes = new ArrayList<>();
+
+    //선호작 수
+    @OneToMany(mappedBy = "novel")
+    private List<FavoriteNovel> favorites;
+
+    //태그 목록
+    @OneToMany(mappedBy = "novel")
+    private List<NovelTag> novelTags;
 
     //평균 별점
     @OneToOne(mappedBy = "novel")

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.novel;
 
 import com.ham.netnovel.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import com.ham.netnovel.episode.service.EpisodeService;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
@@ -11,6 +12,7 @@ import com.ham.netnovel.novel.dto.NovelUpdateDto;
 import com.ham.netnovel.novel.service.NovelService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
@@ -140,7 +142,13 @@ public class NovelController {
         return ResponseEntity.ok("작품 삭제 완료.");
     }
 
-
-
+    @GetMapping("/novels")
+    public ResponseEntity<List<NovelInfoDto>> getNovelsBySorted(
+            @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
+    ) {
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
+        return ResponseEntity.ok(novelService.getNovelsRecent(pageable));
+    }
 
 }

--- a/src/main/java/com/ham/netnovel/novel/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelRepository.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.novel;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,5 +33,17 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
             "where r.rating is not null)")
     List<Novel> findByNovelRating();
 
+
+    @Query("""
+            SELECT DISTINCT n FROM Novel n
+            JOIN FETCH n.episodes e
+            WHERE e.chapter = (
+                SELECT MAX(es.chapter)
+                FROM Episode es
+                WHERE es.novel.id = n.id
+            )
+            ORDER BY e.createdAt DESC
+            """)
+    List<Novel> findByLatestEpisodesOrderByCreatedAt(Pageable pageable);
 
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.novel.dto;
 
 import com.ham.netnovel.novel.data.NovelType;
-import com.ham.netnovel.tag.Tag;
+import com.ham.netnovel.tag.dto.TagDataDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class NovelInfoDto {
 
     @NotNull
-    private Long novelId; //소설 id
+    private Long id; //소설 id
 
     @NotBlank
     @Size(max = 30)
@@ -27,7 +27,7 @@ public class NovelInfoDto {
 
     @NotBlank
     @Size(max = 300)
-    private String description; //작품 소개
+    private String desc; //작품 소개
 
     @NotNull
     private String authorName; //작가 닉네임
@@ -42,12 +42,12 @@ public class NovelInfoDto {
     private Integer favoriteCount; //선호작 수
 
     @NotNull
+    private List<TagDataDto> tags; //작품 태그
+
+    @NotNull
     private NovelType type; //소설 등급
 
     @NotNull
     private Integer episodeCount; //에피소드 총 화수
-
-//    @NotNull
-//    private List<Tag> tags; //작품 태그
 
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -58,7 +58,7 @@ public interface NovelService {
      * @param pageable page number, page size
      * @return
      */
-    List<Novel> getNovels(Pageable pageable);
+    List<NovelInfoDto> getNovelsRecent(Pageable pageable);
 
     /**
      * 유저의 선호작 Novel 리스트 반환.

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -216,18 +216,23 @@ public class NovelServiceImpl implements NovelService {
                         .novel(novel)
                         .averageRating(BigDecimal.valueOf(0))
                         .ratingCount(0)
-                        .build());
+                .build());
+
+        //작품의 태그들 가져오기
+        List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
+                .map(novelTag -> novelTag.getTag().getData())
+                .toList();
 
         return NovelInfoDto.builder()
-                .novelId(novel.getId())
+                .id(novel.getId())
                 .title(novel.getTitle())
-                .description(novel.getDescription())
+                .desc(novel.getDescription())
                 .authorName(novel.getAuthor().getNickName())
                 .views(novel.getEpisodes().stream().mapToInt(Episode::getView).sum())
                 .averageRating(averageRating.getAverageRating())
                 .episodeCount(novel.getEpisodes().size())
-//                .tags(Collections.emptyList())
                 .favoriteCount(novel.getFavorites().size())
+                .tags(dataDtoList)
                 .build();
     }
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -226,9 +226,8 @@ public class NovelServiceImpl implements NovelService {
                 .views(novel.getEpisodes().stream().mapToInt(Episode::getView).sum())
                 .averageRating(averageRating.getAverageRating())
                 .episodeCount(novel.getEpisodes().size())
-                //Todo FavoriteNovel 도메인 완성되는 대로 작업
-                .favoriteCount(0)
 //                .tags(Collections.emptyList())
+                .favoriteCount(novel.getFavorites().size())
                 .build();
     }
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -14,6 +14,7 @@ import com.ham.netnovel.novel.dto.NovelInfoDto;
 import com.ham.netnovel.novel.dto.NovelUpdateDto;
 import com.ham.netnovel.novelAverageRating.NovelAverageRating;
 import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import com.ham.netnovel.tag.dto.TagDataDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -153,8 +154,11 @@ public class NovelServiceImpl implements NovelService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Novel> getNovels(Pageable pageable) {
-        return null;
+    public List<NovelInfoDto> getNovelsRecent(Pageable pageable) {
+        List<Novel> recentNovels = novelRepository.findByLatestEpisodesOrderByCreatedAt(pageable);
+        return recentNovels.stream()
+                .map(this::convertEntityToInfoDto)
+                .toList();
     }
 
     //단순히 엔티티 List만 반환하는 메서드

--- a/src/main/java/com/ham/netnovel/novelTag/service/NovelTagServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelTag/service/NovelTagServiceImpl.java
@@ -47,11 +47,10 @@ public class NovelTagServiceImpl implements NovelTagService {
     public List<NovelTagListDto> getTagsByNovel(Long novelId) {
         List<NovelTag> novelTags = novelTagRepository.findByIdNovelId(novelId);
 
-        List<NovelTagListDto> dtoList = novelTags.stream()
+        return novelTags.stream()
                 .map(NovelTag::getTag)
                 .map(this::convertTagToListDto)
                 .toList();
-        return dtoList;
     }
 
     NovelTagListDto convertTagToListDto(Tag tag) {

--- a/src/main/java/com/ham/netnovel/tag/Tag.java
+++ b/src/main/java/com/ham/netnovel/tag/Tag.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.tag;
 
 
 import com.ham.netnovel.novelTag.NovelTag;
+import com.ham.netnovel.tag.dto.TagDataDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
@@ -39,5 +40,13 @@ public class Tag {
 
     public void changeStatus(TagStatus status) {
         this.status = status;
+    }
+
+    public TagDataDto getData() {
+        return TagDataDto.builder()
+                .id(this.id)
+                .name(this.name)
+                .status(this.status)
+                .build();
     }
 }

--- a/src/main/java/com/ham/netnovel/tag/dto/TagDataDto.java
+++ b/src/main/java/com/ham/netnovel/tag/dto/TagDataDto.java
@@ -1,0 +1,18 @@
+package com.ham.netnovel.tag.dto;
+
+import com.ham.netnovel.tag.TagStatus;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagDataDto {
+    private Long id;
+
+    private String name;
+
+    private TagStatus status;
+}

--- a/src/test/java/com/ham/netnovel/DBRecordTest.java
+++ b/src/test/java/com/ham/netnovel/DBRecordTest.java
@@ -27,6 +27,7 @@ import com.ham.netnovel.novel.Novel;
 import com.ham.netnovel.novel.NovelRepository;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
 import com.ham.netnovel.novel.service.NovelService;
+import com.ham.netnovel.novelAverageRating.NovelAverageRatingRepository;
 import com.ham.netnovel.novelRating.NovelRatingRepository;
 import com.ham.netnovel.novelRating.dto.NovelRatingSaveDto;
 import com.ham.netnovel.novelRating.service.NovelRatingService;

--- a/src/test/java/com/ham/netnovel/DBRecordTest.java
+++ b/src/test/java/com/ham/netnovel/DBRecordTest.java
@@ -10,15 +10,20 @@ import com.ham.netnovel.commentLike.CommentLikeRepository;
 import com.ham.netnovel.commentLike.LikeType;
 import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
 import com.ham.netnovel.commentLike.service.CommentLikeService;
+import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.episode.EpisodeRepository;
 import com.ham.netnovel.episode.dto.EpisodeCreateDto;
 import com.ham.netnovel.episode.service.EpisodeService;
+import com.ham.netnovel.favoriteNovel.FavoriteNovelRepository;
+import com.ham.netnovel.favoriteNovel.service.FavoriteNovelService;
+import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.MemberRepository;
 import com.ham.netnovel.member.OAuthProvider;
 import com.ham.netnovel.member.data.Gender;
 import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.member.dto.MemberCreateDto;
 import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.novel.Novel;
 import com.ham.netnovel.novel.NovelRepository;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
 import com.ham.netnovel.novel.service.NovelService;
@@ -27,8 +32,10 @@ import com.ham.netnovel.novelRating.dto.NovelRatingSaveDto;
 import com.ham.netnovel.novelRating.service.NovelRatingService;
 import com.ham.netnovel.novelTag.NovelTagRepository;
 import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
-import com.ham.netnovel.novelTag.dto.NovelTagListDto;
 import com.ham.netnovel.novelTag.service.NovelTagService;
+import com.ham.netnovel.recentRead.RecentReadId;
+import com.ham.netnovel.recentRead.RecentReadRepository;
+import com.ham.netnovel.recentRead.service.RecentReadService;
 import com.ham.netnovel.tag.TagRepository;
 import com.ham.netnovel.tag.dto.TagCreateDto;
 import com.ham.netnovel.tag.service.TagService;
@@ -37,13 +44,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
 @SpringBootTest
 @Slf4j
-public class MakeTestRecord {
+public class DBRecordTest {
     @Autowired
     MemberRepository memberRepository;
     @Autowired
@@ -59,6 +68,8 @@ public class MakeTestRecord {
     @Autowired
     EpisodeService episodeService;
 
+    @Autowired
+    NovelAverageRatingRepository averageRatingRepository;
     @Autowired
     NovelRatingRepository novelRatingRepository;
     @Autowired
@@ -90,17 +101,34 @@ public class MakeTestRecord {
     NovelTagService novelTagService;
 
     @Autowired
+    RecentReadService recentReadService;
+    @Autowired
+    RecentReadRepository recentReadRepository;
+
+    @Autowired
+    FavoriteNovelRepository favoriteNovelRepository;
+    @Autowired
+    FavoriteNovelService favoriteNovelService;
+
+    @Autowired
     JdbcTemplate jdbcTemplate;
 
+    //DB records 전부 삭제
     @Test
-    void makeTestItems() {
-        //DB records 전부 삭제
+    void clear() {
         commentLikeRepository.deleteAll();
         commentRepository.deleteAll();
         episodeRepository.deleteAll();
         costPolicyRepository.deleteAll();
+
+        averageRatingRepository.deleteAll();
         novelRatingRepository.deleteAll();
+        novelTagRepository.deleteAll();
+        tagRepository.deleteAll();
+        favoriteNovelRepository.deleteAll();
+        recentReadRepository.deleteAll();
         novelRepository.deleteAll();
+
         memberRepository.deleteAll();
 
         //auto_increment id를 1부터 초기화.
@@ -109,7 +137,13 @@ public class MakeTestRecord {
         jdbcTemplate.execute("ALTER TABLE episode ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE comment ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE tag ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE novel_tag ALTER COLUMN id RESTART WITH 1");
 
+    }
+
+    @Test
+    void makeBasicItems() {
         costPolicyService.createPolicy(CostPolicyCreateDto.builder()
                 .name("유료")
                 .coinCost(1)
@@ -121,8 +155,8 @@ public class MakeTestRecord {
         Random random = new Random();
 
         //좋아요 랜덤 설정
-        long likesFirst = random.nextLong(50);
-        long likesSecond = random.nextLong(90);
+        long likesFirst = random.nextLong(70);
+        long likesSecond = random.nextLong(50);
 
         IntStream.rangeClosed(1, 100).forEach(i -> {
 
@@ -175,7 +209,7 @@ public class MakeTestRecord {
             long commentId = 1L;
             if (i >= 70) {
                 commentId = likesFirst;
-            } else if (i >= 90) {
+            } else if (i >= 50) {
                 commentId = likesSecond;
             }
             CommentLikeToggleDto commentLikeToggleDto = CommentLikeToggleDto.builder()
@@ -186,6 +220,27 @@ public class MakeTestRecord {
             commentLikeService.toggleCommentLikeStatus(commentLikeToggleDto);
         });
     }
+
+
+    @Test
+    @Transactional
+    @Commit
+    void makeEpisodeItems() {
+//        episodeRepository.deleteAll();
+//        jdbcTemplate.execute("ALTER TABLE episode ALTER COLUMN id RESTART WITH 1");
+
+        Random random = new Random();
+        IntStream.rangeClosed(1, 50).forEach(i->{
+            long next = random.nextLong(5, 10);
+            episodeService.createEpisode(EpisodeCreateDto.builder()
+                            .novelId(next)
+                            .title("테스트 데이터"+i)
+                            .costPolicyId(1L)
+                            .content("콘텐츠입니다")
+                    .build());
+        });
+    }
+
 
     @Test
     void makeTagItems() {
@@ -247,33 +302,41 @@ public class MakeTestRecord {
             commentLikeService.toggleCommentLikeStatus(commentLikeToggleDto);
 
                 });
-
-
     }
 
     @Test
-    void makeMemberItems() {
-        int max = 10;//생성할 엔티티 번호 max
+    @Transactional
+    @Commit
+    void makeHistoryItems() {
+        recentReadRepository.deleteAll();
+//        jdbcTemplate.execute("ALTER TABLE recent_read ALTER COLUMN id RESTART WITH 1");
+
 //        Random random = new Random();
+//        long next = random.nextLong(1, 5);
 
-        // min (포함) 과 max (포함) 사이의 랜덤 정수 반환
+        Member member = memberService.getMember("test1").get();
 
-        IntStream.rangeClosed(1, max).forEach(i -> {
-            MemberCreateDto build = MemberCreateDto.builder()
-                    .email("test" + i + "@naver.com")
-                    .role(MemberRole.READER)
-                    .gender(Gender.MALE)
-                    .nickName("nick" + i)
-                    .providerId("test" + i)
-                    .provider(OAuthProvider.NAVER)
-                    .build();
-            memberService.createNewMember(build);
-
+        IntStream.rangeClosed(1, 4).forEach(i->{
+            Novel novel = novelService.getNovel((long) i).get();
+            Episode episode = novel.getEpisodes().get(0);
+            RecentReadId recentReadId = new RecentReadId(member.getId(), novel.getId());
+            recentReadService.createRecentRead(recentReadId, member, episode, novel);
 
         });
     }
 
+    @Test
+    @Transactional
+    @Commit
+    void makeLibraryItems() {
+        favoriteNovelRepository.deleteAll();
 
+        Random random = new Random();
+
+        IntStream.rangeClosed(1, 50).forEach(i-> {
+            long user = random.nextLong(1, 100);
+            long novel = random.nextLong(1, 10);
+            favoriteNovelService.toggleFavoriteNovel("test"+user, novel);
+        });
+    }
 }
-
-

--- a/src/test/java/com/ham/netnovel/favoriteNovel/service/FavoriteNovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/favoriteNovel/service/FavoriteNovelServiceImplTest.java
@@ -1,0 +1,46 @@
+package com.ham.netnovel.favoriteNovel.service;
+
+import com.ham.netnovel.favoriteNovel.FavoriteNovel;
+import com.ham.netnovel.favoriteNovel.FavoriteNovelId;
+import com.ham.netnovel.favoriteNovel.FavoriteNovelRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@SpringBootTest
+@Slf4j
+class FavoriteNovelServiceImplTest {
+
+    @Autowired
+    FavoriteNovelRepository repository;
+
+    @Autowired
+    FavoriteNovelService service;
+
+    @Test
+    @Transactional
+//    @Commit
+    void test() {
+        //given
+        Boolean id = service.toggleFavoriteNovel("test1", 1L);
+        log.info("id = " + id.toString());
+
+        //when
+        FavoriteNovel favoriteNovel = repository.findById(id).get();
+
+        //then
+        Assertions.assertThat(favoriteNovel.getNovel().getId()).isEqualTo(1L);
+        Assertions.assertThat(favoriteNovel.getMember().getProviderId()).isEqualTo("test1");
+
+
+        //delete
+        service.toggleFavoriteNovel("test1", 1L);
+        Optional<FavoriteNovel> record = repository.findById(id);
+        Assertions.assertThat(record.isEmpty()).isTrue();
+    }
+}

--- a/src/test/java/com/ham/netnovel/novel/NovelRepositoryTest.java
+++ b/src/test/java/com/ham/netnovel/novel/NovelRepositoryTest.java
@@ -1,11 +1,18 @@
 package com.ham.netnovel.novel;
 
+import com.ham.netnovel.common.utils.PageableUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 
-@DataJpaTest
+import java.util.List;
+
+@SpringBootTest
+@Slf4j
 class NovelRepositoryTest {
 
     @Autowired
@@ -31,6 +38,16 @@ class NovelRepositoryTest {
         Assertions.assertThat(loadNovel.getTitle()).isEqualTo(newNovel.getTitle());
         Assertions.assertThat(loadNovel.getDescription()).isEqualTo(newNovel.getDescription());
 
+    }
+
+    @Test
+    void queryTest() {
+        Pageable pageable = PageableUtil.createPageable(0, 5);
+        List<Novel> list = novelRepository.findByLatestEpisodesOrderByCreatedAt(pageable);
+        Assertions.assertThat(list.isEmpty()).isFalse();
+        list.forEach(novel -> {
+            log.info("id = {}, title = {}", novel.getId(), novel.getTitle());
+        });
     }
 
 }

--- a/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
@@ -1,10 +1,7 @@
 package com.ham.netnovel.novel.service;
 
-import com.ham.netnovel.member.Member;
-import com.ham.netnovel.member.MemberRepository;
-import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.novel.Novel;
-import com.ham.netnovel.novel.NovelRepository;
 import com.ham.netnovel.novel.data.NovelStatus;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
 import com.ham.netnovel.novel.dto.NovelDeleteDto;
@@ -15,7 +12,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -122,6 +119,16 @@ class NovelServiceImplTest {
 
 
 
+    }
+
+    @Test
+    void getBrowseNovels() {
+        Pageable pageable = PageableUtil.createPageable(1, 5);
+        List<NovelInfoDto> list = novelService.getNovelsRecent(pageable);
+        Assertions.assertThat(list.isEmpty()).isFalse();
+        list.forEach(novel -> {
+            log.info("id = {}, title = {}", novel.getId(), novel.getTitle());
+        });
     }
 
 


### PR DESCRIPTION
[refactor: '/members/' api url, '/members/me' 로 변경.](https://github.com/Ham-Novel/netnovel/commit/35b88093cead33fee314aee3ff54a68e13d01f4f) 
- members 전체를 대상으로 하는지, 특정 member 레코드를 지칭하는지 구분해야 RESTful함.

[feat: favoriteNovel 비지니스 로직 제작](https://github.com/Ham-Novel/netnovel/commit/6f0d76fe0fd851085f8d9d9bc1703afcbfa3cfd1) 
- toggle 메서드 구현. 레코드가 없으면 생성, 있으면 삭제 작업.
- NovelInfoDto에 favoriteCount 데이터 전달.

[feat: NovelInfoDto tags 데이터 추가](https://github.com/Ham-Novel/netnovel/commit/b0b320d06639a3f6c0033eedea68175c30b159ab) 
- 원래 NovelTag에서 'novels/id/tags'를 쓰려고 했으나 이중 통신 오버헤드가 발생함으로 '/novels/id'에서 한번에 전달.
- NovelInfoDto 프로퍼티 네이밍 novelId, description => id, desc로 변경.
- 짧은 네이밍의 이유도 있지만 프론트엔드에서 효율적인 데이터 처리를 위함.

[feat: 선호작 등록 해제 api 추가](https://github.com/Ham-Novel/netnovel/commit/06b6856dfeab5a8fc9cdbac2989fdaff49f64a5e)


[feat: Browse 페이지 최신 업데이트 순 작품 데이터 반환 api 추가](https://github.com/Ham-Novel/netnovel/commit/409f0aaa74b430396d1c9f37f90e8abbd063ba77) 
- api: 'api/novels?page&size'
- 작품들을 최신 업데이트한 에피소드 순으로 NovelInfoDto 반환
- test 코드 작성

[test: DBRecordTest 데이터베이스 테스트 데이터 생성 코드 정리](https://github.com/Ham-Novel/netnovel/commit/858996369bee1a7f15e5ac19b2e30a43e65d8751) 
- 엔티티의 Join Fetch 프로퍼티는 @transactional이 있어야 불러올 수 있음.
- @Commit이 있어야 test 코드에서 @transactional의 작업이 롤백되지 않음.

