### PR TITLE
작가의 소설별 수익 확인 및 정산 요청 로직 추가  

### DIFF
--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistory.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistory.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.coinChargeHistory;
 
 
+import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -42,6 +43,10 @@ public class CoinChargeHistory {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "episode_id")
+    private Episode episode;
 
 
     @Builder

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryRepository.java
@@ -5,18 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory,Long> {
-
-
+public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory, Long> {
 
 
     @Query("select c from CoinUseHistory c " +
             "where c.member.providerId = :providerId " +
             "order by c.createdAt desc ")
-    List<CoinUseHistory> findByMemberProviderId(@Param("providerId")String providerId, Pageable pageable);
+    List<CoinUseHistory> findByMemberProviderId(@Param("providerId") String providerId, Pageable pageable);
 
 
     @Query("select c from CoinUseHistory  c " +
@@ -26,6 +25,32 @@ public interface CoinUseHistoryRepository extends JpaRepository<CoinUseHistory,L
     Optional<CoinUseHistory> findByMemberAndEpisode(@Param("providerId") String providerId,
                                                     @Param("episodeId") Long episodeId);
 
-
+    /**
+     * 주어진 소설 ID 목록에 대해 특정 기간 동안 사용된 코인의 총합을 조회합니다.
+     *
+     * <p>이 메서드는 주어진 소설 ID 목록과 시작일, 종료일을 기준으로 {@link CoinUseHistory} 엔티티에서
+     * 각 소설에 대해 사용된 코인의 총 수를 계산합니다. 결과는 소설 ID, 소설 제목, 총 사용된 코인 수,
+     * 작가의 providerId를 포함하는 배열의 리스트로 반환됩니다.</p>
+     *
+     * @param novelIds 소설 ID 목록
+     * @param startDate 조회 시작일
+     * @param endDate 조회 종료일
+     * @return 주어진 기간 동안 각 소설의 총 사용된 코인 수를 포함하는  {@link Object} 타입 {@link List} 객체
+     * 배열, 각 배열은 [소설 ID, 소설 제목, 총 사용된 코인 수, 작가의 providerId]를 포함합니다.
+     */
+    @Query("select " +
+            "e.novel.id, " +//소설 id
+            "e.novel.title, " +//소설 제목
+            "sum(c.amount), " +//소설에 사용된 코인의 총 수
+            "e.novel.author.providerId " +//작가의 providerId
+            "from CoinUseHistory c " +
+            "join c.episode e " +
+            "where e.novel.id in :novelIds " +
+            "and c.createdAt between :startDate and :endDate " +
+            "group by e.novel.id")
+    List<Object[]> findByNovelAndDateTime(
+            @Param("novelIds") List<Long> novelIds,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 
 }

--- a/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/service/CoinUseHistoryService.java
@@ -1,30 +1,45 @@
 package com.ham.netnovel.coinUseHistory.service;
 
-import com.ham.netnovel.coinUseHistory.CoinUseHistory;
 import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
+import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import org.springframework.data.domain.Pageable;
-
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CoinUseHistoryService {
 
 
-   void saveCoinUseHistory(CoinUseCreateDto coinUseCreateDto);
+    void saveCoinUseHistory(CoinUseCreateDto coinUseCreateDto);
 
 
-   List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId, Pageable pageable);
+    List<MemberCoinUseHistoryDto> getMemberCoinUseHistory(String providerId, Pageable pageable);
 
 
-   /**
-    * 유저가 에피소드에 결제한 내역이 있는지 확인하는 메서드
-    * @param providerId 유저 정보
-    * @param episodeId 에피소드의 id
-    * @return 결제 내역이 있을 경우 true, 결제 내역이 없을경우 false 반환
-    */
-   boolean hasMemberUsedCoinsForEpisode(String providerId, Long episodeId);
+    /**
+     * 유저가 에피소드에 결제한 내역이 있는지 확인하는 메서드
+     *
+     * @param providerId 유저 정보
+     * @param episodeId  에피소드의 id
+     * @return 결제 내역이 있을 경우 true, 결제 내역이 없을경우 false 반환
+     */
+    boolean hasMemberUsedCoinsForEpisode(String providerId, Long episodeId);
 
 
-
+    /**
+     * 주어진 소설 ID 목록과 날짜 범위에 대한 코인 사용 내역을 조회하여 반환하는 메서드 입니다.
+     *
+     * <p>이 메서드는 시작일과 종료일을 기준으로 각 소설에 대해 사용된 코인의 총합을 계산합니다.
+     * 결과는 소설 ID, 소설 제목, 작가의 providerId, 총 사용된 코인 수를 포함하는  {@link NovelRevenueDto} 객체로 반환됩니다.
+     * </p>
+     *
+     * @param novelIds 조회할 소설의 ID 목록
+     * @param startDate 조회 시작일
+     * @param endDate 조회 종료일
+     * @return 주어진 날짜 범위에 따른 각 소설의 코인 사용 내역을 포함하는 {@link List} of {@link NovelRevenueDto} 객체
+     * @throws ServiceMethodException 조회 중 예외가 발생할 경우
+     */
+    List<NovelRevenueDto> getCoinUseHistoryByNovelAndDate(List<Long> novelIds,LocalDate startDate, LocalDate endDate);
 
 }

--- a/src/main/java/com/ham/netnovel/episode/Episode.java
+++ b/src/main/java/com/ham/netnovel/episode/Episode.java
@@ -5,7 +5,9 @@ import com.ham.netnovel.comment.Comment;
 import com.ham.netnovel.coinUseHistory.CoinUseHistory;
 import com.ham.netnovel.coinCostPolicy.CoinCostPolicy;
 import com.ham.netnovel.episode.data.EpisodeStatus;
+import com.ham.netnovel.episodeViewCount.EpisodeViewCount;
 import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.weeklyViewCount.WeeklyViewCount;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,6 +78,10 @@ public class Episode {
     //junction table 연결, 코인 사용 기록
     @OneToMany(mappedBy = "episode")
     private List<CoinUseHistory> coinUseHistories = new ArrayList<>();
+
+
+    @OneToMany(mappedBy = "episode")
+    private List<EpisodeViewCount> episodeViewCounts = new ArrayList<>();
 
     @Builder
     public Episode(Integer chapter, String title, String content, Novel novel, CoinCostPolicy costPolicy) {

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -238,43 +238,4 @@ public class MemberController {
         return ResponseEntity.ok(memberRecentReadInfo);
     }
 
-
-    //테스트 API
-    @GetMapping("/member/novel/test")
-    public String memberNovelTest() {
-
-        return "/member/novel-test";
-    }
-
-
-    @GetMapping("/members/comment/test")
-    public String memberCommentTest() {
-
-        return "/member/comment-test";
-    }
-
-    @GetMapping("/members/nickname/test")
-    public String nickNameChangeTest() {
-
-        return "/member/nickname-test";
-    }
-
-    @GetMapping("/members/session/test")
-    @ResponseBody
-    public String sessionTest(Authentication authentication) {
-        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
-
-        log.info("로그인한 유저 정보");
-        log.info("로그인한 유저 providerId={}", principal.getName());
-        log.info("로그인한 유저 nickName={}", principal.getNickName());
-        log.info("로그인한 유저 role={}", principal.getRole());
-        log.info("로그인한 유저 gender={}", principal.getGender());
-        log.info("로그인한 유저 Attributes={}", principal.getAttributes());
-        log.info("로그인한 유저 Authorities={}", principal.getAuthorities());
-
-        return "ok";
-
-    }
-
-
 }

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.ham.netnovel.member.service.impl;
 
 import com.ham.netnovel.common.exception.NotEnoughCoinsException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.member.MemberRepository;
 import com.ham.netnovel.member.data.MemberRole;
@@ -33,6 +34,12 @@ class MemberServiceImpl implements MemberService {
     //가져다 쓸경우 Null체크 필수!!
     @Override
     public Optional<Member> getMember(String providerId) {
+
+        //파라미터 Null, 비어있는지 체크
+        if ( TypeValidationUtil.isNullOrEmpty(providerId)) {
+            throw new IllegalArgumentException("getMember 메서드 에러 providerId 값이 Null 이거나 비었습니다.");
+        }
+
         return memberRepository.findByProviderId(providerId);
     }
 

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -29,6 +29,20 @@ public interface NovelService {
      */
     List<NovelInfoDto> getNovelsByAuthor(String providerId);
 
+
+ /**
+  * 유저가 작성한 소설의 ID 목록을 반환하는 메서드 입니다.
+  *
+  * <p>유효한 providerId가 제공되면, 해당 작가가
+  * 작성한 모든 소설의 ID를 포함하는 {@link List}를 반환합니다.</p>
+  *
+  * @param providerId 유저 정보
+  * @return 해당 작가가 작성한 소설의 ID {@link List} 객체
+  * @throws IllegalArgumentException providerId가 null이거나 비어 있는 경우
+  */
+   List<Long> getNovelIdsByAuthor(String providerId);
+
+
     /**
      * 유저가 생성한 Novel을 DB 저장.
      * @param novelCreateDto 생성 정보가 담긴 dto

--- a/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelServiceImpl.java
@@ -62,12 +62,26 @@ public class NovelServiceImpl implements NovelService {
 
     @Override
     public List<NovelInfoDto> getNovelsByAuthor(String providerId) {
-        //Member Entity 조회 -> Author 검증
-        Member author = memberService.getMember(providerId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 Member 입니다."));
 
-        return novelRepository.findNovelsByMember(author.getId()).stream()
+        if (providerId ==null || providerId.isEmpty()){
+            throw new IllegalArgumentException("getNovelIdsByAuthor 에러, providerId 값이 Null 이거나 비었습니다.");
+        }
+
+        return novelRepository.findNovelsByMember(providerId)
+                .stream()
                 .map(this::convertEntityToInfoDto)
+                .toList();
+    }
+
+    @Override
+    public List<Long> getNovelIdsByAuthor(String providerId) {
+        if (providerId ==null || providerId.isEmpty()){
+            throw new IllegalArgumentException("getNovelIdsByAuthor 에러, providerId 값이 Null 이거나 비었습니다.");
+        }
+        //novelIds List 객체 반환
+        return novelRepository.findNovelsByMember(providerId)
+                .stream()
+                .map(Novel::getId)
                 .toList();
     }
 

--- a/src/main/java/com/ham/netnovel/settlement/Settlement.java
+++ b/src/main/java/com/ham/netnovel/settlement/Settlement.java
@@ -1,0 +1,58 @@
+package com.ham.netnovel.settlement;
+
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.novel.Novel;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Settlement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private Integer coinCount;
+
+    //정산수익(단위 원)
+    @NotNull
+    @Column(nullable = false)
+
+    private Integer revenue;
+
+    @Enumerated(EnumType.STRING)
+    private SettlementStatus status;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;//정산신청날짜
+
+    private LocalDateTime completionDate;  // 정산 완료일
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id")
+    private Novel novel;
+
+
+    @Builder
+    public Settlement(Integer coinCount, Integer revenue, SettlementStatus status, Member member, Novel novel) {
+        this.coinCount = coinCount;
+        this.revenue = revenue;
+        this.status = status;
+        this.member = member;
+        this.novel = novel;
+    }
+}

--- a/src/main/java/com/ham/netnovel/settlement/SettlementRepository.java
+++ b/src/main/java/com/ham/netnovel/settlement/SettlementRepository.java
@@ -1,0 +1,52 @@
+package com.ham.netnovel.settlement;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SettlementRepository extends JpaRepository<Settlement,Long> {
+
+
+    /**
+     * 유저가 마지막으로 정산 받은 날짜를 반환합니다.
+     *
+     * <p>이 메서드는 유저의 정산 기록에서, 정산이 완료된(status가 COMPLETED상태인)
+     * 정산 기록중 가장 최근 날짜를 반환합니다.
+     * </p>
+     * <p>만약 유저가 정산을 받은 기록이 없다면, {@code Optional.empty()}를 반환합니다.
+     * </p>
+     *
+     * @param memberId 유저의 고유 식별자 (memberId), null이 아닐 경우에만 유효합니다.
+     * @return {@link Optional}로 래핑된 {@link LocalDateTime} 객체.
+     *         정산 받은 날짜가 존재하는 경우 그 날짜를 포함하고,
+     *         정산 기록이 없는 경우 {@code Optional.empty()}를 반환합니다.
+     */
+    @Query("select max(st.createdAt) " +
+            "from Settlement  st " +
+            "where st.member.id = :memberId " +
+            "and st.status ='COMPLETED' ")
+    Optional<LocalDateTime> findLatestSettlementDateByMember(@Param("memberId") Long memberId);
+
+    /**
+     * 유저가 요청한 정산 목록을 반환합니다.
+     * <p>
+     * 이 메서드는 지정된 유저의 정산 요청 상태가 'REQUESTED'인 모든 {@link Settlement} 엔티티를 조회합니다.
+     * 유저의 ID를 통해 정산 요청을 필터링하여 해당 유저가 요청한 정산 내역만 반환합니다.
+     * </p>
+     *
+     * @param memberId 유저의 고유 식별자 (memberId), null이 아닐 경우에만 유효합니다.
+     * @return 요청된 정산 내역을 담고 있는 {@link List} 객체.
+     *         요청된 정산이 없는 경우 빈 리스트를 반환합니다.
+     */
+    @Query("select st " +
+            "from Settlement st " +
+            "where st.member.id = :memberId " +
+            "and st.status = 'REQUESTED'  ")
+    List<Settlement> findRequestedByMember(@Param("memberId") Long memberId);
+
+
+}

--- a/src/main/java/com/ham/netnovel/settlement/SettlementStatus.java
+++ b/src/main/java/com/ham/netnovel/settlement/SettlementStatus.java
@@ -1,0 +1,11 @@
+package com.ham.netnovel.settlement;
+
+
+
+public enum SettlementStatus {
+
+    REQUESTED,        // 정산 신청됨
+    COMPLETED,          // 정산 완료됨
+    REJECTED,         // 정산 거부됨
+    CANCELED_BY_USER  // 유저가 정산 취소
+}

--- a/src/main/java/com/ham/netnovel/settlement/service/SettlementService.java
+++ b/src/main/java/com/ham/netnovel/settlement/service/SettlementService.java
@@ -1,0 +1,65 @@
+package com.ham.netnovel.settlement.service;
+
+
+import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
+import com.ham.netnovel.settlement.Settlement;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public interface SettlementService {
+
+
+
+
+    /**
+     * 작성한 소설에 대한 수익 정보를 조회합니다.
+     *
+     * <p>
+     * 이 메서드는 요청한 유저의 정보를 검증하고, 해당 유저가 작성한 소설 ID 목록을 가져온 후,
+     * 마지막 정산일로부터 어제까지 각 소설이 벌어들인 코인 수와 수익금액 등의 정보를 DTO 형태로 반환합니다.
+     * </p>
+     *
+     * @param providerId 유저 정보
+     * @return 작성한 소설의 수익 정보를 담고 있는 {@link List<NovelRevenueDto>} 객체
+     * @throws NoSuchElementException 요청한 유저 정보가 존재하지 않을 경우
+     * @throws IllegalArgumentException 작성한 소설이 없을 경우
+     */
+    List<NovelRevenueDto> getNovelRevenueByAuthor(String providerId);
+
+
+    /**
+     * 지정된 유저의 가장 최근 정산 날짜를 조회합니다.
+     *
+     * <p>
+     * 이 메서드는 주어진 유저의 ID에 대한 최근 정산 날짜를 조회하며,
+     * 정산 이력이 없을 경우 기본 정산 날짜를 반환합니다.
+     * </p>
+     *
+     * @param memberId 유저의 고유 식별자
+     * @return 유저의 가장 최근 정산 날짜를 나타내는 {@link LocalDateTime} 객체
+     * @throws NoSuchElementException 요청한 유저 ID가 존재하지 않을 경우
+     */
+    LocalDateTime getLatestSettlementDate(Long memberId);
+
+
+    /**
+     * 유저의 정산 요청을 처리하는 메서드입니다.
+     *
+     * <p>요청이 들어오면 유저 정보를 검증하고, 검증이 완료되면 새로운 {@link Settlement}
+     * 엔티티를 생성하여 저장합니다.</p>
+     *
+     * <p>만약 유저가 이미 정산 요청을 한 상태라면,
+     * 새로운 정산 요청을 처리하지 않고 false를 반환하여 메서드를 종료합니다.</p>
+     *
+     * @param providerId 유저의 고유 식별자 (providerId)
+     * @return 정산 요청 처리 성공 여부를 나타내는 boolean 값.
+     *         요청이 성공적으로 처리되었으면 true, 이미 요청이 존재하면 false.
+     * @throws NoSuchElementException 요청한 유저 정보가 존재하지 않을 경우
+     * @throws IllegalArgumentException 유저가 작성한 소설이 없을 경우
+     */
+    boolean processSettlementRequest(String providerId);
+
+
+}

--- a/src/main/java/com/ham/netnovel/settlement/service/SettlementServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/settlement/service/SettlementServiceImpl.java
@@ -1,0 +1,196 @@
+package com.ham.netnovel.settlement.service;
+
+import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
+import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.service.NovelService;
+import com.ham.netnovel.settlement.Settlement;
+import com.ham.netnovel.settlement.SettlementRepository;
+import com.ham.netnovel.settlement.SettlementStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@Slf4j
+public class SettlementServiceImpl implements SettlementService {
+
+    private static final LocalDateTime DEFAULT_SETTLEMENT_DATE = LocalDateTime.of(2024, 1, 1, 0, 0);
+    private static final int COIN_PRICE = 100;
+    private final MemberService memberService;
+    private final NovelService novelService;
+    private final SettlementRepository settlementRepository;
+    private final CoinUseHistoryService coinUseHistoryService;
+
+    @Autowired
+    public SettlementServiceImpl(MemberService memberService, NovelService novelService, SettlementRepository settlementRepository, CoinUseHistoryService coinUseHistoryService) {
+        this.memberService = memberService;
+        this.novelService = novelService;
+        this.settlementRepository = settlementRepository;
+        this.coinUseHistoryService = coinUseHistoryService;
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NovelRevenueDto> getNovelRevenueByAuthor(String providerId) {
+
+        //요청 유저정보 검증
+        Member member = memberService.getMember(providerId)
+                .orElseThrow(() ->
+                        new NoSuchElementException("calculateRevenueByAuthor 에러, 유저정보가 없습니다. providerId=" + providerId));
+
+        //유저가 생성한 소설 ID 목록을 받아옴
+        List<Long> novelIds = novelService.getNovelIdsByAuthor(providerId);
+
+        if (novelIds.isEmpty()) {
+            throw new IllegalArgumentException("작성한 소설이 없습니다.");
+        }
+
+        LocalDate yesterday = LocalDate.now().minusDays(1);//어제날짜
+
+        //유저가 마지막으로 정산받은 날짜, 정산받은 이력이 없을경우 디폴트값 할당됨
+        LocalDate latestSettlementDate = getLatestSettlementDate(member.getId()).toLocalDate();
+
+        //마지막 정산일~ 어제까지 소설별로 얼만큼의 코인을 벌었는지 DTO 에 저장하여 반환
+        return coinUseHistoryService.getCoinUseHistoryByNovelAndDate(novelIds, latestSettlementDate, yesterday);
+    }
+
+    @Override
+    public LocalDateTime getLatestSettlementDate(Long memberId) {
+        try {
+            return settlementRepository
+                    .findLatestSettlementDateByMember(memberId)
+                    .orElse(DEFAULT_SETTLEMENT_DATE);
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getLatestSettlementDate 메서드 에러" + ex + ex.getMessage());
+
+        }
+
+    }
+
+
+    @Override
+    @Transactional
+    public boolean processSettlementRequest(String providerId) {
+        // providerId가 null이거나 비어있는 경우 예외로 던짐
+        if (TypeValidationUtil.isNullOrEmpty(providerId)) {
+            throw new IllegalArgumentException("createSettlement 에러, providerId null 이거나 비었습니다..");
+        }
+        //유저 정보 확인
+        Member member = memberService.getMember(providerId)
+                .orElseThrow(() ->
+                        new NoSuchElementException("createSettlement 에러, 유저정보가 없습니다. providerId=" + providerId));
+
+        //유저가 생성한 소설 ID 목록을 받아옴
+        List<Long> novelIds = novelService.getNovelIdsByAuthor(providerId);
+        // 유저가 작성한 소설이 없는 경우 예외로 던짐
+        if (novelIds.isEmpty()) {
+            throw new IllegalArgumentException("작성한 소설이 없습니다.");
+        }
+
+
+        //유저가 정산 요청중인 이력이 있는지 확인, 있으면 true 반환
+        //이미 정산 요청중일경우 false 반환하고 메서드 종료
+        boolean result = hasRequestedSettlement(member.getId());
+        if (result) {
+            return false;
+        }
+
+        // 유저가 마지막으로 정산받은 날짜를 조회
+        // 정산받은 적이 없을 경우 기본값이 할당
+        LocalDateTime latestSettlementDate = getLatestSettlementDate(member.getId());
+
+
+        // 정산 계산 범위의 시작일을 설정
+        // 유저가 이전에 정산받은 마지막 정산일 또는 기본값 사용
+        LocalDate startDate = latestSettlementDate.toLocalDate();
+        // 정산 계산 범위의 종료일을 설정
+        // 현재 날짜에서 하루를 뺀 값을 사용
+        LocalDate endDate = LocalDate.now().minusDays(1);
+
+        //DB 에서 유저가 작성한 소설이 벌어들인 수익 조회
+        List<NovelRevenueDto> novelRevenueDtos = coinUseHistoryService.getCoinUseHistoryByNovelAndDate(novelIds, startDate, endDate);
+
+        // DB에서 조회된 수익 자료로 Settlement 엔티티를 생성
+        List<Settlement> settlements = createSettlementEntity(
+                novelRevenueDtos,
+                member);
+
+        //DB에 Settlement 엔티티 저장
+        settlementRepository.saveAll(settlements);
+        //true 반환
+        return true;
+    }
+
+
+    /**
+     * 주어진 소설 수익 정보를 기반으로 {@link Settlement} 엔티티 목록을 생성하는 메서드 입니다.
+     *
+     * @param novelRevenueDtos 정산할 소설 수익 정보 목록{@link NovelRevenueDto} 객체
+     * @param member           정산을 요청한 {@link Member} 객체
+     * @return 생성된 정산 {@link Settlement}엔티티 List 객체
+     * @throws NoSuchElementException   소설 정보를 찾을 수 없을 때 발생
+     * @throws IllegalArgumentException 정산 요청자와 소설 작가가 다를 경우 발생
+     */
+    private List<Settlement> createSettlementEntity(
+            List<NovelRevenueDto> novelRevenueDtos,
+            Member member) {
+        //반환을 위한 Settlement List 객체 생성
+        List<Settlement> settlements = new ArrayList<>();
+
+        for (NovelRevenueDto novelRevenueDto : novelRevenueDtos) {
+
+            //Novel 조회, Null 일경우 예외로 던짐
+            Novel novel = novelService.getNovel(novelRevenueDto.getNovelId())
+                    .orElseThrow(() -> new NoSuchElementException("createSettlementEntity 에러, Novel 정보가 없습니다."));
+
+            //정산 요청자와 Novel 작가가 동일한지 검증, 다를경우 예외로 던짐
+            if (!novel.getAuthor().getProviderId().equals(member.getProviderId())) {
+                throw new IllegalArgumentException("createSettlement 메서드 에러, " +
+                        "정산 요청자와 소설 작가가 다릅니다. providerId =" + member.getProviderId() + "novelId = " + novel.getId());
+            }
+
+            //벌어들인 총 코인수
+            Integer totalCoins = novelRevenueDto.getTotalCoins();
+            //수익금 계산
+            int revenue = totalCoins * COIN_PRICE;
+
+            //Settlement 엔티티 생성
+            Settlement build = Settlement.builder()
+                    .coinCount(novelRevenueDto.getTotalCoins())//벌어들인 코인수
+                    .member(member)
+                    .revenue(revenue)//총 수익금
+                    .novel(novel)
+                    .status(SettlementStatus.REQUESTED)//요청상태
+                    .build();
+
+            //List 에 엔티티 추가
+            settlements.add(build);
+        }
+        return settlements;
+
+    }
+
+
+    /**
+     * 유저가 정산을 요청했는지 확인하는 메서드 입니다.
+     *
+     * @param memberId 정산 요청 여부를 확인할 회원의 ID
+     * @return 정산 요청이 있는 경우 {@code true}, 그렇지 않은 경우 {@code false} 반환
+     */
+    private boolean hasRequestedSettlement(Long memberId) {
+        List<Settlement> result = settlementRepository.findRequestedByMember(memberId);
+        return !result.isEmpty();
+    }
+
+}


### PR DESCRIPTION
# 요약
- 작가가 자신의 소설에 대해 수익 정산을 요청하는 기능 추가
- CoinUseHistory를 통해 특정 기간 동안 소설별 수익을 확인할 수 있도록 로직 설계


# 변경사항

## feat: 정산 관련 엔티티 및 레포지토리 추가
### Settlement
- 정산 엔티티 추가
- Member 엔티티와 N:1, Novel 엔티티와 N:1 관계
- coinCount, status(정산 상태: 요청, 거부 등), revenue(수익) 멤버 변수로 가짐

### SettlementRepository
- Settlement 엔티티 DAO 계층 인터페이스 추가
- JpaRepository 상속받아 사용
- findLatestSettlementDateByMember
  - 유저가 마지막으로 정산 받은 날짜를 반환하는 메서드 추가
  - 유저의 정산 기록 중, status가 COMPLETED 상태이고 가장 최근인 날짜를 반환
  - 유저가 정산받은 기록이 없다면 Optional.empty() 반환
- findRequestedByMember
  - 유저가 요청한 정산 목록을 반환하는 메서드 추가
  - 유저의 정산 기록 중, status가 REQUESTED 상태인 Settlement 엔티티를 List로 반환

### SettlementStatus
- 정산 요청의 상태를 나타내는 ENUM 클래스 추가
- REQUESTED(정산 신청됨), COMPLETED(정산 완료됨), REJECTED(정산 거부됨), CANCELED_BY_USER(유저가 정산 취소) 4가지 상태를 가짐



## feat: 정산 관련 서비스 계층 추가
### SettlementService / SettlementServiceImpl
- Settlement 엔티티 서비스 계층 클래스 추가
- 정산 날짜 기본값은 netNovel 서비스 시작일로 변경 필요
- getNovelRevenueByAuthor
  - 작성한 소설에 대한 수익 정보를 반환하는 메서드 추가
  - 유저의 마지막 정산일 ~ 어제까지의 소설별 수익을 반환
  - 유저가 정산한 적이 없는 경우, 기본값 ~ 어제까지의 소설별 수익을 반환
- getLatestSettlementDate
  - 유저가 가장 최근에 정산받은 날짜를 반환하는 메서드 추가
  - 정산받은 기록이 없는 경우 기본 날짜 반환
- processSettlementRequest
  - 유저의 정산 요청을 처리하는 메서드 추가
  - 유저의 마지막 정산일부터 어제까지의 수익을 소설별로 Settlement에 저장하고 DB에 저장

### SettlementServiceImpl
- createSettlementEntity
  - 주어진 소설 수익 정보를 기반으로 Settlement 엔티티 목록을 생성하는 메서드 추가
  - 소설 정보가 없거나, 정산 요청자와 소설 작가가 다른 경우 예외 처리
- hasRequestedSettlement
  - 유저가 정산을 요청했는지 확인하는 메서드 추가
  - Settlement 테이블에서 유저의 REQUESTED 요청이 있는지 확인, 있으면 true 반환

## feat: 날짜와 소설 정보로 벌어들인 수익을 계산하는 로직 추가
### NovelRevenueDto
- 소설별 수익을 담을 DTO 클래스 추가
- novelId, novelTitle, providerId(유저 정보), totalCoins(총 벌어들인 코인 수), settlementStartDate(정산 시작일), settlementEndDate(정산 마지막일)을 멤버 변수로 가짐

### CoinUseHistoryRepository
- findByNovelAndDateTime
  - 주어진 소설 ID 목록에 대해 특정 기간 동안 사용된 코인의 총합을 조회하는 메서드
  - 반환된 객체는 Object[] 타입의 List 객체
  - 소설 ID, 소설 제목, 총 사용된 코인 수, 작가의 providerId를 순서대로 포함하여 반환

### CoinUseHistoryService / CoinUseHistoryServiceImpl
- getCoinUseHistoryByNovelAndDate
  - 주어진 소설 ID 목록과 날짜 범위에 대한 코인 사용 내역을 조회하여 반환하는 메서드 추가
  - 반환 데이터는 NovelRevenueDto로 변환하여 반환

### NovelService / NovelServiceImpl
- getNovelIdsByAuthor
  - 유저가 작성한 소설의 ID 목록을 반환하는 메서드 추가

## refactor: 엔티티 의존관계 추가
- CoinChargeHistory
  - Episode와 N:1 관계 추가

- Episode
  - EpisodeViewCount와 1:N 관계 추가

## refactor: 테스트 API 삭제
### MemberController
- 테스트 API 삭제

## refactor: getMember 파라미터 null 체크 추가

### MemberServiceImpl
- getMember
  - 파라미터 null 체크 추가
  - null 일경우 IllegalArgumentException로 던짐
