### PR TITLE
작가명으로 소설 검색 및 Member ROLE을 작가로 전환하는 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/member/Member.java
+++ b/src/main/java/com/ham/netnovel/member/Member.java
@@ -20,6 +20,9 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "member", indexes = @Index(
+        name = "idx_member_Name",
+        columnList = "nick_name"))
 public class Member {
 
     @Id
@@ -115,6 +118,12 @@ public class Member {
     public void increaseMemberCoins(int coinCount){
         Integer totalCoin = this.getCoinCount();
         this.coinCount = totalCoin + coinCount;
+    }
+
+    //Member 엔티티의 ROLE 을 AUTHOR 로 변경하는 메서드
+    public void changeRoleToAuthor(){
+        this.role = MemberRole.AUTHOR;
+
     }
 
 }

--- a/src/main/java/com/ham/netnovel/member/service/MemberService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberService.java
@@ -61,4 +61,13 @@ public interface MemberService {
     MemberMyPageDto getMemberMyPageInfo(String providerId);
 
 
+    /**
+     * 유저의 ROLE을 작가로 전환하는 메서드 입니다.
+     * 이 메소드는 유저 엔티티의 상태를 작가로 변경한 후, 변경된 유저 정보를 저장합니다.
+     *
+     * @param member 상태를 작가로 전환할 {@link Member} 엔티티
+     */
+    void changeMemberToAuthor(Member member);
+
+
 }

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
@@ -5,11 +5,13 @@ import com.ham.netnovel.common.exception.NotEnoughCoinsException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.MemberRepository;
+import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.member.dto.MemberMyPageDto;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.member.dto.ChangeNickNameDto;
 import com.ham.netnovel.member.dto.MemberCreateDto;
 import com.ham.netnovel.member.dto.MemberLoginDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
+@Slf4j
 class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
@@ -178,6 +181,29 @@ class MemberServiceImpl implements MemberService {
         }
 
 
+    }
+
+    @Override
+    @Transactional
+    public void changeMemberToAuthor(Member member) {
+        //파라미터 null체크
+        if (member==null){
+            throw new NoSuchElementException("changeMemberToAuthor 메서드 에러, 유저정보 없음");
+        }
+        try {
+            //유저 ROLE 이 이미 작가일경우 메서드 종료
+            if (member.getRole().equals(MemberRole.AUTHOR)){
+                log.info("유저 Role 이미 AUTHOR 입니다. 메서드 종료");
+                return;
+            }
+            member.changeRoleToAuthor();
+            //DB 에 내용 업데이트
+            memberRepository.save(member);
+            log.info("유저 {} ROLE AUTHOR 로 변경 완료.",member.getId());
+
+        }catch (Exception ex){
+            throw new ServiceMethodException("changeMemberToAuthor 메서드 에러, 예외내용 = "+ ex.getMessage());
+        }
     }
 
 

--- a/src/main/java/com/ham/netnovel/novel/data/NovelSearchType.java
+++ b/src/main/java/com/ham/netnovel/novel/data/NovelSearchType.java
@@ -1,0 +1,7 @@
+package com.ham.netnovel.novel.data;
+
+public enum NovelSearchType {
+
+    AUTHOR_NAME, // 작가이름검색
+    NOVEL_TITLE // 소설제목검색
+}

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
@@ -28,6 +28,9 @@ public class NovelListDto {//랭킹 등 리스트로 소설정보를 전달시 �
     private String authorName; //작가 닉네임
 
     @NotNull
+    private String providerId;//작가 소셜로그인 ID
+
+    @NotNull
     private List<TagDataDto> tags; //작품 태그
 
 

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepository.java
@@ -39,4 +39,17 @@ public interface NovelSearchRepository {
 
 
 
+    /**
+     * 작가명을 통해 소설 목록을 검색하여 반환합니다.
+     * <p>이 메서드는 주어진 작가 이름을 포함하는 작가(Member)를 서브쿼리로 검색하여,
+     * 해당 작가가 작성한 소설 목록을 반환합니다.</p>
+     * <p> 검색 조건에는 작가의 역할이 AUTHOR인지 확인하는 로직이 포함됩니다.</p>
+     *
+     * @param authorName 작가의 이름을 검색어로 사용
+     * @param pageable       {@link Pageable} 페이지 정보를 포함하는 객체 (페이지 번호, 페이지 크기 등)
+     * @return {@link List<NovelListDto>} 소설 목록을 포함하는 리스트
+     */
+    List<NovelListDto> findByAuthorName(String authorName, Pageable pageable);
+
+
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.novel.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.data.NovelSearchType;
 import com.ham.netnovel.novel.dto.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
@@ -198,6 +199,8 @@ public interface NovelService {
 
      * @throws ServiceMethodException 검색 중 예외 발생 시 예외를 던집니다.
      */
-    List<NovelListDto> getNovelsBySearchWord(String searchWord, Pageable pageable);
+    List<NovelListDto> getNovelsBySearchWord(String searchWord,
+                                             NovelSearchType novelSearchType,
+                                             Pageable pageable);
 
 }


### PR DESCRIPTION
# 변경사항
## feat: 작가명으로 소설을 검색하는 로직 추가
### NovelSearchRepository, NovelSearchRepositoryImpl
- findByAuthorName
  - 작가명으로 소설을 검색하는 메서드 추가
  - 검색하려는 문자열이 포함된 Member를 찾아 ROLE이 AUTHOR인지 확인한 후, 해당 작가의 소설을 반환

- findNovelsBySearchConditions, findBySearchWord
  - 소설 정보 반환 시, 작가 정보(닉네임, providerId)도 함께 반환하도록 변경

### NovelController
- 쿼리 파라미터 searchType 추가
  - type에 따라 NovelSearchType을 결정하여 서비스 계층 메서드 호출 시 파라미터로 전달

### NovelSearchType
- 검색어 기반 소설 검색 시 사용할 enum class 추가 (AUTHOR_NAME, NOVEL_TITLE)

### NovelListDto
- String 타입의 providerId 필드 추가 (작가 정보)

### NovelService, NovelServiceImpl
- createNovel
  - 새로운 소설 생성 시 작성자의 ROLE이 READER일 경우 AUTHOR로 변경하는 로직 추가

- getNovelsBySearchWord


## feat: Member ROLE을 작가로 전환하는 로직 추가
### MemberService , MemberServiceImpl
- changeMemberToAuthor
  - 유저의 ROLE을 작가로 전환하는 메서드 추가
  - 파라미터로 Member 엔티티를 받아, ROLE 이 AUTHOR 가 아닐경우, AUTHOR 로 변경후 DB에 저장

### Member
- nickName에 대한 JPA 인덱스 추가(검색 최적화)

- changeRoleToAuthor
  - Member 엔티티의 ROLE 을 AUTHOR 로 변경하는 메서드 추가