### PR TITLE
Redis Pub/Sub 기능, SSE 연결을 통해 유저에게 소설 업데이트 알림 메시지를 보내는 로직 구현

### DIFF
--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelRepository.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelRepository.java
@@ -1,12 +1,37 @@
 package com.ham.netnovel.favoriteNovel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FavoriteNovelRepository extends JpaRepository<FavoriteNovel, FavoriteNovelId> {
 
     List<FavoriteNovel> findByMemberId(Long memberId);
-    
+
+
     List<FavoriteNovel> findByNovelId(Long novelId);
+
+
+    /**
+     * 특정 소설에 좋아요를 누른 유저들의 providerId 목록을 반환합니다.
+     *
+     * <p>
+     * 이 메서드는 `FavoriteNovel` 엔티티를 조회하여, 주어진 소설 ID와 연관된 모든 유저의 `providerId`를 가져옵니다.
+     * </p>
+     * <p>
+     * `FavoriteNovel` 엔티티는 소설과 유저 간의 관계를 나타내는 조인 테이블입니다. 이 테이블에서 주어진 소설 ID와 관련된
+     * 유저들의 `providerId`를 검색하여 리스트 형태로 반환합니다.
+     * </p>
+     *
+     * @param novelId 소설의 고유 식별자 (ID). 이 값으로 해당 소설을 좋아요한 유저들을 조회합니다.
+     * @return 주어진 소설 ID와 관련된 유저들의 `providerId`를 포함하는 리스트. 소설에 좋아요를 누른 유저가 없을 경우 빈 리스트를 반환합니다.
+     */
+    @Query("select f.member.providerId  " +
+            "from FavoriteNovel f " +
+            "where f.novel.id =:novelId ")
+    List<String> findMemberProviderIdsByNovelId(@Param("novelId") Long novelId);
+
+
 }

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelService.java
@@ -1,6 +1,9 @@
 package com.ham.netnovel.favoriteNovel.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.favoriteNovel.FavoriteNovelId;
+
+import java.util.List;
 
 public interface FavoriteNovelService {
 
@@ -13,4 +16,23 @@ public interface FavoriteNovelService {
     Boolean toggleFavoriteNovel(String providerId, Long novelId);
 
     Boolean checkFavorite(String providerId, Long novelId);
+
+
+    /**
+     * 주어진 소설 ID에 대해 구독 중인 유저의 providerId를 반환합니다.
+     *
+     * <p>이 메서드는 소설에 좋아요를 누른 유저들의 providerId를 리스트 형태로 반환합니다.
+     * 주어진 소설 ID가 null인 경우에는 {@link IllegalArgumentException}을 발생시킵니다.
+     * </p>
+     *
+     * <p>
+     *
+     * </p>또한, 데이터베이스 접근 중 예외가 발생할 경우에는 {@link ServiceMethodException}을 발생시킵니다.
+     * @param novelId 소설의 ID (null일 수 없음)
+     * @return 소설에 좋아요를 누른 유저들의 providerId 리스트
+     * @throws IllegalArgumentException 소설 ID가 null인 경우 발생
+     * @throws ServiceMethodException 데이터베이스 접근 중 예외가 발생한 경우
+     */
+    List<String> getSubscribedMemberProviderIds(Long novelId);
+
 }

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.favoriteNovel.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.favoriteNovel.FavoriteNovel;
 import com.ham.netnovel.favoriteNovel.FavoriteNovelId;
 import com.ham.netnovel.favoriteNovel.FavoriteNovelRepository;
@@ -13,12 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
 @Slf4j
-public class FavoriteNovelServiceImpl implements FavoriteNovelService{
+public class FavoriteNovelServiceImpl implements FavoriteNovelService {
 
     private final FavoriteNovelRepository favoriteNovelRepository;
     private final MemberService memberService;
@@ -61,7 +63,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
                 return true; // 이제 레코드 있음
             }
         } catch (Exception ex) {
-            throw new ServiceMethodException("toggleFavoriteNovel() Error : "  + ex.getMessage());
+            throw new ServiceMethodException("toggleFavoriteNovel() Error : " + ex.getMessage());
         }
     }
 
