### PR TITLE
소설 검색어 기반 검색 기능 추가(full text index)

### DIFF
--- a/src/main/java/com/ham/netnovel/GlobalExceptionAdvice.java
+++ b/src/main/java/com/ham/netnovel/GlobalExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel;
 
 import com.ham.netnovel.common.exception.NotEnoughCoinsException;
+import com.ham.netnovel.common.exception.RepositoryMethodException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -74,8 +75,20 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(ServiceMethodException.class)
     public ResponseEntity<String> handleServiceMethodException(ServiceMethodException serviceMethodException) {
         log.error("서비스 계층 작업 에러, ServiceMethodException: {} ",serviceMethodException.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("서버 에러입니다 관리자에게 문의해주세요.");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러입니다 관리자에게 문의해주세요.");
     }
+    /**
+     * 리포지토리 계층 예외처리
+     * @param repositoryMethodException 서비스계층에서 사용하는 custom exception
+     * @return
+     */
+
+    @ExceptionHandler(RepositoryMethodException.class)
+    public ResponseEntity<String> handleServiceMethodException(RepositoryMethodException repositoryMethodException) {
+        log.error("리포지토리 계층 작업 에러, ServiceMethodException: {} ",repositoryMethodException.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러입니다 관리자에게 문의해주세요.");
+    }
+
 
 
     /**

--- a/src/main/java/com/ham/netnovel/common/exception/RepositoryMethodException.java
+++ b/src/main/java/com/ham/netnovel/common/exception/RepositoryMethodException.java
@@ -1,0 +1,13 @@
+package com.ham.netnovel.common.exception;
+
+public class RepositoryMethodException  extends  RuntimeException{
+
+    public RepositoryMethodException(String message) {
+        super(message);
+    }
+
+    public RepositoryMethodException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -50,7 +50,7 @@ public class NovelController {
 
 
     /**
-     * 소설을 검색 조건에 따라 조회하는 API 엔드포인트입니다.
+     * 소설을 검색 조건에 따라 조회하는 API 입니다.
      *
      * <p>
      * 이 메서드는 유저가 제공한 정렬 기준, 페이지 번호, 페이지 크기에 따라 소설 목록을 반환합니다.
@@ -63,32 +63,65 @@ public class NovelController {
      * @return {@link ResponseEntity<>} 소설 정보가 포함된 리스트를 HTTP 200 응답으로 반환합니다.
      * 응답 본문에는 소설 정보 리스트가 담겨 있습니다.
      */
-    @GetMapping("/novels/search")
+    @GetMapping("/novels/browse")
     public ResponseEntity<List<NovelListDto>> getNovelsBySearchCondition(
             @RequestParam(name = "sortBy", defaultValue = "view") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "100") Integer pageSize,
-            @RequestParam(name = "tagId",required = false) String ids) {
+            @RequestParam(name = "tagId", required = false) String ids) {
 
-        List<Long> idList=new ArrayList<>();
+        List<Long> idList = new ArrayList<>();
         //"," 로 구분된 tag 들을 분리하여 List 객체에 담음
-        if (!(ids ==null)){idList= Arrays.stream(ids.split(","))
+        if (!(ids == null)) {
+            idList = Arrays.stream(ids.split(","))
                     .map(Long::valueOf)
                     .toList();
         }
         //페이지 사이즈 수 제한
-        if (pageSize>200){
-            pageSize =200;
+        if (pageSize > 200) {
+            pageSize = 200;
         }
 
         //페이지 네이션을 위한 Pageable 객체 생성
         Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
         //조건을 메서드에 전달하여, 소설 정보 List를 받아옴
-        List<NovelListDto> novels = novelService.getNovelsBySearchCondition(sortBy, pageable,idList);
+        List<NovelListDto> novels = novelService.getNovelsBySearchCondition(sortBy, pageable, idList);
+        return ResponseEntity.ok(novels);//소설 정보 전송
+    }
+
+    /**
+     * 검색어로 소설을 조회하는 API 입니다.
+     * <p>
+     * 이 메서드는 유저가 입력한 검색어에 따라 소설 목록을 반환합니다.
+     * 페이지 네이션을 위해 Pageable 객체를 생성하여, 서비스 계층에서 소설 정보를 DTO 리스트로 받아 이를 HTTP 응답으로 전송합니다.
+     * </p>
+     *
+     * @param searchWord 검색어 {@link String} 객체입니다.
+     * @param pageNumber 조회할 페이지 번호 {@link Integer} 객체 입니다. 기본값은 0입니다.
+     * @param pageSize   한 페이지에 포함될 항목의 수 {@link Integer} 객체  입니다. 기본값은 30입니다.
+     * @return {@link ResponseEntity<>} 소설 정보가 포함된 리스트를 HTTP 200 응답으로 반환합니다.
+     */
+
+    @GetMapping("/novels/search")
+    public ResponseEntity<List<NovelListDto>> getNovelsBySearchWord(
+            @RequestParam(name = "searchWord") String searchWord,
+            @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "30") Integer pageSize) {
+
+
+        //페이지 사이즈 수 제한
+        if (pageSize > 200) {
+            pageSize = 200;
+        }
+
+        //페이지 네이션을 위한 Pageable 객체 생성
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
+        //조건을 메서드에 전달하여, 소설 정보 List를 받아옴
+        List<NovelListDto> novels = novelService.getNovelsBySearchWord(searchWord, pageable);
         return ResponseEntity.ok(novels);//소설 정보 전송
 
-
     }
+
 
     /**
      * 소설 랭킹을 기간에 따라 조회하는 API 엔드포인트입니다.
@@ -114,8 +147,8 @@ public class NovelController {
 
 
         //페이지 사이즈 수 제한
-        if (pageSize>200){
-            pageSize =200;
+        if (pageSize > 200) {
+            pageSize = 200;
         }
 
         //페이지네이션 객체 생성
@@ -126,6 +159,7 @@ public class NovelController {
 
         return ResponseEntity.ok(rankedNovels);//소설 정보 전송
     }
+
     /**
      * 유저가 집핍하는 소설 리스트를 전송하는 API
      *
@@ -156,8 +190,8 @@ public class NovelController {
      */
     @PostMapping("/novels")
     public ResponseEntity<?> createNovel(@Valid @RequestBody NovelCreateDto reqBody,
-                                              BindingResult bindingResult,
-                                              Authentication authentication) {
+                                         BindingResult bindingResult,
+                                         Authentication authentication) {
         //NovelCreateDto Validation 예외 처리
         if (bindingResult.hasErrors()) {
             log.error("createNovel API Error = {}", bindingResult.getFieldError());

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface NovelRepository extends JpaRepository<Novel, Long> {
+public interface NovelRepository extends JpaRepository<Novel, Long>, NovelSearchRepository {
 
 
     @Query("select n from Novel n " +

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
@@ -23,5 +23,20 @@ public interface NovelSearchRepository {
                                                     List<Long> tagIds);
 
 
+    /**
+     * 검색어를 기반으로 소설 목록을 검색하여 반환합니다.
+     * <p>
+     * 검색된 소설 정보를 NovelListDto로 변환하여 페이징 처리된 결과를 반환합니다.
+     * 해당 메서드는 검색어에 대해 Full-Text 검색을 수행하고,
+     * 각 소설의 관련 정보를 DTO로 변환하여 반환합니다.
+     * </p>
+     *
+     * @param searchWord 검색어
+     * @param pageable       {@link Pageable} 페이지 정보를 포함하는 객체 (페이지 번호, 페이지 크기 등)
+     * @return {@link List<NovelListDto>} 정렬 기준과 페이지 정보에 따라 조회된 소설 목록을 포함하는 리스트
+     */
+    List<NovelListDto> findBySearchWord(String searchWord,Pageable pageable);
+
+
 
 }

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.novel.repository;
 
+import com.ham.netnovel.common.exception.RepositoryMethodException;
 import com.ham.netnovel.novel.QNovel;
 import com.ham.netnovel.novel.data.NovelSortOrder;
 import com.ham.netnovel.novel.dto.NovelListDto;
@@ -11,65 +12,149 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
+
+@Slf4j
 public class NovelSearchRepositoryImpl implements NovelSearchRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    private final EntityManager entityManager;
+
+
     @Autowired
-    public NovelSearchRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+    public NovelSearchRepositoryImpl(JPAQueryFactory jpaQueryFactory, EntityManager entityManager) {
         this.jpaQueryFactory = jpaQueryFactory;
+        this.entityManager = entityManager;
     }
 
     @Override
     public List<NovelListDto> findNovelsBySearchConditions(NovelSortOrder novelSortOrder,
                                                            Pageable pageable,
                                                            List<Long> tagIds) {
-        QNovelMetaData novelMetaData = QNovelMetaData.novelMetaData;
-        QNovel novel = QNovel.novel;
-        QNovelTag novelTag = QNovelTag.novelTag;
-        // 파라미터로 받은 조건으로 ORDER BY 조건 생성
-        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(novelSortOrder, novelMetaData);
+        try {
 
-        //조건을 통해 찾은 Novel 엔티티를 DTO로 변환하여 반환하는 쿼리문 생성
-        var query = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
-                        novel.id.as("id"),
-                        novel.title.as("title"),
-                        novelMetaData.totalFavorites.as("totalFavorites"),
-                        novelMetaData.totalViews.as("totalView"),
-                        novelMetaData.latestEpisodeAt.as("latestUpdateAt"),
-                        novel.thumbnailFileName.as("thumbnailUrl")))
-                .from(novel)
-                .join(novel.novelMetaData);//메타 데이터와 JOIN
+            QNovelMetaData novelMetaData = QNovelMetaData.novelMetaData;
+            QNovel novel = QNovel.novel;
+            QNovelTag novelTag = QNovelTag.novelTag;
+            // 파라미터로 받은 조건으로 ORDER BY 조건 생성
+            OrderSpecifier<?> orderSpecifier = getOrderSpecifier(novelSortOrder, novelMetaData);
+
+            //조건을 통해 찾은 Novel 엔티티를 DTO로 변환하여 반환하는 쿼리문 생성
+            var query = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
+                            novel.id.as("id"),
+                            novel.title.as("title"),
+                            novelMetaData.totalFavorites.as("totalFavorites"),
+                            novelMetaData.totalViews.as("totalView"),
+                            novelMetaData.latestEpisodeAt.as("latestUpdateAt"),
+                            novel.thumbnailFileName.as("thumbnailUrl")))
+                    .from(novel)
+                    .join(novel.novelMetaData);//메타 데이터와 JOIN
 
 
-        // 유저가 선택한 Tag가 있을 경우, Tag 조건을 쿼리 검색 AND 조건으로 추가
-        if (!(tagIds == null) && !tagIds.isEmpty()) {
-            query.leftJoin(novel.novelTags, novelTag)//left join으로 tag 정보가 없어도 Novel 레코드 반환
-                    .where(novelTag.tag.id.in(tagIds))//유저가 선택한 tag id와 관계가 있는 엔티티만 가져옴
-                    .groupBy(novel.id)//소설로 그룹화
-                    .having(novelTag.tag.id.in(tagIds).count().eq((long) tagIds.size()));
+            // 유저가 선택한 Tag가 있을 경우, Tag 조건을 쿼리 검색 AND 조건으로 추가
+            if (!(tagIds == null) && !tagIds.isEmpty()) {
+                query.leftJoin(novel.novelTags, novelTag)//left join으로 tag 정보가 없어도 Novel 레코드 반환
+                        .where(novelTag.tag.id.in(tagIds))//유저가 선택한 tag id와 관계가 있는 엔티티만 가져옴
+                        .groupBy(novel.id)//소설로 그룹화
+                        .having(novelTag.tag.id.in(tagIds).count().eq((long) tagIds.size()));
+            }
+
+            //페이지네이션 및 정렬조건 추가
+            List<NovelListDto> novelListDtos = query.offset(pageable.getOffset())//페이지 시작 지점, 0부터 시작함
+                    .limit(pageable.getPageSize())//한페이지에 보여줄 데이터의 개수
+                    .orderBy(orderSpecifier)
+                    .fetch();
+
+
+            //소설 DTO에 태그 정보를 추가
+            for (NovelListDto dto : novelListDtos) {
+                loadTagsForNovel(dto);
+            }
+            //소설 DTO List 반환
+            return novelListDtos;
+
+        }catch (Exception ex){
+            throw new RepositoryMethodException("findNovelsBySearchConditions 메서드 에러"+ex+ex.getMessage());
+
+
         }
 
-        //페이지네이션 및 정렬조건 추가
-        List<NovelListDto> novelListDtos = query.offset(pageable.getOffset())//페이지 시작 지점, 0부터 시작함
-                .limit(pageable.getPageSize())//한페이지에 보여줄 데이터의 개수
-                .orderBy(orderSpecifier)
-                .fetch();
+    }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<NovelListDto> findBySearchWord(String searchWord,Pageable pageable) {
 
-        //소설 DTO에 태그 정보를 추가
-        for (NovelListDto dto : novelListDtos) {
-            loadTagsForNovel(dto);
+        //파라미터 null, 공백 체크
+        if (searchWord==null || searchWord.trim().isEmpty()){
+            return Collections.emptyList();
         }
-        //소설 DTO List 반환
-        return novelListDtos;
+
+        int pageSize = pageable.getPageSize();// 한 페이지에 표시할 항목 수
+        int pageNumber = pageable.getPageNumber();
+        int offset = pageNumber * pageSize; // 오프셋 계산
+
+        //SQL Injection 방지, 특수문자 공백 제거
+        String sanitizedSearchWord  = searchWord.replaceAll("[\\s'\";()*-/]", "");
+
+//        log.info("검색단어 ={}", sanitizedSearchWord);
+
+
+
+        //Native 쿼리문 생성, MySQL 문법 사용
+        String queryStr =
+                "SELECT n.id as novelId, " +
+                        "n.title as novelTitle," +
+                        "n.thumbnail_file_name as fileName, " +
+                        "nm.total_views as totalViews, " +
+                        "nm.total_favorites as totalFavorites, " +
+                        "nm.latest_episode_at as latestAt " +  // 필요한 필드만 선택
+                        "FROM novel n " +
+                        "JOIN novel_meta_data nm ON n.id = nm.novel_id " +
+                        "WHERE MATCH(n.title) AGAINST(:searchWord IN BOOLEAN MODE) " +//index 사용
+                        "LIMIT :limit OFFSET :offset";//페이지네이션
+
+        try {
+            //네이티브 쿼리 객체 생성
+            Query query = entityManager.createNativeQuery(queryStr);
+
+            //매개변수화된 쿼리, 쿼리문에 파라미터 할당
+            query.setParameter("searchWord", sanitizedSearchWord);
+            query.setParameter("offset",offset);
+            query.setParameter("limit", pageSize);
+
+            //쿼리문 실행후 반환된 결과 객체 생성
+            List<Object[]> resultList = query.getResultList();
+
+            //DB에서 찾은 결과 DTO로 변환하여 반환
+            return resultList.stream()
+                    .map(objects -> NovelListDto.builder()
+                            .id((Long) objects[0])
+                            .title((String) objects[1])
+                            .thumbnailUrl((String) objects[2])
+                            .totalView(objects[3] != null ? ((Number) objects[3]).longValue() : 0L) // null-safe 변환
+                            .totalFavorites(objects[4] != null ? ((Number) objects[4]).intValue() : 0) // null-safe 변환
+                            .latestUpdateAt(objects[5] != null ? ((Timestamp) objects[5]).toLocalDateTime() : null) // null-safe 변환
+                            .build()).collect(Collectors.toList());
+        }catch (Exception ex){
+            throw new RepositoryMethodException("findBySearchWord 메서드 에러"+ex+ex.getMessage());
+        }
+
+
     }
 
     /**
@@ -95,6 +180,7 @@ public class NovelSearchRepositoryImpl implements NovelSearchRepository {
                 .fetch();
         dto.setTags(tagDataDtos);
     }
+
 
     /**
      * 주어진 정렬 기준에 따라 {@link OrderSpecifier} 객체를 생성합니다.

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -169,6 +169,7 @@ public interface NovelService {
      * <p>
      * 이 메서드는 기본적으로 소설 목록을 조회수 기준으로 정렬합니다.
      * </p>
+     *
      * <p>
      * 사용자가 제공한 정렬 기준에 따라, 소설 목록을 좋아요 순 또는 최신순으로 정렬할 수 있습니다.
      * 조회된 소설 목록의 썸네일 URL은 S3 서비스의 CloudFront URL로 변환됩니다.
@@ -179,7 +180,24 @@ public interface NovelService {
      *
      * @return List<NovelListDto> 소설 목록을 포함한 DTO 리스트를 반환합니다.
      *         각 소설의 썸네일 URL은 CloudFront URL로 변환되어 반환됩니다.
+     * @throws ServiceMethodException 검색 중 예외 발생 시 예외를 던집니다.
      */
     List<NovelListDto> getNovelsBySearchCondition(String sortOrder, Pageable pageable, List<Long> tagIds);
+
+    /**
+     * 검색어를 기반으로 소설 목록을 검색하여 반환합니다.
+     * <p>
+     * 검색된 소설 정보를 NovelListDto로 변환하여 페이징 처리된 결과를 반환합니다.
+     * 조회된 소설 목록의 썸네일 URL은 S3 서비스의 CloudFront URL로 변환됩니다.
+     * </p>
+     *
+     * @param searchWord 유저가 입력한  검색어 {@link String} 객체
+     * @param pageable 페이지 정보 및 페이징 조건을 포함하는 {@link Pageable} 객체입니다.
+     * @return List<NovelListDto> 소설 목록을 포함한 DTO 리스트를 반환합니다.
+     *         각 소설의 썸네일 URL은 CloudFront URL로 변환되어 반환됩니다.     *
+
+     * @throws ServiceMethodException 검색 중 예외 발생 시 예외를 던집니다.
+     */
+    List<NovelListDto> getNovelsBySearchWord(String searchWord, Pageable pageable);
 
 }


### PR DESCRIPTION
# 변경사항


## feat: 소설 검색어 기반 검색 기능 추가 및 API 엔드포인트 수정
- 소설 제목을 기반으로 하는 Full-Text 검색 기능 추가
- MySQL의 Full-Text 인덱스 사용 (n-gram 파서 적용)

### NovelController
- getNovelsBySearchCondition
  - 엔드포인트 변경: 기존 /novels/search → /novels/browse

- getNovelsBySearchWord
  - 사용자 입력 검색어를 기반으로 소설을 검색하는 API 추가
  - 쿼리 파라미터로 검색어, 페이지 번호, 페이지 크기를 전달받아 서비스 계층에 전달
  - 검색 결과를 사용자에게 반환

### NovelService, NovelServiceImpl
- getNovelsBySearchWord
  - 검색어를 기반으로 소설 목록을 반환하는 메서드 추가
  - NovelSearchRepository의 findBySearchWord 메서드를 호출하여 검색 수행
  - 반환된 소설 목록의 섬네일 URL을 AWS CloudFront URL로 변환하여 반환

### NovelSearchRepository, NovelSearchRepositoryImpl
- findBySearchWord
  - 검색어와 페이지네이션 정보를 사용하여 소설을 찾는 메서드 추가
  - MySQL Full-Text 인덱스를 사용한 Native Query로 검색 처리 (n-gram 파서 기반)


## feat : 리포지토리 계층 커스텀 예외 클래스 추가
### RepositoryMethodException
- 리포지토리 계층 에러 발생시 던져질 커스텀 예외 클래스 추가
- RuntimeException 상속받아 사용

### GlobalExceptionAdvice
- RepositoryMethodException 예외 핸들링 추가



## feat: NovelRepository에 NovelSearchRepository 상속 추가
### NovelSearchRepository
- JpaRepository<Novel, Long>와 NovelSearchRepository를 상속받도록 변경