### PR TITLE
주간 랭킹 집계 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
@@ -15,21 +15,34 @@ public interface NovelRakingRepository extends JpaRepository<NovelRanking, Long>
             "where nr.novel.id = :novelId " +
             "and nr.rankingDate = :rankingDate " +
             "and nr.rankingPeriod =:rankingPeriod")
-   Optional<NovelRanking> findByNovelIdAndRankingAndRankingPeriod(@Param("novelId")Long novelId,
-                                                                      @Param("rankingDate") LocalDate rankingDate,
-                                                                      @Param("rankingPeriod")RankingPeriod rankingPeriod);
+    Optional<NovelRanking> findByNovelIdAndRankingAndRankingPeriod(@Param("novelId") Long novelId,
+                                                                   @Param("rankingDate") LocalDate rankingDate,
+                                                                   @Param("rankingPeriod") RankingPeriod rankingPeriod);
 
 
     /**
      * 랭킹 기록 날짜와, 랭킹 기간으로 엔티티 List를 찾는 메서드
-     * @param rankingDate 랭킹이 기록된 날짜
+     *
+     * @param rankingDate   랭킹이 기록된 날짜
      * @param rankingPeriod 랭킹 기간(일간 주간 월간 전체)
-     * @return      List<NovelRanking>
+     * @return List<NovelRanking>
      */
     @Query("select nr from NovelRanking nr " +
             "where nr.rankingDate = :rankingDate " +
             "and nr.rankingPeriod =:rankingPeriod")
     List<NovelRanking> findByRankingDateAndRankingPeriod(@Param("rankingDate") LocalDate rankingDate,
-                                                    @Param("rankingPeriod")RankingPeriod rankingPeriod);
+                                                         @Param("rankingPeriod") RankingPeriod rankingPeriod);
+
+
+    @Query("select nr.novel, " +
+            "sum(nr.totalViews) as totalView " +
+            "from NovelRanking nr " +
+            "where nr.rankingDate between :startDate and :endDate " +//날짜 범위 지정
+            "and nr.rankingPeriod = :rankingPeriod " +
+            "group by nr.novel")
+    List<Object[]> findTotalViewsByDateAndRankingPeriod(@Param("endDate") LocalDate endDate,
+                                                        @Param("startDate") LocalDate startDate,
+                                                        @Param("rankingPeriod") RankingPeriod rankingPeriod);
+
 
 }

--- a/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
@@ -31,11 +31,12 @@ class NovelRankingServiceImplTest {
         System.out.println(novelRankingEntity.get().getId());
     }
 
+    //테스트 성공
     @Test
     void updateDailyRankings() {
         novelRankingService.updateDailyRankings();
     }
-
+    //테스트 성공
     @Test
     void updateWeeklyRankings() {
         novelRankingService.updateWeeklyRankings();
@@ -48,8 +49,8 @@ class NovelRankingServiceImplTest {
 
     @Test
     void saveRankingToRedis(){
-//        RankingPeriod period = RankingPeriod.DAILY;
-        RankingPeriod period = RankingPeriod.WEEKLY;
+        RankingPeriod period = RankingPeriod.DAILY;
+//        RankingPeriod period = RankingPeriod.WEEKLY;
         novelRankingService.saveRankingToRedis(period);
 
     }


### PR DESCRIPTION
## 변경사항
### NovelRakingRepository
  - findTotalViewsByDateAndRankingPeriod - 날짜 기간과 랭킹 주기(일간,주간,월간) 정보로 기간동안 소설의 총 조회수를 산출하는 메서드 추가 
    - 파라미터로 endDate(집계 마지막 날짜), startDate(집계 시작날짜), rankingPeriod(일간,주간,월간) 받음 - 반환은  List<Object[]> 형태로, 첫번째 인덱스는 Novel 엔티티, 두번째는 총 조회수를 반환

### NovelRankingService
  - updateWeeklyRankings 
    - 주간 조회수 랭킹 집계 방식, NovelRanking 테이블의 일간 조회수 정보로 주간 조회수를 계산하도록 로직 변경

### NovelRankingServiceImplTest
  - updateWeeklyRankings 테스트, 테스트 성공