@@ -78,7 +80,25 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService{
             Optional<FavoriteNovel> record = favoriteNovelRepository.findById(id);
             return record.isPresent();
         } catch (Exception ex) {
-            throw new ServiceMethodException("checkFavorite() Error : "  + ex.getMessage());
+            throw new ServiceMethodException("checkFavorite() Error : " + ex.getMessage());
         }
     }
+
+    @Override
+    public List<String> getSubscribedMemberProviderIds(Long novelId) {
+
+        //파라미터 null 체크
+        if (novelId == null) {
+            throw new IllegalArgumentException("Novel Id가 Null입니다.");
+        }
+        try {
+            //소설에 좋아요 누른 유저의 providerId 값을 리턴
+            return favoriteNovelRepository.findMemberProviderIdsByNovelId(novelId);
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getSubscribedMemberProviderIds 메서드 에러" + ex + ex.getMessage());
+        }
+
+    }
+
+
 }

--- a/src/main/java/com/ham/netnovel/common/config/RedisConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.common.config;
 
+import com.ham.netnovel.common.message.NovelUpdateMessageSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,11 +8,16 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-
+/**
+ * Redis 관련 설정을 구성하는 클래스입니다.
+ * Redis 연결, RedisTemplate, 메시지 리스너 컨테이너 등을 설정합니다.
+ */
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -23,7 +29,11 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String password;
 
-    //Redis 연결을 위한 설정
+    /**
+     * Redis 서버와의 연결을 생성하는 Bean을 생성합니다.
+     *
+     * @return Redis 서버와의 연결을 관리하는 {@link RedisConnectionFactory} 객체
+     */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
@@ -32,13 +42,18 @@ public class RedisConfig {
         redisStandaloneConfiguration.setPassword(password);
 
         //설정된 정보로 RedisConnectionFactory 생성
-        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
-        return lettuceConnectionFactory;
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
-    //Redis와 상호작용할때 사용되는 RedisTemplate Bean 객체 생성
+    /**
+     * Redis 서버와 상호작용하기 위한 RedisTemplate Bean을 생성합니다.
+     * 문자열 형태의 키와 값을 처리하도록 설정됩니다.
+     *
+     * @param redisConnectionFactory Redis 연결을 위한 {@link RedisConnectionFactory} 객체
+     * @return Redis 서버와의 데이터 작업을 수행하는 {@link RedisTemplate} 객체
+     */
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         // RedisConnectionFactory를 RedisTemplate에 설정
         redisTemplate.setConnectionFactory(redisConnectionFactory());
@@ -49,6 +64,66 @@ public class RedisConfig {
 
         return redisTemplate;
     }
+
+    /**
+     * Redis Pub/Sub 메시지를 처리하기 위한 리스너 컨테이너를 생성합니다.
+     * 지정된 채널에서 메시지를 수신하고, 해당 메시지를 처리할 리스너를 등록합니다.
+     *
+     * @param redisConnectionFactory Redis 연결을 위한 {@link RedisConnectionFactory} 객체
+     * @param novelUpdateMessageSubscriber 수신될 메시지를 처리할 {@link NovelUpdateMessageSubscriber} 객체
+     * @param novelUpdateTopic                  메시지를 수신할 {@link ChannelTopic} 객체
+     * @return Redis 메시지 리스너를 관리하는 {@link RedisMessageListenerContainer} 객체
+     */
+    @Bean
+    RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            NovelUpdateMessageSubscriber novelUpdateMessageSubscriber,
+            ChannelTopic novelUpdateTopic) {
+
+        // RedisMessageListenerContainer 객체 생성
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+
+        // Redis 서버와의 연결을 설정
+        container.setConnectionFactory(redisConnectionFactory);
+
+
+        /*
+        소설 업데이트 관련 메시지 설정
+        지정된 채널(novelUpdateTopic)에서 수신한 메시지를 NovelUpdateMessageSubscriber로 전달
+         */
+        container.addMessageListener(novelUpdateMessageSubscriber, novelUpdateTopic);
+
+        // 설정이 완료된 RedisMessageListenerContainer 객체를 반환
+        return container;
+    }
+    /**
+     * Redis Pub/Sub에서 사용될 채널 토픽을 생성합니다.
+     *
+     * @return 메시지를 발행하고 수신할 {@link ChannelTopic} 객체
+     */
+    @Bean
+    public ChannelTopic novelUpdateTopic() {
+        return new ChannelTopic("novel-update-channel");
+    }
+
+
+    ;
+//
+//    /**
+//     * Redis 메시지를 redisMessageSubscriber 객체의 메소드 호출로 변환하는 어댑터
+//     * <p>
+//     * 메시지가 수신되면, 지정된 메서드를 호출
+//     * </p>
+//     *
+//     * @param redisMessageSubscriber 메시지를 처리할 사용자 정의 클래스
+//     * @return
+//     */
+//    @Bean
+//    public MessageListenerAdapter messageListenerAdapter(NovelUpdateMessageSubscriber redisMessageSubscriber) {
+//        return new MessageListenerAdapter(redisMessageSubscriber, "onMessage");//RedisMessageSubscriber의 메서드 이름
+//    }
+
+
 }
 
 

