### PR TITLE
에피소드 불러오기 및 결제 로직 엔드포인트 연결 작업

### DIFF
--- a/src/main/java/com/ham/netnovel/coinCostPolicy/dto/CostPolicyResponseDto.java
+++ b/src/main/java/com/ham/netnovel/coinCostPolicy/dto/CostPolicyResponseDto.java
@@ -12,9 +12,6 @@ import lombok.*;
 @AllArgsConstructor
 public class CostPolicyResponseDto {
 
-    @NotNull
-    private Long id;
-
     @NotBlank
     private String name;
 

--- a/src/main/java/com/ham/netnovel/coinCostPolicy/dto/CostPolicyResponseDto.java
+++ b/src/main/java/com/ham/netnovel/coinCostPolicy/dto/CostPolicyResponseDto.java
@@ -1,0 +1,23 @@
+package com.ham.netnovel.coinCostPolicy.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CostPolicyResponseDto {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private Integer coinCost;
+}

--- a/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
@@ -1,12 +1,21 @@
 package com.ham.netnovel.common.exception;
 
+import com.ham.netnovel.coinCostPolicy.dto.CostPolicyResponseDto;
+import lombok.Getter;
+
 public class EpisodeNotPurchasedException extends RuntimeException{//에피소드 결제 내역이 없을때 예외처리
 
-    public EpisodeNotPurchasedException(String message) {
+    @Getter
+    private final CostPolicyResponseDto coinCostPolicy;
+
+
+    public EpisodeNotPurchasedException(String message, CostPolicyResponseDto coinCostPolicy) {
         super(message);
+        this.coinCostPolicy = coinCostPolicy;
     }
 
-    public EpisodeNotPurchasedException(String message, Throwable cause) {
+    public EpisodeNotPurchasedException(String message, Throwable cause, CostPolicyResponseDto coinCostPolicy) {
         super(message, cause);
+        this.coinCostPolicy = coinCostPolicy;
     }
 }

--- a/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
@@ -1,21 +1,22 @@
 package com.ham.netnovel.common.exception;
 
 import com.ham.netnovel.coinCostPolicy.dto.CostPolicyResponseDto;
+import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.Getter;
 
 public class EpisodeNotPurchasedException extends RuntimeException{//에피소드 결제 내역이 없을때 예외처리
 
     @Getter
-    private final CostPolicyResponseDto coinCostPolicy;
+    private final Integer coinCost; // 결제 실패 시, 응답할 가격 정책 정보
 
 
-    public EpisodeNotPurchasedException(String message, CostPolicyResponseDto coinCostPolicy) {
+    public EpisodeNotPurchasedException(String message, Integer coinCost) {
         super(message);
-        this.coinCostPolicy = coinCostPolicy;
+        this.coinCost = coinCost;
     }
 
-    public EpisodeNotPurchasedException(String message, Throwable cause, CostPolicyResponseDto coinCostPolicy) {
+    public EpisodeNotPurchasedException(String message, Throwable cause, Integer coinCost) {
         super(message, cause);
-        this.coinCostPolicy = coinCostPolicy;
+        this.coinCost = coinCost;
     }
 }

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -1,12 +1,16 @@
 package com.ham.netnovel.episode;
 
+import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.common.utils.PageableUtil;
+import com.ham.netnovel.episode.dto.EpisodeDetailDto;
 import com.ham.netnovel.episode.dto.EpisodeListInfoDto;
 import com.ham.netnovel.episode.dto.EpisodeListItemDto;
+import com.ham.netnovel.episode.service.EpisodeManagementService;
 import com.ham.netnovel.episode.service.EpisodeService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,10 +21,27 @@ import java.util.List;
 @Slf4j
 public class EpisodeController {
     private final EpisodeService episodeService;
+    private final EpisodeManagementService episodeManagementService;
 
     @Autowired
-    public EpisodeController(EpisodeService episodeService) {
+    public EpisodeController(EpisodeService episodeService, EpisodeManagementService episodeManagementService) {
         this.episodeService = episodeService;
+        this.episodeManagementService = episodeManagementService;
+    }
+
+
+
+    @GetMapping("/episodes/{episodeId}")
+    public ResponseEntity<?> getEpisodeDetail(
+            @PathVariable Long episodeId
+    ) {
+        try {
+            EpisodeDetailDto episodeDetail = episodeManagementService.getEpisodeDetail("test1", episodeId);
+            return ResponseEntity.ok(episodeDetail);
+        } catch (EpisodeNotPurchasedException e) {
+            //실패 시 해당하는 코인 정책 반환
+            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(e.getCoinCostPolicy());
+        }
     }
 
     @GetMapping("/novels/{novelId}/episodes")

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
@@ -1,5 +1,7 @@
 package com.ham.netnovel.episode.service;
 
+import com.ham.netnovel.coinCostPolicy.CoinCostPolicy;
+import com.ham.netnovel.coinCostPolicy.dto.CostPolicyResponseDto;
 import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
 import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
@@ -55,9 +57,14 @@ public class EpisodeManagementServiceImpl implements EpisodeManagementService {
         if (coinCost > 0) {
             //유저의 에피소드 결제 내역을 확인, 있을경우 true 없을경우 false 반환
             boolean result = coinUseHistoryService.hasMemberUsedCoinsForEpisode(providerId, episodeId);
+            CostPolicyResponseDto costPolicyDto = CostPolicyResponseDto.builder()
+                    .id(episode.getCostPolicy().getId())
+                    .name(episode.getCostPolicy().getName())
+                    .coinCost(episode.getCostPolicy().getCoinCost())
+                    .build();
             //결제 내역이 없을경우 EpisodeNotPurchasedException 로 던짐
             if (!result) {
-                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId);
+                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId, costPolicyDto);
             }
         }
 

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
@@ -57,14 +57,10 @@ public class EpisodeManagementServiceImpl implements EpisodeManagementService {
         if (coinCost > 0) {
             //유저의 에피소드 결제 내역을 확인, 있을경우 true 없을경우 false 반환
             boolean result = coinUseHistoryService.hasMemberUsedCoinsForEpisode(providerId, episodeId);
-            CostPolicyResponseDto costPolicyDto = CostPolicyResponseDto.builder()
-                    .id(episode.getCostPolicy().getId())
-                    .name(episode.getCostPolicy().getName())
-                    .coinCost(episode.getCostPolicy().getCoinCost())
-                    .build();
             //결제 내역이 없을경우 EpisodeNotPurchasedException 로 던짐
             if (!result) {
-                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId, costPolicyDto);
+                //EpisodeNotPurchasedException 에 coinCost 정보도 함께 전달
+                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId, coinCost);
             }
         }
 

--- a/src/main/java/com/ham/netnovel/member/Member.java
+++ b/src/main/java/com/ham/netnovel/member/Member.java
@@ -90,6 +90,7 @@ public class Member {
         this.role = role;
         this.nickName = nickName;
         this.gender = gender;
+        this.coinCount = coinCount;
     }
 
     public void changeNickName(String nickName) {

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -281,6 +281,7 @@ public class NovelServiceImpl implements NovelService {
     }
 
     NovelInfoDto convertEntityToInfoDto(Novel novel) {
+        //평균 별점 레코드가 없으면 0점짜리 새로 생성
         NovelAverageRating averageRating = Optional.ofNullable(novel.getNovelAverageRating())
                 .orElse(NovelAverageRating.builder()
                         .novel(novel)
@@ -296,12 +297,15 @@ public class NovelServiceImpl implements NovelService {
         //AWS cloud front 섬네일 이미지 URL 객체 반환
         String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName());
 
+        //작품의 모든 에피소드 조회수 총합
+        int viewsSum = novel.getEpisodes().stream().mapToInt(Episode::getView).sum();
+
         return NovelInfoDto.builder()
                 .id(novel.getId())
                 .title(novel.getTitle())
                 .desc(novel.getDescription())
                 .authorName(novel.getAuthor().getNickName())
-                .views(novel.getEpisodes().stream().mapToInt(Episode::getView).sum())
+                .views(viewsSum)
                 .averageRating(averageRating.getAverageRating())
                 .episodeCount(novel.getEpisodes().size())
                 .favoriteCount(novel.getFavorites().size())


### PR DESCRIPTION
# [refactor: NovelInfoDto 변환 메서드 코드 정리](https://github.com/Ham-Novel/netnovel/commit/0d0fedfa30bd51b57b93c349bf51f65fd5fae95e) 
- 조회수 계산 로직 분리
- 주석 추가


# [feat: getEpisodeDetail api 메서드 구현](https://github.com/Ham-Novel/netnovel/commit/694e74ecf295eb5820ff083e82f46cd47c0f76a5) 
- 에피소드 페이지를 불러오는 엔드포인트 api
- 미결재 상태일 시, 402 Payment Required 반환 + 해당 에피소드의 가격 정책 데이터 응답

# [fix: Member 엔티티 생성 시 coinCost 설정하는 코드 누락됨](https://github.com/Ham-Novel/netnovel/commit/aee26991b7cda043e8fa948e069f863c2ff6d771)


# [test: DBRecordTest 테스트 DB 데이터 생성 코드 추가](https://github.com/Ham-Novel/netnovel/commit/e43c576ff6a5aa2afee49439dde4df52c6d4b123)


# [refactor: getEpisodeDetail api 피드백 수정](https://github.com/Ham-Novel/netnovel/pull/50/commits/dea0376a9bf7d4ddd35b80beda164a439c90ee30) 
[dea0376](https://github.com/Ham-Novel/netnovel/pull/50/commits/dea0376a9bf7d4ddd35b80beda164a439c90ee30)
- 미결제 상태 시 402 응답 바디 메세지 변경. coinCostPolicy의 id, name 같은 필요 없는 정보까지 돌려줬는데 이제 coinCost 값만 반환.
- api 통신 시 Authentication 유저 인증 작업 추가