### PR TITLE
소설 랭킹 로직 페이지네이션 적용

### DIFF
--- a/src/main/java/com/ham/netnovel/common/utils/PageableUtil.java
+++ b/src/main/java/com/ham/netnovel/common/utils/PageableUtil.java
@@ -16,7 +16,7 @@ public class PageableUtil {
         if (pageNumber == null || pageSize == null) {
             throw new IllegalArgumentException("createPageable 에러: 파라미터가 null 입니다.");
         } else if (pageNumber <0 || pageSize <0) {
-            throw new IllegalArgumentException("createPageable 에러: 파라미터가 음수입니다. 입니다.");
+            throw new IllegalArgumentException("createPageable 에러: 파라미터가 음수입니다.");
         }
 
         return PageRequest.of(pageNumber, pageSize);

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -34,6 +34,7 @@ public class NovelController {
 
     /**
      * 소설 상세 페이지에서 Novel 데이터 응답하는 API
+     *
      * @param novelId novelId를 담은 url path variable
      * @return ResponseEntity
      */
@@ -49,28 +50,36 @@ public class NovelController {
 
     /**
      * 주어진 랭킹 기간에 따라 소설 랭킹 정보를 조회하고 반환하는 API
+     *
      * @param period 쿼리 파라미터로 랭킹 기간을 받음, (daily, weekly, monthly, all-time 중 하나)
-     * @return ResponseEntity<List<NovelInfoDto>> 소설 정보를 담은 객체 반환.
+     * @return ResponseEntity<List < NovelInfoDto>> 소설 정보를 담은 객체 반환.
      */
     @GetMapping("/novels/ranking")
-    public ResponseEntity<List<NovelInfoDto>> getNovelsByRanking(@RequestParam("period") String period){
+    public ResponseEntity<List<NovelInfoDto>> getNovelsByRanking(@RequestParam("period") String period,
+                                                                 @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+                                                                 @RequestParam(name = "pageSize", defaultValue = "100") int pageSize) {
+       //페이지네이션 객체 생성
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
         //유저가 요청한 랭킹 기간에 따라, 소설 정보를 랭킹 순서대로 정렬하여 List에 담음
-        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period);
+        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period,pageable);
+
+
         return ResponseEntity.ok(rankedNovels);//소설 정보 전송
     }
 
 
     /**
      * 유저가 생성한 소설(Novel) 서버에 저장하는 API
-     * @param reqBody Novel 엔티티의 title, desc, providerId(유저 정보)를 담은 객체
-     * @param bindingResult DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
+     *
+     * @param reqBody        Novel 엔티티의 title, desc, providerId(유저 정보)를 담은 객체
+     * @param bindingResult  DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
     @PostMapping
     public ResponseEntity<String> createNovel(@Valid @RequestBody NovelCreateDto reqBody,
-                                                        BindingResult bindingResult,
-                                                        Authentication authentication) {
+                                              BindingResult bindingResult,
+                                              Authentication authentication) {
         //NovelCreateDto Validation 예외 처리
         if (bindingResult.hasErrors()) {
             log.error("createNovel API Error = {}", bindingResult.getFieldError());
@@ -89,16 +98,17 @@ public class NovelController {
 
     /**
      * 유저가 소설(Novel)의 변경된 내용을 업데이트하는 API
-     * @param reqBody novelId, title, desc, providerId를 담은 객체
-     * @param bindingResult DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
+     *
+     * @param reqBody        novelId, title, desc, providerId를 담은 객체
+     * @param bindingResult  DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
     @PutMapping("/novels/{novelId}")
     public ResponseEntity<String> updateNovel(@PathVariable("novelId") Long urlNovelId,
-                                                        @Valid @RequestBody NovelUpdateDto reqBody,
-                                                        BindingResult bindingResult,
-                                                        Authentication authentication) {
+                                              @Valid @RequestBody NovelUpdateDto reqBody,
+                                              BindingResult bindingResult,
+                                              Authentication authentication) {
         //NovelUpdateDto Validation 예외 처리
         if (bindingResult.hasErrors()) {
             log.error("updateNovel API Error = {}", bindingResult.getFieldError());
@@ -112,20 +122,22 @@ public class NovelController {
         //DTO에 유저 정보(providerId) 값 저장
         reqBody.setAccessorProviderId(principal.getName());
 
-        return ResponseEntity.ok("작품 업데이트 완료.");    }
+        return ResponseEntity.ok("작품 업데이트 완료.");
+    }
 
     /**
      * 유저가 생성한 소설을 DELETE_BY_USER로 삭제 처리하는 API
-     * @param reqBody novelId, providerId를 담은 객체
-     * @param bindingResult DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
+     *
+     * @param reqBody        novelId, providerId를 담은 객체
+     * @param bindingResult  DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
     @DeleteMapping("/novels/{novelId}")
     public ResponseEntity<String> deleteNovel(@PathVariable("novelId") Long urlNovelId,
-                                                        @Valid @RequestBody NovelDeleteDto reqBody,
-                                                        BindingResult bindingResult,
-                                                        Authentication authentication) {
+                                              @Valid @RequestBody NovelDeleteDto reqBody,
+                                              BindingResult bindingResult,
+                                              Authentication authentication) {
         //NovelDeleteDto Validation 예외 처리
         if (bindingResult.hasErrors()) {
             log.error("deleteNovel API Error = {}", bindingResult.getFieldError());

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -75,11 +75,12 @@ public interface NovelService {
 
 
     /**
-     *랭킹에 따른 소설 상세정보를 전달하는 메서드
+     * 랭킹 주기(일간,주간,월간) 과 페이지네이션 정보로 소설 정보를 전달하는 메서드
      * @param period 랭킹주기(daily,weekly,monthly,all-time 디폴트값은 daily)
+     * @param pageable 페지이네이션 정보
      * @return List<NovelInfoDto>
      */
-    List<NovelInfoDto> getNovelsByRanking(String period);
+    List<NovelInfoDto> getNovelsByRanking(String period,Pageable pageable);
 
 
 

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingService.java
@@ -50,7 +50,7 @@ public interface NovelRankingService {
 
     void saveRankingToRedis(RankingPeriod rankingPeriod);
 
-    List<Map<String, Object>> getRankingFromRedis(String period);
+    List<Map<String, Object>> getRankingFromRedis(String period,Integer startIndex, Integer endIndex);
 
 
 }

--- a/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -127,7 +128,7 @@ class NovelServiceImplTest {
         List<NovelInfoDto> list = novelService.getNovelsRecent(pageable);
         Assertions.assertThat(list.isEmpty()).isFalse();
         list.forEach(novel -> {
-            log.info("id = {}, title = {}", novel.getId(), novel.getTitle());
+//            log.info("id = {}, title = {}", novel.getId(), novel.getTitle());
         });
     }
 
@@ -146,9 +147,22 @@ class NovelServiceImplTest {
     @Test
     public void getRankedNovels(){
 
-        String period = "daily";
-        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period);
+//        String period = "daily";//테스트 성공
+        String period = "weekly";//테스트 성공
+//        String period = "monthly";//테스트 성공
+
+        //페이지네이션 테스트 성공
+        Pageable pageable = PageRequest.of(0, 3);
+        List<NovelInfoDto> rankedNovels = novelService.getNovelsByRanking(period,pageable);
+
+        if (rankedNovels.isEmpty()){
+            System.out.println("비었음");
+            return;
+        }
+
+        System.out.println("가져온 소설수 = "+rankedNovels.size());
         for (NovelInfoDto rankedNovel : rankedNovels) {
+            System.out.println("********** 소설정보 **********");
             System.out.println(rankedNovel.toString());
 
         }

--- a/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImplTest.java
@@ -67,7 +67,10 @@ class NovelRankingServiceImplTest {
 //        String period = "daily";
         String period = "weekly";
 //        String period = "monthly";
-        List<Map<String, Object>> rankingFromRedis = novelRankingService.getRankingFromRedis(period);
+        Integer startIndex = 0;
+        Integer endIndex = 3;
+
+        List<Map<String, Object>> rankingFromRedis = novelRankingService.getRankingFromRedis(period,startIndex,endIndex);
         for (Map<String, Object> result : rankingFromRedis) {
             System.out.println("noelid= "+result.get("novelId"));
             System.out.println("랭킹= "+result.get("ranking"));


### PR DESCRIPTION
# 변경사항
## 소설 랭킹 로직 페이지네이션 적용
- 클라이언트에서 보낸 페이지네이션 정보(페이지번호, 사이즈) 로 소설 랭킹 정보를 전송하도록 로직 수정

### NovelController
#### getNovelsByRanking - 쿼리 파라미터로 페이지 번호와 페이지 사이즈를 받도록 변경

### NovelRankingService
#### getRankingFromRedis 
 -  파라미터로 startIndex, endIndex 를 받도록 수정 - Redis에서 랭킹 데이터를 받아올때, 파라미터로 받은 인덱스 번호에 맞춰 데이터를 받아오도록 수정 - endIndex 번호가 저장된 데이터 인덱스 크기보다 크다면, 마지막 인덱스 데이터까지만 가져옴

### NovelRankingServiceImplTest
#### getRankingFromRedis 
 - startIndex, endIndex 적용으로 재 테스트, 테스트 성공

### NovelService
#### getNovelsByRanking
  - 파라미터로 pageable 받도록 수정
  - 파라미터로 받은 pageable 정보로, startIndex, endIndex 계산하여 novelRankingService.getRankingFromRedis() 호출시 사용

### NovelServiceImplTest
  - getRankedNovels 메서드 페이지네이션 적용으로 재 테스트, 테스트 성공

### PageableUtil
  - 에러 메시지 오타 수정