--- a/src/main/java/com/ham/netnovel/common/message/NovelUpdateMessageSubscriber.java
+++ b/src/main/java/com/ham/netnovel/common/message/NovelUpdateMessageSubscriber.java
@@ -1,0 +1,101 @@
+package com.ham.netnovel.common.message;
+
+import com.ham.netnovel.common.utils.TypeValidationUtil;
+import com.ham.netnovel.favoriteNovel.service.FavoriteNovelService;
+import com.ham.netnovel.s3.S3Service;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Redis에서 발행된 메시지를 수신하고 처리하는 클래스입니다.
+ */
+@Slf4j
+@Component
+public class NovelUpdateMessageSubscriber implements MessageListener {
+
+    private final SseService sseService;
+
+    private final FavoriteNovelService favoriteNovelService;
+
+    private final S3Service s3Service;
+
+    @Autowired
+    public NovelUpdateMessageSubscriber(SseService sseService, FavoriteNovelService favoriteNovelService, S3Service s3Service) {
+        this.sseService = sseService;
+        this.favoriteNovelService = favoriteNovelService;
+        this.s3Service = s3Service;
+    }
+
+    /**
+     * Redis로부터 수신된 메시지를 처리하는 메서드입니다.
+     *
+     * @param message 수신된 Redis 메시지
+     * @param pattern 수신된 채널의 패턴 (사용되지 않음)
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String messageBody = new String(message.getBody());
+            log.info("Received message: {} from channel: {}", messageBody, channel);
+
+
+            // 메시지 포맷을 'episodeId:episodeContent'로 가정
+            String[] parts = messageBody.split(":", 5);
+
+            Map<String, String> messageMap = getStringStringMap(parts);
+
+            Long novelId = TypeValidationUtil.validateLong(messageMap.get("novelId"));
+            List<String> providerIds = favoriteNovelService.getSubscribedMemberProviderIds(novelId);
+
+            //테스트로그
+//            for (String providerId : providerIds) {
+//                log.info("유저정보 ={}", providerId);
+//                log.info("----------------------------------------");
+//            }
+
+            if (providerIds.isEmpty()) {
+                log.warn("onMessage 경고, 소설에 좋아요를 누른 유저가 없습니다. novelId={}", novelId);
+                return;
+            }
+            //좋아요 누른 유저가 있을경우, SSE 로 메시지 발송
+            sseService.sendMessageToMembers(providerIds, messageMap);
+            // 추가 로직 구현
+        } catch (Exception ex) {
+            log.error("Error processing message: {}", message, ex);
+        }
+
+
+    }
+
+
+    private Map<String, String> getStringStringMap(String[] parts) {
+        if (parts.length == 5) {
+            String novelIdString = parts[0];
+            String episodeIdString = parts[1];
+            String novelTitle = "[업데이트]" + parts[2];
+            String episodeTitle = parts[3];
+            String cloudFrontUrl = s3Service.generateCloudFrontUrl(parts[4], "mini");
+
+            Map<String, String> messageMap = new HashMap<>();
+            messageMap.put("novelId", novelIdString);
+            messageMap.put("episodeId", episodeIdString);
+            messageMap.put("novelTitle", novelTitle);
+            messageMap.put("episodeTitle", episodeTitle);
+            messageMap.put("thumbnailUrl", cloudFrontUrl);
+            return messageMap;
+
+        } else {
+            log.error("onMessage 에러, messageBody 형식이 올바르지 않습니다.");
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/common/message/RedisMessagePublisher.java
+++ b/src/main/java/com/ham/netnovel/common/message/RedisMessagePublisher.java
@@ -1,0 +1,47 @@
+package com.ham.netnovel.common.message;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Redis를 사용하여 메시지를 발행하는 컴포넌트 클래스입니다.
+ * <p>
+ * 이 클래스는 Redis의 Publish/Subscribe 기능을 사용하여 특정 채널에 메시지를 전송합니다.
+ * 이를 통해 Redis를 구독하고 있는 클라이언트들에게 메시지를 실시간으로 전달할 수 있습니다.
+ * </p>
+ */
+@Component
+public class RedisMessagePublisher {
+
+    // RedisTemplate을 사용하여 Redis와 상호작용
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    /**
+     * RedisMessagePublisher 생성자
+     *
+     * @param redisTemplate Redis 서버와의 상호작용을 위한 RedisTemplate 객체
+     */
+    @Autowired
+    public RedisMessagePublisher(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+
+    /**
+     * 주어진 채널에 메시지를 발행합니다.
+     *
+     * <p>이 메서드는 Redis를 사용하여 특정 채널에 메시지를 전송합니다.
+     * Redis의 publish/subscribe 기능을 활용하여 메시지를 구독하고 있는 클라이언트에게 전송됩니다.
+     * </p>
+     *
+     * @param channel 발행할 Redis 채널의 이름
+     * @param message 발행할 메시지의 내용
+     */
+    public void publish(String channel,String message) {
+        redisTemplate.convertAndSend(channel, message);
+    }
+}

--- a/src/main/java/com/ham/netnovel/common/message/SseController.java
+++ b/src/main/java/com/ham/netnovel/common/message/SseController.java
@@ -1,0 +1,42 @@
+package com.ham.netnovel.common.message;
+
+import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.utils.Authenticator;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class SseController {
+    private final SseService sseService;
+    private final Authenticator authenticator;
+
+    public SseController(SseService sseService, Authenticator authenticator) {
+        this.sseService = sseService;
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * 클라이언트의 SSE 연결을 수립합니다.
+     *
+     * <p>
+     * 이 메서드는 클라이언트의 SSE 연결을 생성하여 실시간으로 서버의 이벤트를 수신할 수 있도록 합니다.
+     * 클라이언트의 인증 정보를 기반으로 `SseEmitter` 객체를 생성하고 반환합니다.
+     * </p>
+     * <p>
+     * 인증된 사용자의 이름을 사용하여 `SseEmitter`를 생성하며, 이 `SseEmitter`를 통해 실시간 알림이나 업데이트를 전송할 수 있습니다.
+     * </p>
+     *
+     * @param authentication 클라이언트의 인증 정보를 포함하는 {@link Authentication} 객체입니다.
+     *                       이 객체를 사용하여 클라이언트의 인증 상태를 확인하고 사용자 정보를 얻습니다.
+     * @return `SseEmitter` {@link SseEmitter}객체를 반환합니다. 이 객체는 클라이언트와의 SSE 연결을 나타내며, 서버에서 발생하는 이벤트를 실시간으로 클라이언트에게 전달합니다.
+     */
+
+    @GetMapping("/api/sse/subscribe")
+    public SseEmitter createSseConnection(Authentication authentication) {
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+        return sseService.createConnection(principal.getName());
+//        return sseService.createConnection("test1");
+    }
+}

--- a/src/main/java/com/ham/netnovel/common/message/SseService.java
+++ b/src/main/java/com/ham/netnovel/common/message/SseService.java
@@ -1,0 +1,114 @@
+package com.ham.netnovel.common.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+public class SseService {
+
+    // 유저 ID를 키로, SseEmitter를 값으로 저장
+    private Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+    // 생성자 주입
+    public SseService(Map<String, SseEmitter> sseEmitters) {
+        this.sseEmitters = sseEmitters;
+    }
+
+    // 기본 생성자
+    public SseService() {}
+
+    // 새로운 SSE 연결 생성
+    public SseEmitter createConnection(String providerId) {
+        SseEmitter emitter = new SseEmitter();
+        //유저 provider id로 새로운 emitter 생성
+        sseEmitters.put(providerId, emitter);
+
+        // 연결이 끊어졌을 때 처리
+        emitter.onCompletion(() -> sseEmitters.remove(providerId));
+        emitter.onTimeout(() -> sseEmitters.remove(providerId));
+
+        return emitter;
+    }
+
+    /**
+     * 특정 유저들에게 메시지를 전송합니다.
+     *
+     * <p>주어진 유저들의 `providerId` 목록을 기반으로, 연결된 `SseEmitter` 인스턴스에 메시지를 전송합니다.
+     * 각 `providerId`에 대해 `SseEmitter`를 조회하고, 해당 `SseEmitter`가 유효한 경우에만 메시지를 전송합니다.
+     * 만약 메시지 전송 중 오류가 발생하면 해당 `SseEmitter`를 연결 목록에서 제거합니다.
+     * </p>
+     *
+     * @param memberProviderIds 메시지를 전송할 유저들의 `providerId` 목록입니다. 각 유저의 `SseEmitter`에 메시지를 전송합니다.
+     * @param message           전송할 메시지 내용입니다. 모든 대상 유저에게 동일한 메시지가 전송됩니다.
+     */
+    public void sendMessageToMembers(List<String> memberProviderIds, Map<String, String> message) {
+        log.info("유저에게 메시지 전달");
+        for (String memberProviderId : memberProviderIds) {
+            sendMessageToEmitter(memberProviderId, message);
+        }
+    }
+
+    /**
+     * 특정 클라이언트의 SSE 연결에 메시지를 전송합니다.
+     *
+     * <p>
+     * 이 메서드는 주어진 `providerId`에 해당하는 클라이언트의 `SseEmitter`를 찾아서,
+     * 지정된 메시지를 전송합니다. 메시지 전송 중 오류가 발생하면, 해당 클라이언트의 연결을 제거하고
+     * 로그에 경고 메시지를 기록합니다.
+     * </p>
+     *
+     * @param providerId 메시지를 전송할 대상 클라이언트의 식별자입니다. 이 식별자는 `sseEmitters` 맵에서
+     *                   해당 클라이언트의 `SseEmitter`를 찾는 데 사용됩니다.
+     * @param message 전송할 메시지를 포함하는 `Map` 객체입니다. 이 메시지는 SSE를 통해 클라이언트에게 전달됩니다.
+     *                메시지는 `Map<String, String>` 형태로 전달되며, 클라이언트 측에서 이를 적절히 처리해야 합니다.
+     */
+    private void sendMessageToEmitter(String providerId, Map<String, String> message) {
+        SseEmitter emitter = sseEmitters.get(providerId);
+        if (emitter != null) {
+            try {
+                log.info("유저 정보={}", providerId);
+                emitter.send(SseEmitter.event().name("message").data(message));
+            } catch (IOException e) {
+                log.warn("메시지 전송실패, providerId: {} 연결을 제거합니다.", providerId, e);
+                sseEmitters.remove(providerId);
+            }
+        }
+    }
+    /**
+     * 모든 활성화된 SSE 연결에 메시지를 전송합니다.
+     *
+     * <p>
+     * 이 메서드는 내부적으로 유지 관리되는 모든 `SseEmitter` 객체에 대해 지정된 메시지를 전송합니다.
+     * 각 `SseEmitter`는 클라이언트와의 SSE 연결을 나타내며, 이를 통해 실시간으로 데이터를 전송할 수 있습니다.
+     *  </p>
+     * <p>
+     *
+     * </p>만약 메시지 전송 중 오류가 발생하면, 해당 클라이언트의 `SseEmitter`를 제거하고 로그에 경고 메시지를 기록합니다.
+     *
+     *
+     * @param message 전송할 메시지의 내용입니다. 이 메시지는 SSE를 통해 모든 연결된 클라이언트에게 전송됩니다.
+     */
+    public void sendMessageToAll(String message) {
+//         모든 활성화된 SSE 연결에 메시지 전송
+        sseEmitters.forEach((providerId, emitter) -> {
+                    try {
+                        emitter.send(SseEmitter.event().name("message").data(message));
+                    } catch (IOException e) {
+                        log.warn("Failed to send message to all. Removing providerId: {}", providerId, e);
+                        sseEmitters.remove(providerId); // 오류가 발생하면 해당 유저의 SSE 연결 제거
+                    }
+                }
+        );
+    }
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementService.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementService.java
@@ -1,11 +1,13 @@
 package com.ham.netnovel.episode.service;
 
+import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.episode.dto.EpisodeDetailDto;
 import com.ham.netnovel.episodeViewCount.ViewCountIncreaseDto;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 public interface EpisodeManagementService {
 
@@ -13,13 +15,22 @@ public interface EpisodeManagementService {
 
 
     /**
-     * 에피소드 상세 정보를 전송하는 메서드
+     * 지정된 에피소드의 상세 정보를 반환합니다.
      *
-     * 유저의 에피소드 결제 내역이 존재할경우 에피소드 전송
-     * 문제 없을경우, Redis에 에피소드 조회수 기록 1 증가시킴
-     * @param providerId 에피소드 조회를 요청한 유저
-     * @param episodeId 유저가 요청한 에피소드 ID
-     * @return EpisodeDetailDto 에피소드 상세정보
+     * <ul>
+     *     <li>에피소드가 존재하는지 확인하고, 존재하지 않으면 {@link NoSuchElementException}을 발생시킵니다.</li>
+     *     <li>코인 비용을 검증하고, 유효하지 않으면 {@link IllegalArgumentException}을 발생시킵니다.</li>
+     *     <li>유료 에피소드일 경우 사용자의 결제 내역을 확인하고, 결제 내역이 없으면 {@link EpisodeNotPurchasedException}을 발생시킵니다.</li>
+     *     <li>레디스에서 에피소드 조회수를 1 증가시킵니다.</li>
+     *     <li>{@link EpisodeDetailDto} 객체로 에피소드 정보를 반환합니다.</li>
+     * </ul>
+     *
+     * @param providerId 요청자의 ID
+     * @param episodeId 조회할 에피소드의 ID
+     * @return {@link EpisodeDetailDto} 에피소드 상세 정보
+     * @throws NoSuchElementException 에피소드가 존재하지 않는 경우
+     * @throws EpisodeNotPurchasedException 유료 에피소드에 대한 결제 내역이 없는 경우
+     * @throws IllegalArgumentException 코인 비용이 유효하지 않은 경우
      */
     EpisodeDetailDto getEpisodeDetail(String providerId,Long episodeId);
 

--- a/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelRanking/service/NovelRankingServiceImpl.java
@@ -279,12 +279,22 @@ public class NovelRankingServiceImpl implements NovelRankingService {
 
 
     /**
-     * 소설 랭킹 엔티티 정보를 저장하거나 업데이트하는 메서드
+     * 소설 랭킹 엔티티 정보를 저장하거나 업데이트하는 메서드입니다.
+     * <p>
+     * 이 메서드는 주어진 날짜와 랭킹 주기에 따라 소설 랭킹 정보를 업데이트합니다.
+     * 전달된 DTO 리스트를 기반으로, 기존에 저장된 랭킹 엔티티를 조회하고, 해당 엔티티가 존재하지 않으면 새로 생성합니다.
+     * </p>
+     * <p>
+     * 존재하는 엔티티는 업데이트 후, 변경 사항을 데이터베이스에 저장합니다.
+     * </p>
      *
-     * @param todayDate              오늘 날짜, 즉 랭킹을 업데이트할 기준 날짜
-     * @param rankingPeriod          랭킹 주기 (일간, 주간, 월간 등)
-     * @param novelRankingUpdateDtos 업데이트할 소설 랭킹 정보가 담긴 DTO 리스트
-     * @param existingRankings       기존에 DB에 저장된 랭킹 엔티티가 담긴 Map 객체
+     *
+     *
+     * @param todayDate              오늘 날짜 {@link LocalDate }객체 입니다. 랭킹 정보를 업데이트할 기준 날짜로 사용됩니다.
+     * @param rankingPeriod          랭킹 주기입니다. 예를 들어, 일간, 주간, 월간 등의 주기를 설정하는 {@link RankingPeriod} 객체입니다.
+     * @param novelRankingUpdateDtos 업데이트할 소설 랭킹 정보가 담긴 DTO 리스트입니다. 각 DTO는 소설의 점수와 랭킹 정보를 포함합니다.
+     * @param existingRankings       기존에 데이터베이스에 저장된 랭킹 엔티티를 담고 있는 {@link Map} 객체입니다.
+     *                              이 맵의 키는 소설 ID이며, 값은 해당 소설의 랭킹 엔티티입니다.
      */
     private void saveOrUpdateNovelRankings(LocalDate todayDate,
                                            RankingPeriod rankingPeriod,


### PR DESCRIPTION

# 변경사항
## Redis Pub/Sub 기능, SSE 연결을 통해 유저에게 메시지를 보내는 로직 구현
### RedisMessagePublisher
  - Redis를 사용하여 메시지를 발행하는 컴포넌트 클래스 추가
  - Redis Pub/Sub 기능을 활용하여 특정 채널을 구독 중인 WAS 인스턴스에 메시지를 전송
  - WAS는 해당 인스턴스와 연결된 클라이언트에게 메시지를 전달

  - publish
    - 특정 채널에 메시지를 발행하는 메서드
    - 채널과 메시지를 파라미터로 받아 Redis에서 메시지를 발행

### RedisConfig
  - redisMessageListenerContainer
    - Redis Pub/Sub 메시지 처리를 위한 리스너 컨테이너 추가
    - Bean으로 등록하여 관리
    - 특정 채널에서 수신되는 메시지를 처리하기 위한 리스너를 설정
  - novelUpdateTopic
    - Redis Pub/Sub에서 사용될 소설 업데이트 알림 채널 생성

### NovelUpdateMessageSubscriber
  - Redis에서 발행된 소설 업데이트 메시지를 수신하고 처리하는 클래스 추가

  - onMessage
    - 수신된 메시지를 처리하는 메서드
    - 메시지에 포함된 novelId를 기반으로 해당 소설을 구독 중인 유저에게 메시지 전송

  - getStringStringMap
    - 수신된 메시지를 Map 자료형으로 변환하는 메서드
    - novelId, episodeId, novelTitle, episodeTitle, thumbnailUrl 순서로 저장하여 반환

### SseController
  - SSE 연결을 관리하는 컨트롤러 추가

  - createSseConnection
    - 클라이언트(유저)와 WAS 간의 SSE 연결을 생성하는 API
    - 유저의 providerId 값을 키로 하여 SSE Emitter를 생성하고 WAS에 저장

### SseService
  - SSE 관련 서비스 계층 추가

  - createConnection
    - 유저의 providerId 값으로 새로운 SSE Emitter를 생성하는 메서드
  - sendMessageToMembers
    - 특정 유저에게 메시지를 전송하는 메서드
    - 유저의 providerId 리스트를 파라미터로 받아, 연결된 WAS에 메시지를 전송
    - 메시지 전송 실패 시, SSE 연결을 제거

  - sendMessageToEmitter
    - 특정 클라이언트의 SSE 연결에 메시지를 전송하는 메서드
    - providerId 값을 파라미터로 받아 해당 SSE 연결을 찾아 메시지를 전송

  - sendMessageToAll
    - 모든 활성화된 SSE 연결에 메시지를 전송하는 메서드

### FavoriteNovelRepository
  - findMemberProviderIdsByNovelId
    - 특정 소설에 좋아요를 누른 유저들의 providerId 목록을 반환하는 메서드 추가

### FavoriteNovelService
  - getSubscribedMemberProviderIds
    - 주어진 소설 ID에 대해 좋아요 누른 유저의 providerId를 반환하는 메서드 추가
    - 소설 ID null 체크 후 DB에서 providerId List를 받아와 반환


## 새로운 에피소드 생성 시 알림 전송 로직 추가
### EpisodeServiceImpl
  - publishUpdateMessage
    - Redis를 사용하여 소설 업데이트 메시지를 발송하는 메서드를 추가

  - createEpisode
    - 에피소드 생성 시 publishUpdateMessage 메서드를 호출하여, 업데이트 메시지를 구독한 유저에게 전송하도록 로직 구현