### PR TITLE
작품, 에피소드 생성 api 구현 및 402 PaymentRequired 응답 처리

### DIFF
--- a/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/EpisodeNotPurchasedException.java
@@ -1,22 +1,23 @@
 package com.ham.netnovel.common.exception;
 
 import com.ham.netnovel.coinCostPolicy.dto.CostPolicyResponseDto;
+import com.ham.netnovel.episode.dto.EpisodePaymentDto;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.Getter;
 
+@Getter
 public class EpisodeNotPurchasedException extends RuntimeException{//에피소드 결제 내역이 없을때 예외처리
 
-    @Getter
-    private final Integer coinCost; // 결제 실패 시, 응답할 가격 정책 정보
+    private final EpisodePaymentDto paymentInfo; // 결제 실패 시, 응답할 가격 정책 정보
 
 
-    public EpisodeNotPurchasedException(String message, Integer coinCost) {
+    public EpisodeNotPurchasedException(String message, EpisodePaymentDto paymentInfo) {
         super(message);
-        this.coinCost = coinCost;
+        this.paymentInfo = paymentInfo;
     }
 
-    public EpisodeNotPurchasedException(String message, Throwable cause, Integer coinCost) {
+    public EpisodeNotPurchasedException(String message, Throwable cause, EpisodePaymentDto paymentInfo) {
         super(message, cause);
-        this.coinCost = coinCost;
+        this.paymentInfo = paymentInfo;
     }
 }

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -4,18 +4,22 @@ import com.ham.netnovel.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.PageableUtil;
+import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import com.ham.netnovel.episode.data.IndexDirection;
+import com.ham.netnovel.episode.dto.EpisodeCreateDto;
 import com.ham.netnovel.episode.dto.EpisodeDetailDto;
 import com.ham.netnovel.episode.dto.EpisodeListInfoDto;
 import com.ham.netnovel.episode.dto.EpisodeListItemDto;
 import com.ham.netnovel.episode.service.EpisodeManagementService;
 import com.ham.netnovel.episode.service.EpisodeService;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -51,11 +55,7 @@ public class EpisodeController {
             EpisodeDetailDto episodeDetail = episodeManagementService.getEpisodeDetail(principal.getName(), episodeId);
             return ResponseEntity.ok(episodeDetail);
         } catch (EpisodeNotPurchasedException e) {
-            //실패 시 해당하는 코인 정책 반환
-            HashMap<String, Integer> respBody = new HashMap<>() {{
-                put("coinCost", e.getCoinCost());
-            }};
-            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(respBody);
+            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(e.getPaymentInfo());
         }
     }
 
@@ -77,10 +77,7 @@ public class EpisodeController {
         }
         catch (EpisodeNotPurchasedException e) {
             //실패 시 해당하는 코인 정책 반환
-            HashMap<String, Integer> respBody = new HashMap<>() {{
-                put("coinCost", e.getCoinCost());
-            }};
-            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(respBody);
+            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(e.getPaymentInfo());
         }
     }
 

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodePaymentDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodePaymentDto.java
@@ -1,0 +1,23 @@
+package com.ham.netnovel.episode.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+@Builder
+@Setter
+@Getter
+@ToString
+public class EpisodePaymentDto {
+    @NotNull
+    private Long episodeId;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private Integer coinCost;
+}

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
@@ -8,6 +8,7 @@ import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.episode.EpisodeRepository;
 import com.ham.netnovel.episode.data.IndexDirection;
 import com.ham.netnovel.episode.dto.EpisodeDetailDto;
+import com.ham.netnovel.episode.dto.EpisodePaymentDto;
 import com.ham.netnovel.episodeViewCount.ViewCountIncreaseDto;
 import com.ham.netnovel.episodeViewCount.service.EpisodeViewCountService;
 import com.ham.netnovel.novel.Novel;
