### PR TITLE
월간 소설 랭킹 집계 로직 및 일간/주간/월간 랭킹 스케줄러(Quartz 라이브러리, Redis) 구현

### DIFF
--- a/src/main/java/com/ham/netnovel/common/config/NovelRankingQuartzConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/NovelRankingQuartzConfig.java
@@ -1,0 +1,163 @@
+package com.ham.netnovel.common.config;
+
+
+import com.ham.netnovel.novelRanking.job.NovelRankingMonthlyJob;
+import com.ham.netnovel.novelRanking.job.NovelRankingPreviousDayJob;
+import com.ham.netnovel.novelRanking.job.NovelRankingWeeklyJob;
+import com.ham.netnovel.novelRanking.job.NovelRankingDailyJob;
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Date;
+
+@Configuration
+public class NovelRankingQuartzConfig {
+
+
+    //일간 Novel 조회수 랭킹 갱신 JobDetail 설정
+    @Bean
+    public JobDetail novelDailyRankingJobDetail() {
+        return JobBuilder.newJob(NovelRankingDailyJob.class)
+                .withIdentity("novelDailyRankingJob")//식별자 설정
+                .withDescription("Update daily novel rankings.")//설명추가
+                .storeDurably()
+                .build();
+    }
+
+
+    //일간 Novel 조회수 랭킹 갱신 Trigger 설정, 10시 15시 20시에 갱신
+    @Bean
+    public Trigger novelDailyRatingTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(novelDailyRankingJobDetail())//트리거와 novelAverageRatingJobDetail 연결
+                .withIdentity("novelDailyRatingTrigger")//트리거 식별자 설정
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 10,15,20 * * ?")) // 매일 10시, 15시, 20시에 실행
+                .build();
+    }
+
+
+    //어제 일자 일간 Novel 조회수 랭킹 갱신 JobDetail 설정
+    @Bean
+    public JobDetail novelRankingPreviousDayJobDetail() {
+        return JobBuilder.newJob(NovelRankingPreviousDayJob.class)
+                .withIdentity("novelRankingPreviousDayJob")//식별자 설정
+                .withDescription("Update previous day daily novel rankings.")//설명추가
+                .storeDurably()
+                .build();
+
+    }
+
+    //어제 일자 일간 Novel 조회수 랭킹 갱신 Trigger 설정, 00시 1분에 실행
+    @Bean
+    public Trigger novelRankingPreviousDayTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(novelRankingPreviousDayJobDetail())//트리거와 novelAverageRatingJobDetail 연결
+                .withIdentity("novelRankingPreviousDayTrigger")//트리거 식별자 설정
+                .withSchedule(CronScheduleBuilder.cronSchedule("1 0 0 * * ?")) // 매일 00시 1분에 실행
+                .build();
+    }
+
+
+    //주간 Novel 조회수 랭킹 갱신 JobDetail 설정
+    @Bean
+    public JobDetail novelRankingWeeklyJobDetail() {
+        return JobBuilder.newJob(NovelRankingWeeklyJob.class)
+                .withIdentity("novelRankingWeeklyJob")
+                .withDescription("Update weekly novel rankings.")
+                .storeDurably()
+                .build();
+
+    }
+
+    //주간 Novel 조회수 랭킹 갱신 Trigger 설정, 매일 자정 00시 5분에 실행
+    @Bean
+    public Trigger novelRankingWeeklyTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(novelRankingWeeklyJobDetail())//트리거와 novelAverageRatingJobDetail 연결
+                .withIdentity("novelRankingWeeklyTrigger")//트리거 식별자 설정
+                .withSchedule(CronScheduleBuilder.cronSchedule("3 0 0 * * ?")) // 매일 00시 03분에 실행
+                .startNow()
+                .build();
+    }
+
+
+
+    //월간 Novel 조회수 랭킹 갱신 JobDetail 설정
+    @Bean
+    public JobDetail novelRankingMonthlyJobDetail() {
+        return JobBuilder.newJob(NovelRankingMonthlyJob.class)
+                .withIdentity("novelRankingMonthlyJob")
+                .withDescription("Update monthly novel rankings.")
+                .storeDurably()
+                .build();
+    }
+
+    //주간 Novel 조회수 랭킹 갱신 Trigger 설정, 매일 자정 00시 5분에 실행
+    @Bean
+    public Trigger novelRankingMonthlyTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(novelRankingMonthlyJobDetail())//트리거와 novelAverageRatingJobDetail 연결
+                .withIdentity("novelRankingMonthlyTrigger")//트리거 식별자 설정
+                .withSchedule(CronScheduleBuilder.cronSchedule("5 0 0 * * ?")) // 매일 00시 05분에 실행
+                .build();
+    }
+
+
+
+
+    //애플리케이션 시작시 어제 일자 일간 Novel 조회수 랭킹 갱신  Trigger 설정
+    //시작 시점부터 3초뒤 주간 Novel 랭킹 갱신
+    @Bean
+    public Trigger novelRankingPreviousDayAtStartTime() {
+        return createSingleRunTrigger("novelRankingPreviousDayAtStartTime",
+                novelRankingPreviousDayJobDetail(),//실행시킬 JobDetail
+                3);//딜레이 시간(초)
+    }
+
+    //애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
+    //시작 시점부터 10초뒤 주간 Novel 랭킹 갱신
+    @Bean
+    public Trigger novelRankingWeeklyTriggerAtStartTime() {
+        return createSingleRunTrigger("novelRankingWeeklyTriggerAtStartTime",
+                novelRankingWeeklyJobDetail(),//실행시킬 JobDetail
+                10);//딜레이 시간(초)
+    }
+
+    //애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
+    //시작 시점부터 10초뒤 주간 Novel 랭킹 갱신
+    @Bean
+    public Trigger novelRankingMonthlyTriggerAtStartTime() {
+        return createSingleRunTrigger("novelRankingMonthlyTriggerAtStartTime",
+                novelRankingMonthlyJobDetail(),//실행시킬 JobDetail
+                15);//딜레이 시간(초)
+    }
+
+
+
+
+    /**
+     * 애플리케이션 시작시 한번만 실행되는 Trigger 정의 메서드
+     *
+     * @param triggerName    트리거 메서드 이름
+     * @param jobDetail      실행시킬 jobDetail
+     * @param delayInSeconds 애플리케이션 시작후 n초 뒤 실행
+     * @return
+     */
+    private Trigger createSingleRunTrigger(String triggerName, JobDetail jobDetail, int delayInSeconds) {
+        Date startTime = DateBuilder.futureDate(delayInSeconds, DateBuilder.IntervalUnit.SECOND);
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)//실행시킬 JobDetail 메서드
+                .withIdentity(triggerName)//식별자 이름
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withRepeatCount(0)) // 단 한 번만 실행
+                .startAt(startTime) // 지정된 시간에 실행 시작
+                .build();
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/common/config/QuartzConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/QuartzConfig.java
@@ -8,7 +8,9 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QuartzConfig {
-    // JobDetail을 정의하는 메서드
+
+
+    //소설의 평균 별점 갱신 JobDetail 설정
     @Bean
     public JobDetail novelAverageRatingJobDetail() {
         return JobBuilder.newJob(NovelAverageRatingJob.class)
@@ -18,7 +20,7 @@ public class QuartzConfig {
                 .build();
     }
 
-    // 트리거를 정의하는 메서드
+    //주간 Novel 조회수 랭킹 갱신 Trigger 설정, 1분마다 실행
     @Bean
     public Trigger novelAverageRatingTrigger() {
         return TriggerBuilder.newTrigger()

--- a/src/main/java/com/ham/netnovel/common/config/RedisConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/RedisConfig.java
@@ -22,25 +22,28 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String password;
 
+    //Redis 연결을 위한 설정
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(port);
         redisStandaloneConfiguration.setPassword(password);
+
+        //설정된 정보로 RedisConnectionFactory 생성
         LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
         return lettuceConnectionFactory;
     }
 
+    //Redis와 상호작용할때 사용되는 RedisTemplate Bean 객체 생성
     @Bean
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-
+        // RedisConnectionFactory를 RedisTemplate에 설정
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-        // spring-redis간 데이터 직렬화를 위해 설정, 설정하지 않아도 동작에 문제는 없음.
+        // Key와 Value에 대해 StringRedisSerializer를 사용하여 직렬화/역직렬화를 설정
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-
         return redisTemplate;
     }
 }

