### PR TITLE
QueryDSL을 사용한 소설 검색 동적 쿼리 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/novel/data/NovelSortOrder.java
+++ b/src/main/java/com/ham/netnovel/novel/data/NovelSortOrder.java
@@ -1,0 +1,12 @@
+package com.ham.netnovel.novel.data;
+
+/*
+Novel 쿼리문에 사용될 Enum 타입 필터, 클라이언트에서 지정
+ */
+public enum NovelSortOrder {
+
+    VIEWCOUNT,
+    FAVORITES,
+    LATEST;
+
+}

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -27,11 +28,21 @@ public class NovelListDto {//랭킹 등 리스트로 소설정보를 전달시 �
     private String authorName; //작가 닉네임
 
     @NotNull
-    private Integer favoriteCount; //선호작 수
-
-    @NotNull
     private List<TagDataDto> tags; //작품 태그
 
-    private String thumbnailUrl;
+
+    @NotNull
+    private Integer totalFavorites; //총좋아요수
+
+
+    private Long totalView;    //총조회수
+
+    private LocalDateTime latestUpdateAt;//최근업데이트시간
+
+
+    private String thumbnailUrl;//섬네일 URL
+
+
+
 
 }

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
@@ -8,7 +8,19 @@ import java.util.List;
 
 public interface NovelSearchRepository {
 
-    List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder, Pageable pageable);
+    /**
+     * 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회합니다.
+     * <p>
+     * 이 메서드는 소설의 기본 정보를 조회하고, 각 소설에 대해 태그 정보를 추가로 조회하여 최종 결과를 반환합니다.
+     * </p>
+     *
+     * @param novelSortOrder {@link NovelSortOrder} 소설을 정렬할 기준을 나타내는 열거형 객체
+     * @param pageable       {@link Pageable} 페이지 정보를 포함하는 객체 (페이지 번호, 페이지 크기 등)
+     * @return {@link List<NovelListDto>} 정렬 기준과 페이지 정보에 따라 조회된 소설 목록을 포함하는 리스트
+     */
+    List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder,
+                                                    Pageable pageable,
+                                                    List<Long> tagIds);
 
 
 

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
@@ -1,0 +1,15 @@
+package com.ham.netnovel.novel.repository;
+
+import com.ham.netnovel.novel.data.NovelSortOrder;
+import com.ham.netnovel.novel.dto.NovelListDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface NovelSearchRepository {
+
+    List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder, Pageable pageable);
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
@@ -27,27 +27,18 @@ public class NovelSearchRepositoryImpl implements NovelSearchRepository {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-
-    /**
-     * 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회합니다.
-     *<p>
-     * 이 메서드는 소설의 기본 정보를 조회하고, 각 소설에 대해 태그 정보를 추가로 조회하여 최종 결과를 반환합니다.
-     *</p>
-     *
-     *
-     * @param novelSortOrder {@link NovelSortOrder} 소설을 정렬할 기준을 나타내는 열거형 객체
-     * @param pageable {@link Pageable} 페이지 정보를 포함하는 객체 (페이지 번호, 페이지 크기 등)
-     * @return {@link List<NovelListDto>} 정렬 기준과 페이지 정보에 따라 조회된 소설 목록을 포함하는 리스트
-     */
     @Override
-    public List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder, Pageable pageable) {
+    public List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder,
+                                                           Pageable pageable,
+                                                           List<Long> tagIds) {
         QNovelMetaData novelMetaData = QNovelMetaData.novelMetaData;
         QNovel novel = QNovel.novel;
+        QNovelTag novelTag = QNovelTag.novelTag;
         // 파라미터로 받은 조건으로 ORDER BY 조건 생성
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(novelSortOrder, novelMetaData);
 
-        //조건을 통해 찾은 Novel 엔티티를 DTO로 변환하여 반환
-        List<NovelListDto> novelListDtos = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
+        //조건을 통해 찾은 Novel 엔티티를 DTO로 변환하여 반환하는 쿼리문 생성
+        var query = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
                         novel.id.as("id"),
                         novel.title.as("title"),
                         novelMetaData.totalFavorites.as("totalFavorites"),
@@ -55,11 +46,23 @@ public class NovelSearchRepositoryImpl implements NovelSearchRepository {
                         novelMetaData.latestEpisodeAt.as("latestUpdateAt"),
                         novel.thumbnailFileName.as("thumbnailUrl")))
                 .from(novel)
