### PR TITLE
AWS S3 파일 업로드 및 CloudFront URL 생성 관련 로직 추가 , Novel 엔티티 섬네일 관리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 
+    //AWS S3 SDK, versionCheck 2024-08-19
+    implementation 'software.amazon.awssdk:s3:2.27.7'
+
+    implementation 'software.amazon.awssdk:cloudfront:2.27.7'
+
+
 
 
 }

--- a/src/main/java/com/ham/netnovel/common/config/AWSConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/AWSConfig.java
@@ -1,0 +1,44 @@
+package com.ham.netnovel.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AWSConfig {
+    @Value("${aws.s3.accessKey}")
+    private String accessKey;
+
+    @Value("${aws.s3.secretKey}")
+    private String secretKey;
+
+
+
+    //AWS S3 접속 클라이언트 객체 이미지 업로드시 사용
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)//지역설정, 한국지역 상수입력
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials.create(accessKey, secretKey)))//key설정
+                .build();
+
+
+    }
+
+    //AWS cloud front 접속 클라이언트 객체
+    @Bean
+    public CloudFrontClient cloudFrontClient(){
+        return CloudFrontClient.builder()
+                .region(Region.AP_NORTHEAST_2)//지역설정, 한국지역 상수입력
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/novel/Novel.java
+++ b/src/main/java/com/ham/netnovel/novel/Novel.java
@@ -38,6 +38,9 @@ public class Novel {
     @Enumerated(EnumType.STRING)
     private NovelStatus status;
 
+    //섬네일 파일명
+    private String thumbnailFileName;
+
     //작가
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -82,6 +85,12 @@ public class Novel {
     }
     public void updateType(NovelType type){
         this.type = type;
+    }
+
+    //섬네일 파일명 변경
+    public void updateThumbnailFileName(String thumbnailFileName){
+        this.thumbnailFileName = thumbnailFileName;
+
     }
 
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
@@ -1,22 +1,20 @@
 package com.ham.netnovel.novel.dto;
 
-import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.tag.dto.TagDataDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
 @Setter
 @ToString
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class NovelInfoDto {
+@Builder
+public class NovelListDto {//랭킹 등 리스트로 소설정보를 전달시 사용하는 DTO
 
     @NotNull
     private Long id; //소설 id
@@ -25,18 +23,8 @@ public class NovelInfoDto {
     @Size(max = 30)
     private String title; //소설 제목
 
-    @NotBlank
-    @Size(max = 300)
-    private String desc; //작품 소개
-
     @NotNull
     private String authorName; //작가 닉네임
-
-    @NotNull
-    private Integer views; //조회수
-
-    @NotNull
-    private BigDecimal averageRating; //평균 별점
 
     @NotNull
     private Integer favoriteCount; //선호작 수
@@ -44,13 +32,6 @@ public class NovelInfoDto {
     @NotNull
     private List<TagDataDto> tags; //작품 태그
 
-    @NotNull
-    private NovelType type; //소설 등급
-
-    @NotNull
-    private Integer episodeCount; //에피소드 총 화수
-
-    @NotNull
-    private String thumbnailUrl;//섬네일 AWS URL
+    private String thumbnailUrl;
 
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -1,11 +1,10 @@
 package com.ham.netnovel.novel.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.novel.Novel;
-import com.ham.netnovel.novel.dto.NovelCreateDto;
-import com.ham.netnovel.novel.dto.NovelDeleteDto;
-import com.ham.netnovel.novel.dto.NovelInfoDto;
-import com.ham.netnovel.novel.dto.NovelUpdateDto;
+import com.ham.netnovel.novel.dto.*;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -75,12 +74,41 @@ public interface NovelService {
 
 
     /**
-     * 랭킹 주기(일간,주간,월간) 과 페이지네이션 정보로 소설 정보를 전달하는 메서드
-     * @param period 랭킹주기(daily,weekly,monthly,all-time 디폴트값은 daily)
-     * @param pageable 페지이네이션 정보
-     * @return List<NovelInfoDto>
+     * 주어진 기간에 따라 소설의 랭킹을 조회하여 해당 페이지의 소설 정보를 반환합니다.
+     *
+     * <p>이 메서드는 다음과 같은 작업을 수행합니다:</p>
+     * <ul>
+     *     <li>페이지 번호와 페이지 크기를 사용하여 데이터의 시작 인덱스와 끝 인덱스를 계산합니다.</li>
+     *     <li>Redis에서 주어진 기간에 해당하는 소설 랭킹 데이터를 가져옵니다.</li>
+     *     <li>가져온 데이터에서 소설 ID를 추출합니다.</li>
+     *     <li>추출한 소설 ID를 사용하여 소설 엔티티를 조회하고, 랭킹 순서로 정렬하여 DTO로 변환합니다.</li>
+     * </ul>
+     *
+     * <p>작업 중 예외가 발생하면 {@link ServiceMethodException}이 발생합니다.</p>
+     *
+     * @param period 소설 랭킹을 조회할 기간. "daily", "weekly", "monthly" 중 하나로 지정합니다.
+     * @param pageable 페이지 정보. 페이지 번호와 페이지 크기를 포함합니다.
+     * @return 주어진 페이지와 기간에 해당하는 소설 정보를 담은 {@link List}입니다.
+     * @throws ServiceMethodException 메서드 실행 중 오류가 발생한 경우 발생합니다.
      */
-    List<NovelInfoDto> getNovelsByRanking(String period,Pageable pageable);
+    List<NovelListDto> getNovelsByRanking(String period, Pageable pageable);
+
+
+    /**
+     * AWS S3에 소설의 섬네일을 업로드하고, 소설 엔티티의 섬네일 정보를 업데이트합니다.
+     *
+     * <p>요청자의 정보와 소설 작가 정보가 일치하지 않거나, 소설이 데이터베이스에 없으면 {@link IllegalArgumentException}이 발생합니다.</p>
+     *
+     * <p>업로드와 저장이 성공하면 {@code true}를 반환합니다. 과정 중 오류가 발생하면 {@link ServiceMethodException}이 발생합니다.</p>
+     *
+     * @param file 소설의 섬네일로 업로드할 파일. {@code null}이 될 수 없습니다.
+     * @param novelId 섬네일을 업데이트할 소설의 ID. {@code null}이 될 수 없습니다.
+     * @param providerId 섬네일 변경 요청자의 사용자 ID. {@code null}이 될 수 없습니다.
+     * @return 섬네일 변경 성공 시 {@code true}. 실패 시 {@link ServiceMethodException}이 발생합니다.
+     * @throws IllegalArgumentException 소설을 찾을 수 없거나 요청자와 소설 작가가 일치하지 않을 때 발생합니다.
+     * @throws ServiceMethodException 파일 업로드나 소설 엔티티 저장 중 오류 발생 시 발생합니다.
+     */
+    boolean updateNovelThumbnail(MultipartFile file, Long novelId, String providerId);
 
 
 

--- a/src/main/java/com/ham/netnovel/s3/S3Service.java
+++ b/src/main/java/com/ham/netnovel/s3/S3Service.java
@@ -1,0 +1,40 @@
+package com.ham.netnovel.s3;
+
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+
+    /**
+     * 파일을 Amazon S3 버킷에 업로드합니다.
+     *
+     * <p>이 메서드는 {@link MultipartFile} 객체를 받아, 현재 타임스탬프를 이용해 고유한 파일 이름을 생성하고,
+     * 해당 파일을 지정된 S3 버킷과 폴더에 업로드합니다. 업로드가 성공하면 메서드는 파일 이름을 반환합니다.</p>
+     *
+     * <p>application properties 에서 파일 용량 제한이 필요합니다. </p>
+     *
+     * <p>업로드 과정에서 오류가 발생하면 {@link RuntimeException}이 발생합니다.</p>
+     *
+     * @param file S3에 업로드할 {@link MultipartFile} 객체
+     * @return S3에 업로드된 후의 파일 이름
+     * @throws ServiceMethodException 파일 업로드 중 오류가 발생한 경우
+     */
+    String uploadFileToS3(MultipartFile file);
+
+
+
+    /**
+     * 주어진 파일 이름을 사용하여 CloudFront URL을 생성합니다.
+     *
+     * <p>이 메서드는 파일 이름을 받아서 CloudFront 도메인, 폴더 이름, 파일 이름을 조합하여
+     * CloudFront URL을 생성하고 반환합니다. URL 생성 중 오류가 발생하면
+     * {@link RuntimeException}이 발생합니다.</p>
+     *
+     * @param fileName CloudFront URL을 생성할 파일의 이름
+     * @return 생성된 CloudFront URL
+     * @throws RuntimeException URL 생성 중 오류가 발생한 경우
+     */
+   String generateCloudFrontUrl(String fileName);
+
+}

--- a/src/main/java/com/ham/netnovel/s3/S3ServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/s3/S3ServiceImpl.java
@@ -1,0 +1,71 @@
+package com.ham.netnovel.s3;
+
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+@Service
+@Slf4j
+public class S3ServiceImpl implements S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.buket}")
+    private String BUKET_NAME;//S3 버킷이름
+
+    @Value("${aws.cloudfront.domain}")
+    private String DOMAIN_NAME;//cloud front 가상 도메인 이름
+
+    public S3ServiceImpl(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    private final String FOLDER_NAME = "thumbnail";//S3 버킷에서 접근할 폴더 이름
+
+
+    @Override
+    public String uploadFileToS3(MultipartFile file) {
+        //현재시간과 파일이름으 조합으로 고유한 파일명 생성
+        String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        try {
+            //S3에 Put 요청을 하기위한 Request 객체 생성
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(BUKET_NAME)//S3에서 사용될 버킷 이름
+                    .key(FOLDER_NAME + "/" + fileName)//버킷 안에 폴더 이름과 파일 명으로 엔드포인트 설정
+                    .build();
+
+            //업로드할 파일을 바이트로 변환하여 S3 버킷에 저장후, 반환된 응답 객체에 저장
+            PutObjectResponse response = s3Client.putObject(putObjectRequest,
+                    RequestBody.fromBytes(file.getBytes()));
+
+            //업로드 결과 출력
+            log.info("S3 파일 업로드 결과 ={}",response.toString());
+
+            return fileName;
+        } catch (Exception ex) {
+            throw new ServiceMethodException("uploadFileToS3 메서드 에러, S3 파일 업로드 실패"+ex+ex.getMessage());
+        }
+    }
+
+    @Override
+    public String generateCloudFrontUrl(String fileName) {
+        try {
+            //cloudfront 도메인으로 S3 이미지 접근, URL은 https://{cloudfront도메인이름}/{폴더이름}/{파일이름}
+            return String.format("https://%s/%s/%s", DOMAIN_NAME, FOLDER_NAME, fileName); //생성된 URL 반환
+        } catch (Exception ex) {
+            throw new ServiceMethodException("generateCloudFrontUrl 메서드 에러 cloudfront URL 생성실패"+ex+ex.getMessage());
+        }
+    }
+}
+
+
+
+
+

--- a/src/main/java/com/ham/netnovel/s3/S3ServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/s3/S3ServiceImpl.java
@@ -45,7 +45,7 @@ public class S3ServiceImpl implements S3Service {
             PutObjectResponse response = s3Client.putObject(putObjectRequest,
                     RequestBody.fromBytes(file.getBytes()));
 
-            //업로드 결과 출력
+            //업로드 결과 출력, 업로드 실패시 예외로 던져짐
             log.info("S3 파일 업로드 결과 ={}",response.toString());
 
             return fileName;


### PR DESCRIPTION
# 변경사항

## AWS SDK 의존성 추가 및 S3 파일 업로드/CloudFront URL 생성 기능 구현
### build.gradle
  - AWS의 s3, cloudfront 관련 sdk 의존성 추가

### AWSConfig
  - s3, cloudfront 연결을 위한 Bean 객체 생성

### S3Service
  - AWS 관련 변수들은 application properties 에 보관
  - uploadFileToS3
    - 파일을 Amazon S3 버킷에 업로드 하는 메서드 추가
    - 파라미터로 MultipartFile 타입의 file 을 받아 S3에 업로드
    - application properties 에서 파일 용량 제한 필요

  - generateCloudFrontUrl
    - 파일 이름을 사용하여 CloudFront URL 을 생성하는 메서드 추가
    - 소설 정보 전달시, URL만 전달 후 클라이언트사이드 랜더링 진행



## Novel 엔티티 섬네일 관리 기능 추가 (S3 업로드 및 엔티티 업데이트)
### Novel
  - thumbnailFileName 필드 추가, 섬네일 파일명만 저장
  - updateThumbnailFileName
    - Novel 엔티티의 thumbnailFileName 필드값을 변경하는 메서드 추가

### NovelService
  - updateNovelThumbnail
    - AWS S3에 소설의 섬네일을 업로드하고, 소설 엔티티의 섬네일 정보를 업데이트하는 메서드 추가
    - 섬네일 업로드 실패시 예외로 던져짐
    - 업로드 성공시 Novel 엔티티 thumbnailFileName 필드값 업데이트 후 DB에 저장

### NovelListDto
  - 랭킹 등 리스트로 소설 정보를 전달시 사용할 DTO 생성
  - id,제목,작가명,좋아요수,태그,섬네일 URL 정보를 멤버변수로 가짐

### NovelInfoDto
  - thumbnailUrl 멤버변수 추가

### NovelController
  - uploadNovelThumbnail
    - 소설의 섬네일을 AWS S3에 업로드하고, 소설의 섬네일 파일명을 업데이트하는 API 추가.
    - 파라미터로 소설의 ID, 업로드할 파일, providerId 정보를 받음
    - 업로드 성공시 HTTP 200 전송, 실패시 HTTP 500 전송