--- a/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/NovelRakingRepository.java
@@ -15,14 +15,13 @@ public interface NovelRakingRepository extends JpaRepository<NovelRanking, Long>
             "where nr.novel.id = :novelId " +
             "and nr.rankingDate = :rankingDate " +
             "and nr.rankingPeriod =:rankingPeriod")
-    Optional<NovelRanking> findByNovelIdAndRankingAndRankingPeriod(@Param("novelId") Long novelId,
-                                                                   @Param("rankingDate") LocalDate rankingDate,
-                                                                   @Param("rankingPeriod") RankingPeriod rankingPeriod);
+    Optional<NovelRanking> findByNovelIdAndRankingDateAndRankingPeriod(@Param("novelId") Long novelId,
+                                                                       @Param("rankingDate") LocalDate rankingDate,
+                                                                       @Param("rankingPeriod") RankingPeriod rankingPeriod);
 
 
     /**
      * 랭킹 기록 날짜와, 랭킹 기간으로 엔티티 List를 찾는 메서드
-     *
      * @param rankingDate   랭킹이 기록된 날짜
      * @param rankingPeriod 랭킹 기간(일간 주간 월간 전체)
      * @return List<NovelRanking>

--- a/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingDailyJob.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingDailyJob.java
@@ -1,0 +1,40 @@
+package com.ham.netnovel.novelRanking.job;
+
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@Slf4j
+public class NovelRankingDailyJob implements Job {//일간 조회수 랭킹을 갱신하는 Job
+
+    private final NovelRankingService novelRankingService;
+
+    @Autowired
+    public NovelRankingDailyJob(NovelRankingService novelRankingService) {
+        this.novelRankingService = novelRankingService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("일간 조회수 랭킹 업데이트 시작");
+
+        //메서드 실행시점 연 월 일 객체에 저장
+        LocalDate todayDate = LocalDate.now();
+        // 1. 일간 랭킹 업데이트
+        novelRankingService.updateDailyRankings(todayDate);
+
+        // 2. Redis에 랭킹 저장
+        novelRankingService.saveRankingToRedis(RankingPeriod.DAILY);
+
+        log.info("일간 조회수 랭킹 업데이트 완료 및 Redis 저장 완료");
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingMonthlyJob.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingMonthlyJob.java
@@ -1,0 +1,33 @@
+package com.ham.netnovel.novelRanking.job;
+
+
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class NovelRankingMonthlyJob implements Job {
+    private final NovelRankingService novelRankingService;
+
+    public NovelRankingMonthlyJob(NovelRankingService novelRankingService) {
+        this.novelRankingService = novelRankingService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("월간 조회수 랭킹 업데이트 시작");
+        // 1. 월간 랭킹 업데이트
+        novelRankingService.updateMonthlyRankings();
+
+        // 2. Redis에 랭킹 저장
+        novelRankingService.saveRankingToRedis(RankingPeriod.MONTHLY);
+
+        log.info("월간 조회수 랭킹 업데이트 완료 및 Redis 저장 완료");
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingPreviousDayJob.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingPreviousDayJob.java
@@ -1,0 +1,39 @@
+package com.ham.netnovel.novelRanking.job;
+
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@Slf4j
+public class NovelRankingPreviousDayJob implements Job {
+
+    private final NovelRankingService novelRankingService;
+
+    @Autowired
+    public NovelRankingPreviousDayJob(NovelRankingService novelRankingService) {
+        this.novelRankingService = novelRankingService;
+    }
+
+    //어제 일자 일간 조회수 랭킹 갱신
+    //조회수는 23시59분까지 꾸준히 오르므로, 마지막 갱신은 다음날 진행
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("어제 일자 일간 조회수 랭킹 업데이트 시작");
+        //메서드 실행시점 연 월 일 객체에 저장
+        LocalDate previousDayDate = LocalDate.now().minusDays(1);
+        // 1. 일간 랭킹 업데이트
+        novelRankingService.updateDailyRankings(previousDayDate);
+        //2. Redis에 랭킹 저장
+        novelRankingService.saveRankingToRedis(RankingPeriod.DAILY);
+        log.info("어제 일자 일간 조회수 랭킹 업데이트 완료");
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingWeeklyJob.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/job/NovelRankingWeeklyJob.java
@@ -1,0 +1,33 @@
+package com.ham.netnovel.novelRanking.job;
+
+import com.ham.netnovel.novelRanking.RankingPeriod;
+import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class NovelRankingWeeklyJob implements Job {
+    private final NovelRankingService novelRankingService;
+    @Autowired
+    public NovelRankingWeeklyJob(NovelRankingService novelRankingService) {
+        this.novelRankingService = novelRankingService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("주간 조회수 랭킹 업데이트 시작");
+        // 1. 주간 랭킹 업데이트
+        novelRankingService.updateWeeklyRankings();
+
+        // 2. Redis에 랭킹 저장
+        novelRankingService.saveRankingToRedis(RankingPeriod.WEEKLY);
+
+        log.info("주간 조회수 랭킹 업데이트 완료 및 Redis 저장 완료");
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
@@ -26,15 +26,25 @@ public interface NovelRankingService {
      * 해당 날짜의 조회수를 기반으로 새로운 랭킹 데이터를 생성하거나
      * 기존 랭킹 데이터를 업데이트
      */
