### PR TITLE
 소설 썸네일 업로드 시 AWS Lambda를 이용한 리사이징 및 미니 썸네일 저장 기능 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -260,6 +260,11 @@ public class NovelServiceImpl implements NovelService {
 
     }
 
+    /**
+     * 랭킹과 같이 대량의 소설정보를 전달시 사용하는 DTO로 변환하는 메서드 입니다.
+     * @param novel 소설 엔티티
+     * @return NovelListDto
+     */
     NovelListDto convertEntityToListDto(Novel novel){
         //작품의 태그들 가져오기
         List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
@@ -267,7 +272,7 @@ public class NovelServiceImpl implements NovelService {
                 .toList();
 
         //AWS cloud front 섬네일 이미지 URL 객체 반환
-        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName());
+        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName(),"mini");
 
         //DTO 반환
        return NovelListDto.builder()
@@ -294,7 +299,7 @@ public class NovelServiceImpl implements NovelService {
                 .toList();
 
         //AWS cloud front 섬네일 이미지 URL 객체 반환
-        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName());
+        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName(),"original");
 
         return NovelInfoDto.builder()
                 .id(novel.getId())

--- a/src/main/java/com/ham/netnovel/s3/S3Service.java
+++ b/src/main/java/com/ham/netnovel/s3/S3Service.java
@@ -32,9 +32,10 @@ public interface S3Service {
      * {@link RuntimeException}이 발생합니다.</p>
      *
      * @param fileName CloudFront URL을 생성할 파일의 이름
+     * @param thumbnailType 미니 사이즈로 리사이징 된 이미지 사용시, mini 대입(랭킹 등 대량의 섬네일이 필요한 경우)
      * @return 생성된 CloudFront URL
      * @throws RuntimeException URL 생성 중 오류가 발생한 경우
      */
-   String generateCloudFrontUrl(String fileName);
+   String generateCloudFrontUrl(String fileName,String thumbnailType);
 
 }


### PR DESCRIPTION
# 변경사항
 ## 소설 썸네일 업로드 시 AWS Lambda를 이용한 리사이징 및 미니 썸네일 저장 기능 추가

- 썸네일과 미니 썸네일을 각각의 S3 버킷에 저장
- 미니 사이즈 썸네일은 랭킹 리스트 등 대량의 이미지가 필요한 경우 사용

### S3Service
  - 미니 썸네일 버킷명 및 CloudFront 도메인 상수 추가
  - generateCloudFrontUrl
    - String 타입의 `thumbnailType` 파라미터 추가
    - `thumbnailType`이 `mini`일 경우, 미니 썸네일 버킷의 도메인과 파일명으로 URL 반환

### NovelService
  - convertEntityToListDto, convertEntityToInfoDto - 썸네일 URL 생성 시, 파라미터로 썸네일 사이즈(미니 여부)를 명시하도록 수정