### PR TITLE
에피소드 CRUD 로직, QueryDSL 에피소드 검색 로직(DAO) 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/service/FavoriteNovelServiceImpl.java
@@ -38,9 +38,9 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService {
     public Boolean toggleFavoriteNovel(String providerId, Long novelId) {
         //유저, 작품 레코드 DB 검증
         Member member = memberService.getMember(providerId)
-                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Member 입니다."));
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Member 입니다."+providerId));
         Novel novel = novelService.getNovel(novelId)
-                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Novel 입니다."));
+                .orElseThrow(() -> new NoSuchElementException("toggleFavoriteNovel() Error : 존재하지 않는 Novel 입니다."+novelId));
 
         try {
             FavoriteNovelId id = new FavoriteNovelId(member.getId(), novel.getId());
@@ -99,6 +99,7 @@ public class FavoriteNovelServiceImpl implements FavoriteNovelService {
         }
 
     }
+
 
 
 }

--- a/src/main/java/com/ham/netnovel/common/utils/ValidationErrorHandler.java
+++ b/src/main/java/com/ham/netnovel/common/utils/ValidationErrorHandler.java
@@ -1,11 +1,14 @@
 package com.ham.netnovel.common.utils;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
 import java.util.List;
 
 
+@Slf4j
 public class ValidationErrorHandler {
 
     //static으로 인스턴스화 하지 않고 사용
@@ -14,5 +17,17 @@ public class ValidationErrorHandler {
            return bindingResult.getFieldErrors().stream()
                     .map(FieldError::getDefaultMessage)
                     .toList();
+    }
+
+
+    public static List<String> handleValidationErrorMessages(BindingResult bindingResult,String methodName ) {
+
+        //에러 메시지 List로 추출
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .toList();
+        log.error("{} }API 에러발생={}", methodName,errorMessages);
+        //에러 메시지 반환
+        return errorMessages;
     }
 }

--- a/src/main/java/com/ham/netnovel/episode/EpisodeCustomRepository.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeCustomRepository.java
@@ -1,0 +1,12 @@
+package com.ham.netnovel.episode;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface EpisodeCustomRepository {
+
+
+    List<Episode> findEpisodesByConditions(String sortBy, Long novelId , Pageable pageable);
+
+}

--- a/src/main/java/com/ham/netnovel/episode/EpisodeCustomRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.ham.netnovel.episode;
+
+import com.ham.netnovel.novel.QNovel;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.JPQLQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public class EpisodeCustomRepositoryImpl implements EpisodeCustomRepository {
+
+    private final JPQLQueryFactory jpaQueryFactory;
+
+    public EpisodeCustomRepositoryImpl(JPQLQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    @Override
+    public List<Episode> findEpisodesByConditions(String sortBy, Long novelId, Pageable pageable) {
+        QNovel novel = QNovel.novel;
+        QEpisode episode = QEpisode.episode;
+
+
+        return jpaQueryFactory.select(episode)
+                .from(episode)
+                .join(novel).on(episode.novel.id.eq(novel.id))
+                .where(episode.novel.id.eq(novelId))
+                .orderBy(getOrderSpecifier(sortBy))
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortBy) {
+        QEpisode episode = QEpisode.episode;
+
+        return switch (sortBy) {
+            case "recent" -> new OrderSpecifier<>(Order.DESC, episode.createdAt);
+            case "initial" -> new OrderSpecifier<>(Order.ASC, episode.createdAt);
+            default -> throw new IllegalArgumentException("필터가 올바르지 않습니다, 파라미터 :  " + sortBy);
+
+        };
+    }
+}

--- a/src/main/java/com/ham/netnovel/episode/EpisodeRepository.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeRepository.java
@@ -3,12 +3,10 @@ package com.ham.netnovel.episode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
-public interface EpisodeRepository extends JpaRepository<Episode,Long> {
+public interface EpisodeRepository extends JpaRepository<Episode,Long>, EpisodeCustomRepository {
 
     @Query("select e from Episode e " +
             "join fetch e.novel n " +
@@ -16,21 +14,6 @@ public interface EpisodeRepository extends JpaRepository<Episode,Long> {
             "and e.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
             "order by e.createdAt desc") //최신순
     List<Episode> findByNovel(@Param("novelId") Long novelId);
-
-
-    @Query("select e from Episode e " +
-            "join fetch e.novel n " +
-            "where n.id = :novelId " +
-            "and e.status = 'ACTIVE' " //ACTIVE 상태인 댓글만 가져옴
-            +"order by e.createdAt desc") //최신순
-    List<Episode> findByNovelOrderByCreatedAtDesc(@Param("novelId") Long novelId, Pageable pageable);
-
-    @Query("select e from Episode e " +
-            "join fetch e.novel n " +
-            "where n.id = :novelId " +
-            "and e.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
-            "order by e.createdAt asc") //최초순
-    List<Episode> findByNovelOrderByCreatedAtAsc(@Param("novelId") Long novelId, Pageable pageable);
 
     @Query("SELECT e FROM Episode e " +
             "WHERE e.novel.id = :novelId AND e.chapter = :chapter")

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeCreateDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeCreateDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.episode.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -11,15 +12,19 @@ import lombok.*;
 @AllArgsConstructor
 public class EpisodeCreateDto {
 
-    @NotNull
     private Long novelId;
 
     @NotNull
+    @Size(min = 1, max = 100,message = "제목은 최대 100 자까지 작성 가능합니다!")//최대 100자까지 제한
     private String title;
 
     @NotNull
-    private String content;
+    @Size(min = 1, max = 10000,message = "에피소드는 최대 10000 자까지 작성 가능합니다!")//최대 10000자까지 제한
+    private String content;//내용
 
     @NotNull
     private Long costPolicyId;
+
+
+    private String providerId;//에피소드 생성 요청자 정보
 }

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeDeleteDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeDeleteDto.java
@@ -15,4 +15,6 @@ public class EpisodeDeleteDto {
     @NotNull
     private Long episodeId;
 
+    private String providerId;
+
 }

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeUpdateDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.episode.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,12 +13,18 @@ import lombok.ToString;
 @Builder
 public class EpisodeUpdateDto {
 
-    @NotNull
     private Long episodeId;
 
+    @NotNull
+    @Size(min = 1, max = 100,message = "제목은 최대 100 자까지 작성 가능합니다!")//최대 100자까지 제한
     private String title;
 
+    @NotNull
+    @Size(min = 1, max = 10000,message = "에피소드는 최대 10000 자까지 작성 가능합니다!")//최대 10000자까지 제한
     private String content;
 
+    @NotNull
     private Long costPolicyId;
+
+    private String providerId;//에피소드 업데이트 요청자 정보
 }

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeService.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeService.java
@@ -1,10 +1,12 @@
 package com.ham.netnovel.episode.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.episode.dto.*;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public interface EpisodeService {
@@ -24,7 +26,22 @@ public interface EpisodeService {
     List<Episode> getEpisodeList(List<Long> episodeIds);
 
     /**
-     * Episode를 DB에 생성하는 메서드
+     * 새로운 에피소드를 생성합니다.
+     *
+     * <p>이 메서드는 제공된 {@link  EpisodeCreateDto}를 기반으로 새로운 에피소드를 생성합니다.</p>
+     *
+     * <p>먼저 에피소드 생성 요청자(제공자)가 소설의 저자와 일치하는지 확인합니다. 요청자와 저자가 일치하지 않거나
+     * 소설이 존재하지 않는 경우 예외가 발생합니다. </p>
+     * <p>또한, 제공된 {@code CostPolicyId}에 해당하는
+     * {@code CoinCostPolicy} 정보가 없으면 예외로 던집니다..</p>
+     *
+     * <p>에피소드 엔티티가 성공적으로 생성되면, 데이터베이스에 저장하고 해당 소설이 업데이트되었다는
+     * 메시지를 Redis를 통해 발송합니다. 예외가 발생할 경우, {@code ServiceMethodException} 예외가 던져집니다.</p>
+     *
+     * @param episodeCreateDto 새로운 에피소드의 정보를 담고 있는 {@link  EpisodeCreateDto} 객체
+     * @throws IllegalArgumentException 유효하지 않은 소설 정보이거나 요청자 정보가 올바르지 않은 경우
+     * @throws NoSuchElementException 제공된 {@code CostPolicyId}에 대한 {@code CoinCostPolicy} 정보가 없는 경우
+     * @throws ServiceMethodException 데이터베이스 작업 중 예외가 발생한 경우
      */
     void createEpisode(EpisodeCreateDto episodeCreateDto);
 
@@ -34,16 +51,21 @@ public interface EpisodeService {
     void updateEpisode(EpisodeUpdateDto episodeUpdateDto);
 
     /**
-     * DB에 저장된 Episode 삭제하는 메서드
+     * 에피소드 상태를 삭제상태로 변경하는 메서드 입니다.
+     *
+     * <p>주어진 {@link  EpisodeDeleteDto}를 바탕으로 에피소드를 삭제합니다. </p>
+     * <p>먼저, 데이터베이스에서 해당 에피소드를 조회하고,
+     * 에피소드의 소속 소설의 작가 정보와 삭제 요청자의 정보가 일치하는지 확인합니다.
+     * 일치하지 않거나 에피소드 정보가 존재하지 않는 경우 예외로 던집니다.</p>
+     * <p>이후, 에피소드의 상태를{@code DELETED_BY_USER}로 변경하고,
+     * 변경된 엔티티를 데이터베이스에 저장합니다.</p>
+     *
+     * @param episodeDeleteDto 에피소드 삭제 정보를 담고 있는 {@link  EpisodeDeleteDto} 객체
+     * @throws NoSuchElementException 에피소드 정보가 존재하지 않거나 요청자와 작가 정보가 일치하지 않는 경우
+     * @throws ServiceMethodException 데이터베이스 작업 중 예외가 발생한 경우
      */
     void deleteEpisode(EpisodeDeleteDto episodeDeleteDto);
 
-    /**
-     * 해당 Novel에 속한 모든 Episodes List 데이터를 가져오는 메서드
-     * @param novelId 소설 id
-     * @return List<EpisodeDataDto>
-     */
-    List<EpisodeListItemDto> getNovelEpisodes(Long novelId);
 
     /**
      * 해당 Novel에 속한 모든 Episodes List의 메타 데이터를 가져오는 메서드
@@ -53,20 +75,16 @@ public interface EpisodeService {
     EpisodeListInfoDto getNovelEpisodesInfo(Long novelId);
 
     /**
-     * 해당 Novel에 속한 모든 Episodes List dto를 최신순으로 가져오는 메서드.
-     * 페이지 단위로 일부만 가져옴.
-     * @param novelId 소설 id
-     * @param pageable 페이지 정보.
-     * @return List<EpisodeDataDto>
+     * 소설 ID와 필터 조건에 따라 에피소드 목록을 조회하는 메서드 입니다.
+     *
+     * <p> 이 메서드는 에피소드 검색 리포지토리에서 주어진 필터를 적용하여 결과를 가져온 뒤,
+     * 각 에피소드 엔티티를 {@link EpisodeListItemDto}로 변환하여 반환합니다.</p>
+     *
+     * @param sortBy 정렬 기준
+     * @param novelId 소설의 고유 ID
+     * @param pageable 페이지네이션 정보를 포함한 객체
+     * @return  에피소드 목록을 나타내는 {@link EpisodeListItemDto} 리스트
+     * @throws ServiceMethodException 메서드 실행 중 예외가 발생한 경우
      */
-    List<EpisodeListItemDto> getNovelEpisodesByRecent(Long novelId, Pageable pageable);
-
-    /**
-     * 해당 Novel에 속한 모든 Episodes List dto를 최초순으로 가져오는 메서드.
-     * 페이지 단위로 일부만 가져옴.
-     * @param novelId 소설 id
-     * @param pageable 페이지 정보.
-     * @return List<EpisodeDataDto>
-     */
-    List<EpisodeListItemDto> getNovelEpisodesByInitial(Long novelId, Pageable pageable);
+    List<EpisodeListItemDto> getEpisodesByConditions(String sortBy, Long novelId, Pageable pageable);
 }


### PR DESCRIPTION
# 변경사항

## 에피소드 CRUD 로직, QueryDSL 에피소드 검색 로직 추가
### EpisodeController
  - getEpisodesByNovel
    - 로직 변경에 따른 호출 메서드 변경

  - createEpisode
    - 에피소드 생성 API 추가

  - updateEpisode
    - 에피소드 업데이트 API 추가

  - deleteEpisode
    - 에피소드 삭제 API 추가

### EpisodeCustomRepository , EpisodeCustomRepositoryImpl
  - 에피소드 검색용 QueryDSL 메서드 생성을 위한 인터페이스, 클래스 추가

  - findEpisodesByConditions
    - 파마리터 조건에 따라 에피소드를 검색하는 메서드
    - 최신순/오래된순 으로 소설의 에피소드를 정렬하여 검색

  - getOrderSpecifier
    - 정렬조건에 따라 ORDER BY 쿼리문을 추가하는 메서드

### EpisodeRepository
  - EpisodeCustomRepository 클래스 extends 추가

  - findByNovelOrderByCreatedAtDesc,findByNovelOrderByCreatedAtAsc 메서드 삭제후 EpisodeCustomRepository 메서드로 통합

### EpisodeServiceImpl
  - createEpisode,updateEpisode,deleteEpisode
    - 요청자와 소설 작가가 동일한지 확인하는 로직 추가

  - validateEpisodeAuthor
    - 작업 요청 유저와 소설 작가가 일치하는지 검증하는 메서드 추가

  - getEpisodesByConditions
    - 소설 ID와 조건에 따라 에피소드 목록을 조회하는 메서드 추가
    - 파라미터에 따라 소설의 에피소드를 최신순,오래된 순으로 반환

  - getNovelEpisodesByRecent, getNovelEpisodesByInitial
    - getEpisodesByConditions 메서드로 기능 통합, 메서드 삭제

### EpisodeUpdateDto
  - providerId 멤버변수 추가
  - 멤버변수 길이제한 추가

### EpisodeCreateDto
  - providerId 멤버변수 추가
  - 멤버변수 길이제한 추가

### EpisodeDeleteDto
  - providerId 멤버변수 추가



## ValidationErrorHandler 클래스 에러 핸들링 메서드 추가
### ValidationErrorHandler
  - handleValidationErrorMessages
    - bindingResult  와 methodName 을 받아 에러를 처리하는 메서드 추가
    - bindingResult 을 List로 반환하고, methodName 으로 log를 남김

## 에피소드 반환 로직 수정
### EpisodeManagementServiceImpl
  - getBesideEpisode
    - 다음 에피소드가 ACTIVE 상태일때만 에피소드 반환, ACTIVE 상태가 아닐경우 ACTIVE인 에피소드가 나올때까지 반복문을 돌며 찾음