-                .join(novel.novelMetaData)
-                .offset(pageable.getOffset())//페이지 시작 지점, 0부터 시작함
+                .join(novel.novelMetaData);//메타 데이터와 JOIN
+
+
+        // 유저가 선택한 Tag가 있을 경우, Tag 조건을 쿼리 검색 AND 조건으로 추가
+        if (!(tagIds == null) && !tagIds.isEmpty()) {
+            query.leftJoin(novel.novelTags, novelTag)//left join으로 tag 정보가 없어도 Novel 레코드 반환
+                    .where(novelTag.tag.id.in(tagIds))//유저가 선택한 tag id와 관계가 있는 엔티티만 가져옴
+                    .groupBy(novel.id)//소설로 그룹화
+                    .having(novelTag.tag.id.in(tagIds).count().eq((long) tagIds.size()));
+        }
+
+        //페이지네이션 및 정렬조건 추가
+        List<NovelListDto> novelListDtos = query.offset(pageable.getOffset())//페이지 시작 지점, 0부터 시작함
                 .limit(pageable.getPageSize())//한페이지에 보여줄 데이터의 개수
                 .orderBy(orderSpecifier)
                 .fetch();
+
 
         //소설 DTO에 태그 정보를 추가
         for (NovelListDto dto : novelListDtos) {
@@ -95,14 +98,13 @@ public class NovelSearchRepositoryImpl implements NovelSearchRepository {
 
     /**
      * 주어진 정렬 기준에 따라 {@link OrderSpecifier} 객체를 생성합니다.
-     *<p>
-     *   이 메서드는 소설 정렬 기준에 맞춰 정렬 조건을 설정하여 {@link OrderSpecifier}를 반환합니다.
-     *   이는 쿼리문에서 ORDER BY 조건을 추가할때 사용합니다.
-     *</p>
-     *
+     * <p>
+     * 이 메서드는 소설 정렬 기준에 맞춰 정렬 조건을 설정하여 {@link OrderSpecifier}를 반환합니다.
+     * 이는 쿼리문에서 ORDER BY 조건을 추가할때 사용합니다.
+     * </p>
      *
      * @param novelSortOrder {@link NovelSortOrder} 소설 정렬 기준을 나타내는 열거형
-     * @param novelMetaData {@link QNovelMetaData} 소설 메타데이터 엔티티를 나타내는 QueryDSL Q 클래스
+     * @param novelMetaData  {@link QNovelMetaData} 소설 메타데이터 엔티티를 나타내는 QueryDSL Q 클래스
      * @return {@link OrderSpecifier} 주어진 정렬 기준에 따라 설정된 정렬 조건
      * @throws IllegalArgumentException 지원되지 않는 정렬 기준이 제공된 경우 발생
      */

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
@@ -1,0 +1,122 @@
+package com.ham.netnovel.novel.repository;
+
+import com.ham.netnovel.novel.QNovel;
+import com.ham.netnovel.novel.data.NovelSortOrder;
+import com.ham.netnovel.novel.dto.NovelListDto;
+import com.ham.netnovel.novelMetaData.QNovelMetaData;
+import com.ham.netnovel.novelTag.QNovelTag;
+import com.ham.netnovel.tag.QTag;
+import com.ham.netnovel.tag.dto.TagDataDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class NovelSearchRepositoryImpl implements NovelSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Autowired
+    public NovelSearchRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    /**
+     * 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회합니다.
+     *<p>
+     * 이 메서드는 소설의 기본 정보를 조회하고, 각 소설에 대해 태그 정보를 추가로 조회하여 최종 결과를 반환합니다.
+     *</p>
+     *
+     *
+     * @param novelSortOrder {@link NovelSortOrder} 소설을 정렬할 기준을 나타내는 열거형 객체
+     * @param pageable {@link Pageable} 페이지 정보를 포함하는 객체 (페이지 번호, 페이지 크기 등)
+     * @return {@link List<NovelListDto>} 정렬 기준과 페이지 정보에 따라 조회된 소설 목록을 포함하는 리스트
+     */
+    @Override
+    public List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder, Pageable pageable) {
+        QNovelMetaData novelMetaData = QNovelMetaData.novelMetaData;
+        QNovel novel = QNovel.novel;
+        // 파라미터로 받은 조건으로 ORDER BY 조건 생성
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(novelSortOrder, novelMetaData);
+
+        //조건을 통해 찾은 Novel 엔티티를 DTO로 변환하여 반환
+        List<NovelListDto> novelListDtos = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
+                        novel.id.as("id"),
+                        novel.title.as("title"),
+                        novelMetaData.totalFavorites.as("totalFavorites"),
+                        novelMetaData.totalViews.as("totalView"),
+                        novelMetaData.latestEpisodeAt.as("latestUpdateAt"),
+                        novel.thumbnailFileName.as("thumbnailUrl")))
+                .from(novel)
+                .join(novel.novelMetaData)
+                .offset(pageable.getOffset())//페이지 시작 지점, 0부터 시작함
+                .limit(pageable.getPageSize())//한페이지에 보여줄 데이터의 개수
+                .orderBy(orderSpecifier)
+                .fetch();
+
+        //소설 DTO에 태그 정보를 추가
+        for (NovelListDto dto : novelListDtos) {
+            loadTagsForNovel(dto);
+        }
+        //소설 DTO List 반환
+        return novelListDtos;
+    }
+
+    /**
+     * 주어진 소설 DTO에 대해 태그 정보를 조회하여 설정합니다.
+     *
+     * <p>파라미터로 받은 소설에 관련된 태그를 조회하여 해당 소설의 DTO에 태그 정보를 추가합니다.</p>
+     *
+     * @param dto {@link NovelListDto} 태그 정보를 설정할 소설 DTO
+     */
+    private void loadTagsForNovel(NovelListDto dto) {
+
+        QNovelTag novelTag = QNovelTag.novelTag;
+        QTag tag = QTag.tag;
+
+        //소설의 태그들을 DTO로 변환하여, NovelListDto 에 할당
+        List<TagDataDto> tagDataDtos = jpaQueryFactory.select(Projections.bean(TagDataDto.class,
+                        tag.id.as("id"),
+                        tag.name.as("name"),
+                        tag.status.as("status")))
+                .from(novelTag)
+                .join(tag).on(tag.id.eq(novelTag.tag.id))//NovelTag와 JOIN
+                .where(novelTag.novel.id.eq(dto.getId()))
+                .fetch();
+        dto.setTags(tagDataDtos);
+    }
+
+    /**
+     * 주어진 정렬 기준에 따라 {@link OrderSpecifier} 객체를 생성합니다.
+     *<p>
+     *   이 메서드는 소설 정렬 기준에 맞춰 정렬 조건을 설정하여 {@link OrderSpecifier}를 반환합니다.
+     *   이는 쿼리문에서 ORDER BY 조건을 추가할때 사용합니다.
+     *</p>
+     *
+     *
+     * @param novelSortOrder {@link NovelSortOrder} 소설 정렬 기준을 나타내는 열거형
+     * @param novelMetaData {@link QNovelMetaData} 소설 메타데이터 엔티티를 나타내는 QueryDSL Q 클래스
+     * @return {@link OrderSpecifier} 주어진 정렬 기준에 따라 설정된 정렬 조건
+     * @throws IllegalArgumentException 지원되지 않는 정렬 기준이 제공된 경우 발생
+     */
+    private OrderSpecifier<?> getOrderSpecifier(NovelSortOrder novelSortOrder,
+                                                QNovelMetaData novelMetaData) {
+        //novelSortOrder 조건에 따라, ORDER BY 조건 반환
+        return switch (novelSortOrder) {
+            case LATEST -> new OrderSpecifier<>(Order.DESC, novelMetaData.latestEpisodeAt);
+            case VIEWCOUNT -> new OrderSpecifier<>(Order.DESC, novelMetaData.totalViews);
+            case FAVORITES -> new OrderSpecifier<>(Order.DESC, novelMetaData.totalFavorites);
+            default -> throw new IllegalArgumentException("Unsupported filter: " + novelSortOrder);
+
+        };
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -53,6 +53,7 @@ public interface NovelService {
      */
     NovelInfoDto getNovelInfo(Long novelId);
 
+    //ToDo 메서드 기능 통합 후 삭제
     /**
      * DB의 저장된 모든 Novel 리스트를 최신순으로 가져오는 메서드.
      * 페이지 단위로 일부 리스트만 가져온다.
@@ -110,7 +111,7 @@ public interface NovelService {
      * @throws IllegalArgumentException 소설을 찾을 수 없거나 요청자와 소설 작가가 일치하지 않을 때 발생합니다.
      * @throws ServiceMethodException 파일 업로드나 소설 엔티티 저장 중 오류 발생 시 발생합니다.
      */
-    boolean updateNovelThumbnail(MultipartFile file, Long novelId, String providerId);
+    boolean updateNovelThumbnail(MultipartFile file, Long novelId, java.lang.String providerId);
 
 
     /**
@@ -148,7 +149,10 @@ public interface NovelService {
      *
      * <p>
      * 데이터베이스에서 소설의 ID와 해당 소설의 최근 업데이트 날짜를 조회한 후,
-     * 이를 Map 형태로 반환합니다. Map의 키는 소설 ID(Long)이고, 값은최근 업데이트 날짜(LocalDateTime)입니다.
+     * 이를 Map 형태로 반환합니다.
+     * </p>
+     * <p>
+     * Map의 키는 소설 ID(Long)이고, 값은최근 업데이트 날짜(LocalDateTime)입니다.
      * </p>
      *
      * @param pageable 페이징 정보를 담고 있는 {@link Pageable} 객체
@@ -157,5 +161,24 @@ public interface NovelService {
      */
     Map<Long, LocalDateTime> getNovelWithLatestEpisodeCreateTime(Pageable pageable);
 
+
+    /**
+     * 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회하는 메서드입니다.
+     *
+     * <p>
+     * 이 메서드는 기본적으로 소설 목록을 조회수 기준으로 정렬합니다.
+     * </p>
+     * <p>
+     * 사용자가 제공한 정렬 기준에 따라, 소설 목록을 좋아요 순 또는 최신순으로 정렬할 수 있습니다.
+     * 조회된 소설 목록의 썸네일 URL은 S3 서비스의 CloudFront URL로 변환됩니다.
+     * </p>
+     * @param sortOrder 소설 목록의 정렬 기준을 나타내는 문자열입니다.
+     *                  "favorites"는 좋아요 순, "latest"는 최신순, 기본값은 "view"로 조회수 순입니다.
+     * @param pageable 페이지 정보 및 페이징 조건을 포함하는 {@link Pageable} 객체입니다.
+     *
+     * @return List<NovelListDto> 소설 목록을 포함한 DTO 리스트를 반환합니다.
+     *         각 소설의 썸네일 URL은 CloudFront URL로 변환되어 반환됩니다.
+     */
+    List<NovelListDto> getNovelsBySearchCondition(String sortOrder, Pageable pageable, List<Long> tagIds);
 
 }


### PR DESCRIPTION
# 변경사항

## QueryDSL 태그 검색 조건 추가, 컨트롤러 API, 서비스 계층 메서드 추가
###  NovelService
  - getNovelsBySearchCondition
    - 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회하는 메서드 추가
    - 파라미터에 따라 정렬조건 변경, 디폴드값은 조회수

###NovelController
  - getNovelsBySearchCondition
    - 유저가 선택한 검색 조건에 따라 소설을 조회하는 API 추가
    - 파라미터로 정렬조건(좋아요순, 조회수순, 최신순), 페이지네이션정보, 태그ID 리스트를 받아 서비스계층에 전달
    - pageSize 는 200으로 제한

### NovelListDto
  - 멤버변수 latestUpdateAt, totalView 추가
  - favoriteCount ->totalFavorites 변수명 변경

###NovelSearchRepository
  - findNovelsBySearchConditions
    - 주석 설명 추가
    - 태그 검색을 위한 List<Long> tagIds 파라미터 추가

### NovelSearchRepositoryImpl
  - 유저가 선택한 tag를 AND 조건으로 검색하는 쿼리문 추가



## QueryDSL 기반 Novel 검색 기능 추가
- NovelSearchRepository
  - QueryDSL을 이용하여 동적으로 Novel 을 찾는 DAO 인터페이스 추가

### NovelSearchRepositoryImpl
  - NovelSearchRepository를 상속받는 구현체 클래스 추가

  - findNovelsBySearchConditions 메서드 추가
    - 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회

  - loadTagsForNovel 메서드 추가
    - 파라미터로 받은 소설 DTO에 태그 정보를 설정
    - 태그는 TagDataDto로 변환하여 List로 소설 DTO에 설정

  - getOrderSpecifier 메서드 추가
    - 주어진 조건에 따라 OrderSpecifier 객체를 생성
    - 정렬 기준을 최신순, 조회수순, 좋아요순으로 동적 할당

### NovelSortOrder
  - 소설의 정렬 조건을 제한하기 위한 enum 클래스 추가
  - VIEWCOUNT, FAVORITES, LATEST 상수를 가짐