@@ -57,7 +58,12 @@ public class EpisodeManagementServiceImpl implements EpisodeManagementService {
             //결제 내역이 없을경우 EpisodeNotPurchasedException 로 던짐
             if (!result) {
                 //EpisodeNotPurchasedException 에 coinCost 정보도 함께 전달
-                throw new EpisodeNotPurchasedException("에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId, coinCost);
+                throw new EpisodeNotPurchasedException(
+                        "에피소드 결제 내역 없음, providerId = " + providerId + ", episodeId = " + episodeId,
+                        EpisodePaymentDto.builder().episodeId(episode.getId())
+                                .title(episode.getTitle())
+                                .coinCost(coinCost)
+                                .build());
             }
         }
 

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -136,8 +136,8 @@ public class NovelController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
-    @PostMapping
-    public ResponseEntity<String> createNovel(@Valid @RequestBody NovelCreateDto reqBody,
+    @PostMapping("/novels")
+    public ResponseEntity<?> createNovel(@Valid @RequestBody NovelCreateDto reqBody,
                                               BindingResult bindingResult,
                                               Authentication authentication) {
         //NovelCreateDto Validation 예외 처리
@@ -153,7 +153,9 @@ public class NovelController {
         //DTO에 유저 정보(providerId) 값 저장
         reqBody.setAccessorProviderId(principal.getName());
 
-        return ResponseEntity.ok("작품 생성 완료.");
+        Long createdId = novelService.createNovel(reqBody);
+
+        return ResponseEntity.ok(createdId);
     }
 
     /**

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -261,9 +261,11 @@ public class NovelController {
      * @return 성공 시 HTTP 200과 "섬네일 변경 성공!" 메시지, 실패 시 HTTP 500과 "섬네일 변경 실패." 메시지를 반환합니다.
      */
     @PostMapping("/novels/{novelId}/thumbnail")
-    public ResponseEntity<?> uploadNovelThumbnail(@PathVariable("novelId") Long urlNovelId
-            , MultipartFile multipartFile//업로드할 섬네일 파일
-            , Authentication authentication) {
+    public ResponseEntity<?> uploadNovelThumbnail(
+            @PathVariable("novelId") Long urlNovelId,
+            @RequestParam("file") MultipartFile multipartFile, //업로드할 섬네일 파일
+            Authentication authentication
+    ) {
         //유저 인증. 없으면 badRequest 응답. 있으면 CustomOAuth2User 타입캐스팅.
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
 

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -126,6 +126,24 @@ public class NovelController {
 
         return ResponseEntity.ok(rankedNovels);//소설 정보 전송
     }
+    /**
+     * 유저가 집핍하는 소설 리스트를 전송하는 API
+     *
+     * @param authentication 유저의 인증 정보
+     * @return ResponseEntity 유저가 소유한 소설 리스트를 담은 응답 객체
+     */
+    @GetMapping("/members/me/novels")
+    public ResponseEntity<?> getMyWorks(Authentication authentication) {
+
+        //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        List<NovelInfoDto> novels = novelService.getNovelsByAuthor(principal.getName());
+
+        //정보 전송
+        return ResponseEntity.ok(novels);
+
+    }
 
 
     /**

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
@@ -19,6 +19,5 @@ public class NovelCreateDto {
     @Size(max = 300)
     private String description;
 
-    @NotNull
     private String accessorProviderId; //실행자 유저 ID
 }

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
@@ -13,8 +13,8 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
 
     @Query("select n from Novel n " +
             "join fetch n.author m " +
-            "where m.id = :providerId")
-    List<Novel> findNovelsByMember(@Param("providerId") String providerId);
+            "where m.id = :memberId")
+    List<Novel> findNovelsByMember(@Param("memberId") Long id);
 
 
 

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -31,8 +31,9 @@ public interface NovelService {
     /**
      * 유저가 생성한 Novel을 DB 저장.
      * @param novelCreateDto 생성 정보가 담긴 dto
+     * @return 생성한 episode id 값
      */
-    void createNovel(NovelCreateDto novelCreateDto);
+    Long createNovel(NovelCreateDto novelCreateDto);
 
     /**
      * DB에 저장된 Novel 데이터 변경.

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -26,7 +26,7 @@ public interface NovelService {
      * @param providerId 유저 id
      * @return Optional<Novel>
      */
-    List<Novel> getNovelsByAuthor(String providerId);
+    List<NovelInfoDto> getNovelsByAuthor(String providerId);
 
     /**
      * 유저가 생성한 Novel을 DB 저장.

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -58,8 +58,14 @@ public class NovelServiceImpl implements NovelService {
     }
 
     @Override
-    public List<Novel> getNovelsByAuthor(java.lang.String providerId) {
-        return novelRepository.findNovelsByMember(providerId);
+    public List<NovelInfoDto> getNovelsByAuthor(String providerId) {
+        //Member Entity 조회 -> Author 검증
+        Member author = memberService.getMember(providerId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 Member 입니다."));
+
+        return novelRepository.findNovelsByMember(author.getId()).stream()
+                .map(this::convertEntityToInfoDto)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -64,7 +64,7 @@ public class NovelServiceImpl implements NovelService {
 
     @Override
     @Transactional
-    public void createNovel(NovelCreateDto novelCreateDto) {
+    public Long createNovel(NovelCreateDto novelCreateDto) {
         log.info("Novel 생성 = {}", novelCreateDto.toString());
 
         //Member Entity 조회 -> Author 검증
@@ -80,12 +80,12 @@ public class NovelServiceImpl implements NovelService {
                     .type(NovelType.ONGOING)
                     .status(NovelStatus.ACTIVE)
                     .build();
-            novelRepository.save(targetNovel);
+            Novel saved = novelRepository.save(targetNovel);
+            return saved.getId();
         } catch (Exception ex) {
             //나머지 예외처리
             throw new ServiceMethodException("createNovel 메서드 에러 발생", ex.getCause());
         }
-
     }
 
     @Override

--- a/src/test/java/com/ham/netnovel/DBRecordTest.java
+++ b/src/test/java/com/ham/netnovel/DBRecordTest.java
@@ -29,7 +29,6 @@ import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.member.dto.MemberCreateDto;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.novel.Novel;
-import com.ham.netnovel.novel.NovelRepository;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
 import com.ham.netnovel.novel.service.NovelService;
 import com.ham.netnovel.novelAverageRating.NovelAverageRatingRepository;

--- a/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
+++ b/src/test/java/com/ham/netnovel/novel/service/NovelServiceImplTest.java
@@ -41,16 +41,13 @@ class NovelServiceImplTest {
                 .description("Duis ea aliquip dolor sit dolore ut adipisicing eu tempor.")
                 .accessorProviderId(authorId)
                 .build();
-//        log.info(createDto.toString());
 
         // when
-        novelService.createNovel(createDto);
+        Long novelId = novelService.createNovel(createDto);
 
         // then
-        List<Novel> novels = novelService.getNovelsByAuthor(authorId);
-        Novel recentCreated = novels.get(novels.size() - 1);
-        Assertions.assertThat(recentCreated.getTitle()).isEqualTo(createDto.getTitle());
-        Assertions.assertThat(recentCreated.getDescription()).isEqualTo(createDto.getDescription());
+        Optional<Novel> novel = novelService.getNovel(novelId);
+        Assertions.assertThat(novel.isPresent()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
# [refactor: Novel 생성 로직 리팩토링](https://github.com/Ham-Novel/netnovel/commit/e8c0d03d45991c62aed96d4752554c5c57a56007) 

- NovelController api url 작성
- NovelCreateDto accessorProviderId Nullable 변경, 해당 프로퍼티는 인증 과정에서 처리
- 변경 사항 Test 코드 작성

# [feat: 멤버가 생성한 Novel 리스트 가져오는 api 구현](https://github.com/Ham-Novel/netnovel/commit/e7e1562f82d37d2255240c3fa080ff3aba7f4922) 

- NovelController api '/members/me/novels' 구현
- NovelRepository findNovelsByMember() 버그 픽스
- NovelService getNovelsByAuthor() NovelInfoDto 리스트 반환 및 예외 처리

# [refactor: NovelController 내 uploadNovelThumbnail() MultipartFile 파라미터](https://github.com/Ham-Novel/netnovel/commit/ba14dde80bdc88e48acf86608d44d81880f3d3a2) RequestParam 적용

# [feat: episode 세부 정보 api, 402 실패 시 에피소드 일부 정보와 결제 정보 반환](https://github.com/Ham-Novel/netnovel/commit/fac4abfbcdc88a0d195f9e992a162b5cc412e0a3) 

- EpisodePaymentDto 에피소드 정보 일부와 결제 정보 담은 dto
- EpisodeNotPurchasedException 결제 실패 예외에 EpisodePaymentDto 담아 catch 문에 전달

# [fix: NovelRepository findNovelsByMember() member id가 아니라 provider id로 검색하는 버그 해결