-    void updateDailyRankings();
+    void updateDailyRankings(LocalDate localDate);
+
 
     /**
      * 소설의 주간 랭킹을 업데이트하는 메서드
-     * 이 메서드는 지정된 기간(어제 기준 7일 전까지)의 조회수를 기반으로
-     * 주간 랭킹 데이터를 생성하거나 업데이트
+     * 실행일 기준 7일 전부터 1일 전까지의 조회수를 합산하여 랭킹을 산출
+     *
+     * 이미 DB에 랭킹이 있는 경우: 조회수와 랭킹을 업데이트.
+     * 랭킹이 없는 경우: 새로운 엔티티를 생성해 DB에 저장
      */
     void updateWeeklyRankings();
 
+    /**
+     * 소설의 주간 랭킹을 업데이트하는 메서드
+     * 실행일 기준 30일 전부터 1일 전까지의 조회수를 합산하여 랭킹을 산출
+     *
+     * 이미 DB에 랭킹이 있는 경우: 조회수와 랭킹을 업데이트.
+     * 랭킹이 없는 경우: 새로운 엔티티를 생성해 DB에 저장
+     */
     void updateMonthlyRankings();
 
 

--- a/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
@@ -8,6 +8,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,7 +36,9 @@ class NovelRankingServiceImplTest {
     //테스트 성공
     @Test
     void updateDailyRankings() {
-        novelRankingService.updateDailyRankings();
+        LocalDate todayDate = LocalDate.now();
+
+        novelRankingService.updateDailyRankings(todayDate);
     }
     //테스트 성공
     @Test
@@ -45,20 +49,31 @@ class NovelRankingServiceImplTest {
 
     @Test
     void updateMonthlyRankings() {
+        novelRankingService.updateMonthlyRankings();
+
     }
 
     @Test
     void saveRankingToRedis(){
-        RankingPeriod period = RankingPeriod.DAILY;
+//        RankingPeriod period = RankingPeriod.DAILY;
 //        RankingPeriod period = RankingPeriod.WEEKLY;
+        RankingPeriod period = RankingPeriod.MONTHLY;
         novelRankingService.saveRankingToRedis(period);
 
     }
     @Test
     void getRankingFromRedis(){
 
-        String period = "daily";
-        novelRankingService.getRankingFromRedis(period);
+//        String period = "daily";
+        String period = "weekly";
+//        String period = "monthly";
+        List<Map<String, Object>> rankingFromRedis = novelRankingService.getRankingFromRedis(period);
+        for (Map<String, Object> result : rankingFromRedis) {
+            System.out.println("noelid= "+result.get("novelId"));
+            System.out.println("랭킹= "+result.get("ranking"));
+
+
+        }
 
     }
 }


### PR DESCRIPTION
# 변경사항
## 소설 랭킹 집계 스케줄러 로직 구현(일간,주간,월간 랭킹)
### NovelRankingQuartzConfig
  - 소설 랭킹 스케줄링을 위한 Quartz 라이브러리 설정 클래스 추가
  - 애플리케이션 시작시, 시작일로부터 전날 일간 랭킹, 주간랭킹, 월간랭킹을 계산하여 Redis 에 저장
  - 일간 랭킹은 10시 15시 20시에 갱신
  - 어제 일자 일간 랭킹은 매일 0시 1분에 갱신
  - 주간 랭킹은 매일 0시 3분에 갱신, 현재로부터 7일전~1일전 조회수 합산하여 랭킹 갱신
  - 월간 랭킹은 매일 0시 5분에 갱신, 현재로부터 30일전~1일전 조회수 합산하여 랭킹 갱신

### NovelRankingPreviousDayJob
  - 어제 날짜 일간 조회수 랭킹을 갱신하는 Job 추가
  - 조회수 계산 후 Redis 에 저장(일간 조회수 랭킹 갱신시 덮어씌워짐)

### NovelRankingDailyJob
  - 일간 조회수 랭킹을 갱신하는 Job 추가
  - 조회수 계산 후 Redis 에 저장

### NovelRankingWeeklyJob
  - 주간 조회수 랭킹을 갱신하는 Job 추가
  - 조회수 계산 후 Redis 에 저장

### NovelRankingMonthlyJob
  - 월간 조회수 랭킹을 갱신하는 Job 추가
  - 조회수 계산 후 Redis 에 저장



## 월간 소설 랭킹 집계 로직 추가, 랭킹 집계 메서드 수정
### NovelRankingService
  - updateDailyRankings
    - 랭킹 집계 날짜를 파라미터로 받도록 수정
  - updateWeeklyRankings
    - 해당 갱신일에 주간 랭킹 엔티티가 있을경우, 엔티티의 랭킹과 조회수를 수정하도록 로직 추가
  - updateWeeklyRankings
    - 월간 랭킹 집계 메서드 구현

### NovelRankingServiceImplTest
  - updateDailyRankings, updateMonthlyRankings , getRankingFromRedis 메서드 테스트, 테스트 성공