### PR TITLE
Novel 생성 및 업데이트 로직 서비스 계층 분리, NovelTag 생성 로직 최적화

### DIFF
--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -6,6 +6,7 @@ import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import com.ham.netnovel.novel.data.NovelSearchType;
 import com.ham.netnovel.novel.dto.*;
+import com.ham.netnovel.novel.service.NovelEditingService;
 import com.ham.netnovel.novel.service.NovelService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +28,12 @@ import java.util.List;
 public class NovelController {
     private final NovelService novelService;
     private final Authenticator authenticator;
+    private final NovelEditingService novelEditingService;
 
-    public NovelController(NovelService novelService, Authenticator authenticator) {
+    public NovelController(NovelService novelService, Authenticator authenticator, NovelEditingService novelEditingService) {
         this.novelService = novelService;
         this.authenticator = authenticator;
+        this.novelEditingService = novelEditingService;
     }
 
     /**
@@ -215,7 +218,7 @@ public class NovelController {
         //DTO에 유저 정보(providerId) 값 저장
         reqBody.setAccessorProviderId(principal.getName());
 
-        Long createdId = novelService.createNovel(reqBody);
+        Long createdId = novelEditingService.createNovel(reqBody);
 
         return ResponseEntity.ok(createdId);
     }
@@ -278,12 +281,7 @@ public class NovelController {
         return ResponseEntity.ok("작품 삭제 완료.");
     }
 
-    @GetMapping("/novels")
-    public ResponseEntity<List<NovelInfoDto>> getNovelsBySorted(@RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
-                                                                @RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
-        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
-        return ResponseEntity.ok(novelService.getNovelsRecent(pageable));
-    }
+
 
     /**
      * 소설의 섬네일을 AWS S3에 업로드하고, 소설의 섬네일 파일명을 업데이트하는 API입니다.

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
@@ -1,9 +1,10 @@
 package com.ham.netnovel.novel.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -20,4 +21,8 @@ public class NovelCreateDto {
     private String description;
 
     private String accessorProviderId; //실행자 유저 ID
+
+    private List<String> tagNames;//작가가 선택한 태그의 이름들
+
+
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Setter
 @ToString
@@ -24,6 +26,8 @@ public class NovelUpdateDto {
 
     @Size(max = 300)
     private String description;
+
+    private List<String> tagNames;
 
     private NovelType type;
 }

--- a/src/main/java/com/ham/netnovel/novel/service/NovelEditingService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelEditingService.java
@@ -1,0 +1,34 @@
+package com.ham.netnovel.novel.service;
+
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.novel.dto.NovelCreateDto;
+import com.ham.netnovel.novel.dto.NovelUpdateDto;
+
+import java.nio.file.AccessDeniedException;
+import java.util.NoSuchElementException;
+
+public interface NovelEditingService {
+
+    /**
+     * 주어진 소설 생성 DTO를 기반으로 새로운 소설을 생성하는 메서드입니다.
+     *
+     * <p>유저 정보를 DB에서 찾고, 없으면 예외로 던집니다.</p>
+     * <p>DTO에 등록된 정보로 소설 엔티티를 생성하여 DB에 저장합니다.</p>
+     * <p>유저의 ROLE이 READER인 경우 AUTHOR로 변경하여 DB에 저장합니다.</p>
+     *
+     * @param novelCreateDto 새 소설의 데이터가 포함된 {@link NovelCreateDto} 객체입니다.
+     * @return 생성된 소설의 ID입니다.
+     * @throws NoSuchElementException 해당 작가가 존재하지 않을 경우 발생합니다.
+     * @throws ServiceMethodException 소설 생성 중 오류가 발생할 경우 발생합니다.
+     */
+    Long createNovel(NovelCreateDto novelCreateDto);
+
+
+
+    Boolean updateNovel(NovelUpdateDto novelUpdateDto) throws AccessDeniedException;
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/novel/service/NovelEditingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelEditingServiceImpl.java
@@ -1,0 +1,296 @@
+package com.ham.netnovel.novel.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.member.Member;
+import com.ham.netnovel.member.data.MemberRole;
+import com.ham.netnovel.member.service.MemberService;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.data.NovelStatus;
+import com.ham.netnovel.novel.data.NovelType;
+import com.ham.netnovel.novel.dto.NovelCreateDto;
+import com.ham.netnovel.novel.dto.NovelUpdateDto;
+import com.ham.netnovel.novel.repository.NovelRepository;
+import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
+import com.ham.netnovel.novelTag.dto.NovelTagDeleteDto;
+import com.ham.netnovel.novelTag.service.NovelTagService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.AccessDeniedException;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class NovelEditingServiceImpl implements NovelEditingService {
+
+
+    private final NovelTagService novelTagService;
+    private final MemberService memberService;
+
+    private final NovelRepository novelRepository;
+
+    public NovelEditingServiceImpl(NovelTagService novelTagService, MemberService memberService, NovelRepository novelRepository) {
+        this.novelTagService = novelTagService;
+        this.memberService = memberService;
+        this.novelRepository = novelRepository;
+    }
+
+
+    /**
+     * 주어진 소설 생성 DTO를 기반으로 새로운 소설을 생성하는 메서드 입니다.
+     *
+     * <p>유저 정보를 DB에서 찾고, 없으면 예외로 던집니다.</p>
+     * <p>DTO에 등록된 정보로 소설 엔티티를 생성하여 DB에 저장합니다.</p>
+     * <p>유저의 ROLE 이 READER 인경우 AUTHOR로 변경하여 DB에 저장합니다.</p>
+     *
+     * @param novelCreateDto 새 소설의 데이터가 포함된 {@link NovelCreateDto} 객체
+     * @return 생성된 소설의 ID
+     * @throws NoSuchElementException 해당 작가가 존재하지 않을 경우
+     * @throws ServiceMethodException 소설 생성 중 오류가 발생할 경우
+     */
+    @Override
+    @Transactional
+    public Long createNovel(NovelCreateDto novelCreateDto) {
+        //Member Entity 조회 -> Author 검증
+        Member author = memberService.getMember(novelCreateDto.getAccessorProviderId())
+                .orElseThrow(() -> new NoSuchElementException("createNovel 메서드 에러, 존재하지 않는 Member 입니다. providerId ="
+                        + novelCreateDto.getAccessorProviderId()));
+
+        try {
+            //Novel 생성
+            Novel targetNovel = Novel.builder()
+                    .title(novelCreateDto.getTitle())
+                    .description(novelCreateDto.getDescription())
+                    .author(author)
+                    .type(NovelType.ONGOING)
+                    .status(NovelStatus.ACTIVE)
+                    .build();
+
+            //DB에 내용 저장
+            Novel novel = novelRepository.save(targetNovel);
+
+            //작가가 작성한 태그를 소설에 추가(NovelTag junction table로 매핑)
+            //태그명으로 된 태그엔티티가 없는경우, 새로 생성하여 저장됨
+            addTagsToNovel(novelCreateDto.getTagNames(), novel.getId());
+
+            //작가가 READER ROLE을 갖고있으면 작가 상태로 변경
+            if (author.getRole().equals(MemberRole.READER)) {
+                memberService.changeMemberToAuthor(author);
+            }
+            log.info("새로운 소설 생성 완료! novelId ={}", novel.getId());
+            //생성된 Novel의 ID 값 반환
+            return novel.getId();
+        } catch (Exception ex) {
+            //나머지 예외처리
+            throw new ServiceMethodException("createNovel 메서드 에러 발생" + ex + ex.getMessage());
+        }
+    }
+
+
+    /**
+     * 소설 정보를 업데이트하는 메서드입니다.
+     * <p>변경되는 소설 정보는 제목, 설명, 타입이며, 변경 사항이 있는 경우에만 업데이트합니다.</p>
+     *
+     * <p>태그를 변경할 때는 기존의 태그 중 삭제되는 태그는 NovelTag 테이블에서 제거하고,
+     * 새로 추가된 태그는 NovelTag 테이블에 추가합니다.</p>
+     *
+     * @param novelUpdateDto 소설 업데이트에 필요한 정보를 담고 있는 {@link NovelUpdateDto} 객체
+     * @return 업데이트 성공 시 true를 반환합니다.
+     * @throws AccessDeniedException 요청자가 소설의 작가가 아닌 경우 발생합니다.
+     * @throws NoSuchElementException 주어진 novelId에 해당하는 소설이 존재하지 않을 경우 발생합니다.
+     * @throws ServiceMethodException 서비스 메서드 실행 중 예외가 발생할 경우 발생합니다.
+     */
+    @Override
+    @Transactional
+    public Boolean updateNovel(NovelUpdateDto novelUpdateDto) throws AccessDeniedException {
+
+        //Novel DB 데이터 검증
+        Novel novel = novelRepository.findById(novelUpdateDto.getNovelId())
+                .orElseThrow(() -> new NoSuchElementException("updateNovel 에러, 존재하지 않는 Novel 입니다. " +
+                        "novelId= " + novelUpdateDto.getNovelId()));
+
+        //소설 변경 요청자와 작가가 같은지 검증, 다를경우 예외로 던짐
+        validateNovelAuthor(novelUpdateDto.getAccessorProviderId()
+                , novel.getAuthor().getProviderId());
+
+        try {
+            //유저가 변경하고자 하는 부분만 업데이트(제목/설명/타입)
+            updateNovelIfPresent(novel::updateTitle, novelUpdateDto.getTitle());
+            updateNovelIfPresent(novel::updateDesc, novelUpdateDto.getDescription());
+            updateNovelIfPresent(novel::updateType, novelUpdateDto.getType());
+            //DB에 Novel 엔티티 변경내용 저장
+            novelRepository.save(novel);
+
+            // 유저가 선택한 태그 이름을 양쪽 공백 제거 후 중복 제거 후 List 객체 생성
+            List<String> newTagNames = novelUpdateDto.getTagNames()
+                    .stream()
+                    .map(String::trim)
+                    .distinct()//중복제거
+                    .toList();
+
+            //소설과 연결된 Tag들의 이름을 List 객체로 가져옴
+            List<String> novelTagList = getNovelTagList(novel);
+            // 새로운 태그 리스트와 현재 태그 리스트를 비교하여 업데이트 진행
+            updateTagsToNovel(newTagNames, novelTagList,novel.getId());
+
+            //변경이 성공적임을 true를 반환하여 알림
+            return true;
+        } catch (Exception ex) {
+            throw new ServiceMethodException("updateNovel 메서드 에러 발생", ex.getCause());
+        }
+    }
+
+    /**
+     * 작업 요청자와 소설 작가가 동일한지 검증하는 메서드 입니다.
+     *
+     * @param providerId       작업 요청자의 providerId
+     * @param authorProviderId 소설 작가의 providerId
+     * @throws AccessDeniedException 작업 요청자와 소설 작가가 다른경우
+     */
+    private void validateNovelAuthor(String providerId, String authorProviderId)
+            throws AccessDeniedException {
+        //요청자의 providerId가 작가의 providerId와 같은지 검증
+        boolean result = providerId.equals(authorProviderId);
+        //다를경우 예외로 던짐
+        if (!result) {
+            throw new AccessDeniedException("해당 Novel에 접근 권한이 없습니다.");
+        }
+    }
+
+    /**
+     * 주어진 값이 존재하고 유효한 경우, 주어진 업데이트 함수를 사용하여 값을 업데이트하는 메서드 입니다.
+     *
+     * <p>값이 null이 아니고, 값이 String인 경우에는 비어 있지 않은지 확인합니다.
+     * 비어 있지 않은 경우에만 업데이트 함수가 실행됩니다.</p>
+     *
+     * @param updateFunction 값이 존재할 때 실행할 업데이트 함수
+     * @param value          업데이트할 값. null일 수 있으며, String일 경우 비어있지 않아야 합니다.
+     */
+    private <T> void updateNovelIfPresent(Consumer<T> updateFunction, T value) {
+        if (value != null && (!(value instanceof String) || !((String) value).isBlank())) {
+            updateFunction.accept(value);
+        }
+    }
+
+    /**
+     * 주어진 태그를 소설에 추가하는 메서드입니다.
+     * <p>
+     * 태그 이름 리스트가 비어있거나 소설 ID가 null인 경우, 메서드는 아무 작업도 수행하지 않고 종료합니다.
+     * </p>
+     * <p>
+     * 각 태그 이름에 대해 NovelTagCreateDto를 생성하고, 해당 소설 ID와 태그 이름을 설정한 후
+     * novelTagService를 통해 소설과 태그 간의 관계를 추가합니다.
+     * </p>
+     *
+     * @param tagNames 추가할 태그 이름의 리스트
+     * @param novelId 태그가 추가될 소설의 ID
+     */
+    private void addTagsToNovel(List<String> tagNames, Long novelId) {
+
+        //태그 이름을 담는 리스트가 비어있거나 novelID가 null이면 메서드 종료
+        if (tagNames == null || tagNames.isEmpty() || novelId == null) {
+            return;
+        }
+        //novelTag 엔티티에 소설정보와 태그정보 추가
+        //태그명으로 된 엔티티가 없을경우, 새로만들어서 추가
+        for (String tagName : tagNames) {
+            NovelTagCreateDto build = NovelTagCreateDto.builder()
+                    .novelId(novelId)
+                    .tagName(tagName)
+                    .build();
+
+            //junction table에 소설과 tag 관계 추가
+            novelTagService.createNovelTag(build);
+        }
+    }
+
+    /**
+     * 주어진 태그를 소설에서 삭제하는 메서드입니다.
+     * <p>
+     * 태그 이름 리스트가 비어있거나 소설 ID가 null인 경우, 메서드는 아무 작업도 수행하지 않고 종료합니다.
+     * </p>
+     * <p>
+     * 각 삭제할 태그 이름에 대해 NovelTagDeleteDto를 생성하고, 해당 소설 ID와 태그 이름으로
+     * novelTagService를 통해 소설에서 태그를 삭제합니다.
+     * </p>
+     *
+     * @param deleteTagNames 삭제할 태그 이름의 리스트
+     * @param novelId 태그가 삭제될 소설의 ID
+     */
+    private void deletedTagsToNovel(List<String> deleteTagNames,Long novelId) {
+        //태그 이름을 담는 리스트가 비어있거나 novelID가 null이면 메서드 종료
+        if (deleteTagNames==null || deleteTagNames.isEmpty() || novelId == null) {
+            return;
+        }
+        //반복문을 돌며, NovelTag 엔티티 삭제
+        for (String deletedTag : deleteTagNames) {
+            NovelTagDeleteDto deleteDto = NovelTagDeleteDto.builder()
+                    .tagName(deletedTag)
+                    .novelId(novelId)
+                    .build();
+
+            //엔티티 삭제
+            novelTagService.deleteNovelTag(deleteDto);
+        }
+    }
+
+    /**
+     * 소설의 태그를 업데이트하는 메서드입니다.
+     * <p>
+     * 기존 태그 목록에서 새로운 태그 목록에 없는 태그는 삭제하고,
+     * 새로운 태그 목록에서 기존 태그 목록에 없는 태그는 추가합니다.
+     * </p>
+     *
+     * @param updateTagNames 소설에 추가할 새로운 태그 이름의 리스트
+     * @param existingTagNames 소설에 현재 연결된 태그 이름의 리스트
+     * @param novelId 태그가 업데이트될 소설의 ID
+     */
+    private void updateTagsToNovel(List<String> updateTagNames,
+                                   List<String> existingTagNames,
+                                   Long novelId) {
+
+
+        // 기존 태그 목록에서 새로운 태그 목록에 없는 태그를 추출하여 삭제
+
+        List<String> deleteTags = existingTagNames.stream()
+                .filter(novelTag -> !updateTagNames.contains(novelTag))
+                .toList();
+        deletedTagsToNovel(deleteTags,novelId);
+
+        // 새로운 태그 목록에서 기존 태그 목록에 없는 태그를 추출하여 추가
+        List<String> newTags = updateTagNames
+                .stream()
+                .filter(novelTag -> !existingTagNames.contains(novelTag))
+                .toList();
+        addTagsToNovel(newTags, novelId);
+    }
+
+
+    /**
+     * 주어진 소설의 태그 목록을 반환하는 메서드입니다.
+     * <p>
+     * 소설이 null이거나 소설에 연결된 태그 목록이 null인 경우, 빈 리스트를 반환합니다.
+     * </p>
+     *
+     * @param novel 태그 목록을 가져올 {@link Novel} 객체
+     * @return 소설에 연결된 태그 이름의 리스트. 소설이 null이거나 태그 목록이 없을 경우 빈 리스트를 반환합니다.
+     */
+    private List<String> getNovelTagList(Novel novel){
+        // 널 체크 및 빈 리스트 반환
+        if (novel == null || novel.getNovelTags() == null) {
+            return Collections.emptyList();
+        }
+       return novel.getNovelTags().stream()
+                .map(novelTag -> novelTag.getTag().getName())
+               .collect(Collectors.toList());
+    }
+
+
+
+
+}

--- a/src/main/java/com/ham/netnovel/novel/service/NovelService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelService.java
@@ -43,18 +43,7 @@ public interface NovelService {
    List<Long> getNovelIdsByAuthor(String providerId);
 
 
-    /**
-     * 유저가 생성한 Novel을 DB 저장.
-     * @param novelCreateDto 생성 정보가 담긴 dto
-     * @return 생성한 episode id 값
-     */
-    Long createNovel(NovelCreateDto novelCreateDto);
 
-    /**
-     * DB에 저장된 Novel 데이터 변경.
-     * @param novelUpdateDto 업데이트 정보가 담긴 dto
-     */
-    void updateNovel(NovelUpdateDto novelUpdateDto);
 
     /**
      * DB에 저장된 Novel 삭제.

--- a/src/main/java/com/ham/netnovel/novelTag/dto/NovelTagDeleteDto.java
+++ b/src/main/java/com/ham/netnovel/novelTag/dto/NovelTagDeleteDto.java
@@ -15,4 +15,6 @@ public class NovelTagDeleteDto {
 
     @NotNull
     private Long tagId;
+
+    private String tagName;
 }

--- a/src/main/java/com/ham/netnovel/novelTag/service/NovelTagService.java
+++ b/src/main/java/com/ham/netnovel/novelTag/service/NovelTagService.java
@@ -2,7 +2,6 @@ package com.ham.netnovel.novelTag.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.novelTag.NovelTag;
-import com.ham.netnovel.novelTag.NovelTagId;
 import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
 import com.ham.netnovel.novelTag.dto.NovelTagDeleteDto;
 import com.ham.netnovel.novelTag.dto.NovelTagListDto;
@@ -42,11 +41,6 @@ public interface NovelTagService {
      */
     Boolean createNovelTag(NovelTagCreateDto createDto);
 
-//    NovelTagId createNovelTag(Long novelId, Long tagId);
 
-    /**
-     * Novel에서 Tag를 제거하는 메서드
-     * @param deleteDto novel id, tag id
-     */
     void deleteNovelTag(NovelTagDeleteDto deleteDto);
 }

--- a/src/main/java/com/ham/netnovel/novelTag/service/NovelTagService.java
+++ b/src/main/java/com/ham/netnovel/novelTag/service/NovelTagService.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.novelTag.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.novelTag.NovelTag;
 import com.ham.netnovel.novelTag.NovelTagId;
 import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
@@ -7,6 +8,7 @@ import com.ham.netnovel.novelTag.dto.NovelTagDeleteDto;
 import com.ham.netnovel.novelTag.dto.NovelTagListDto;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public interface NovelTagService {
@@ -28,11 +30,17 @@ public interface NovelTagService {
     List<NovelTagListDto> getTagsByNovel(Long novelId);
 
     /**
-     * Novel에 Tag를 항달하는 메서드
-     * @param createDto novel id, tag 이름
-     * @return NovelTagId
+     * 소설과 태그를 연결하는 메서드입니다.
+     *
+     * <p>주어진 소설 ID와 태그명을 기반으로 태그를 소설에 연결합니다.
+     * 태그가 존재하지 않을 경우 레코드를 생성한 후 소설에 태그를 추가합니다.</p>
+     *
+     * @param createDto 소설 ID와 태그명을 포함하는 {@link NovelTagCreateDto} 객체
+     * @return 소설에 태그를 성공적으로 추가하면 {@code true}, 이미 태그가 존재하면 {@code false} 반환
+     * @throws NoSuchElementException 소설 ID로 소설을 찾을 수 없을 때 발생
+     * @throws ServiceMethodException 태그 추가 과정에서 예외 발생 시 발생
      */
-    NovelTagId createNovelTag(NovelTagCreateDto createDto);
+    Boolean createNovelTag(NovelTagCreateDto createDto);
 
 //    NovelTagId createNovelTag(Long novelId, Long tagId);
 

--- a/src/main/java/com/ham/netnovel/novelTag/service/NovelTagServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novelTag/service/NovelTagServiceImpl.java
@@ -10,20 +10,19 @@ import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
 import com.ham.netnovel.novelTag.dto.NovelTagDeleteDto;
 import com.ham.netnovel.novelTag.dto.NovelTagListDto;
 import com.ham.netnovel.tag.Tag;
-import com.ham.netnovel.tag.dto.TagCreateDto;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
 import com.ham.netnovel.tag.service.TagService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 public class NovelTagServiceImpl implements NovelTagService {
 
     private final NovelTagRepository novelTagRepository;
@@ -62,40 +61,37 @@ public class NovelTagServiceImpl implements NovelTagService {
 
     @Override
     @Transactional
-    public NovelTagId createNovelTag(NovelTagCreateDto createDto) {
-        //작품 레코드 조회 검증
+    public Boolean createNovelTag(NovelTagCreateDto createDto) {
+        //작품 레코드 조회 검증하여 문제없을경우 객체 생성
         Novel novel = novelService.getNovel(createDto.getNovelId())
                 .orElseThrow(() -> new NoSuchElementException("createNovelTag() Error : Novel return value is null. novelId=" + createDto.getNovelId()));
-        try {
-            //같은 이름의 태그 레코드 존재하는지 조회
-            Tag tag = tagService.getTagByName(createDto.getTagName())
-                    .orElseGet(() -> {
-                        //존재하지 않는다면 새로 생성.
-                        Long newTagId = tagService.createTag(TagCreateDto.builder().name(createDto.getTagName()).build());
-                        return tagService.getTag(newTagId)
-                                .orElseThrow(() -> new NoSuchElementException("Error In Create New Tag"));
-                    });
 
+        //태그 엔티티 객체 생성, DB에 있을경우 가져오고 없을경우 생성해서 가져옴
+        Tag tag = tagService.getOrCreateTag(createDto.getTagName());
+
+        try {
             //NovelTag 생성에 사용할 NovelTagId 값 생성
             NovelTagId novelTagId = new NovelTagId(novel.getId(), tag.getId());
 
-            //NovelTag 레코드가 존재하는지 조회 검증
-            novelTagRepository.findById(novelTagId)
-                    .ifPresent((value) -> {
-                        throw new DataIntegrityViolationException("Already Existing NovelTag Record");
+            //NovelTag 엔티티가 있을경우 false 반환, 없을경우 새로 생성후 true 반환
+            return novelTagRepository.findById(novelTagId)
+                    .map(novelTag -> {
+                        log.warn("이미 소설에 태그 정보가 등록되어 있습니다" +
+                                "novel id =" + novel.getId() + " tagId=" + tag.getId());
+                        return false;
+                    })
+                    .orElseGet(() -> {
+                        novelTagRepository.save(NovelTag.builder()
+                                .id(novelTagId)
+                                .novel(novel)
+                                .tag(tag)
+                                .build());
+
+                        return true;
                     });
 
-            //DB에 저장
-            novelTagRepository.save(NovelTag.builder()
-                            .id(novelTagId)
-                            .novel(novel)
-                            .tag(tag)
-                    .build());
-
-            return novelTagId;
-
         } catch (Exception ex) {
-            throw new ServiceMethodException("createNovelTag() Error : "  + ex.getMessage());
+            throw new ServiceMethodException("createNovelTag메서드 에러 : " + ex + ex.getMessage());
         }
     }
 
@@ -124,7 +120,7 @@ public class NovelTagServiceImpl implements NovelTagService {
                 tagService.deleteTag(TagDeleteDto.builder().tagId(tag.getId()).build());
             }
         } catch (Exception ex) {
-            throw new ServiceMethodException("deleteNovelTag() Error : "  + ex.getMessage());
+            throw new ServiceMethodException("deleteNovelTag() Error : " + ex.getMessage());
         }
 
     }

--- a/src/main/java/com/ham/netnovel/tag/service/TagService.java
+++ b/src/main/java/com/ham/netnovel/tag/service/TagService.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.tag.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.tag.Tag;
-import com.ham.netnovel.tag.dto.TagCreateDto;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
 
 import java.util.Optional;
@@ -24,11 +24,29 @@ public interface TagService {
 
 
     /**
-     * 새 Tag 등록 메서드
-     * @param createDto Tag 콘텐츠가 들어 있음.
-     * @return Long 생성한 Tag 레코드의 PK 값
+     * 새로운 태그를 생성하는 메서드입니다.
+     *
+     * <p>태그명은 검증 후, 이미 존재하는 태그명이 아닐 경우 새롭게 태그를 생성하여 저장합니다.
+     * 태그는 한글, 숫자, 영문으로 구성된 10자 이하의 문자열이어야 하며, null 또는 빈 값일 수 없습니다.</p>
+     *
+     * @param tagName 생성할 태그명 (10자 이하의 한글/숫자/영문으로 구성)
+     * @return 생성된 {@link Tag} 엔티티 객체
+     * @throws ServiceMethodException 만약 태그명이 이미 존재하거나 예외가 발생할 경우
+     *
      */
-    Long createTag(TagCreateDto createDto);
+    Tag createTag(String tagName);
+
+     /**
+     * 주어진 태그명을 기준으로 태그를 조회하거나, 존재하지 않으면 새로 생성하는 메서드입니다.
+     *
+     * <p>태그명이 존재하면 해당 태그를 반환하고, 태그명이 없을 경우 새로운 태그를 생성하여 반환합니다.</p>
+     *
+     * @param tagName 조회 또는 생성할 태그명 (10자 이하의 한글/숫자/영문으로 구성)
+     * @return 기존 또는 새로 생성된 {@link Tag} 엔티티 객체
+     * @throws ServiceMethodException 태그 조회 또는 생성 과정에서 발생한 예외
+     *
+     */
+    Tag getOrCreateTag(String tagName);
 
     /**
      * 등록된 Tag 제거 메서드

--- a/src/main/java/com/ham/netnovel/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/tag/service/TagServiceImpl.java
@@ -4,8 +4,8 @@ import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.tag.Tag;
 import com.ham.netnovel.tag.TagRepository;
 import com.ham.netnovel.tag.TagStatus;
-import com.ham.netnovel.tag.dto.TagCreateDto;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,14 +14,15 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
-public class TagServiceImpl implements TagService{
+@Slf4j
+public class TagServiceImpl implements TagService {
 
-    TagRepository tagRepository;
+   private final TagRepository tagRepository;
 
-    @Autowired
     public TagServiceImpl(TagRepository tagRepository) {
         this.tagRepository = tagRepository;
     }
+
 
     @Override
     @Transactional(readOnly = true)
@@ -37,21 +38,88 @@ public class TagServiceImpl implements TagService{
 
     @Override
     @Transactional
-    public Long createTag(TagCreateDto createDto) {
-        try {
-            if (tagRepository.existsByName(createDto.getName())) {
-                throw new RuntimeException("이미 존재하는 값입니다.");
-            }
+    public Tag createTag(String tagName) {
 
-            Tag newRecord = Tag.builder()
-                    .name(createDto.getName())
+        //파라미터 검증, 태그가 null 이거나 비어있으면 안되고, 10글자 이하의 한글/숫자/영문 이여야함
+        String validateTagName = validateTagName(tagName);
+
+        //태그명이 존재하는 경우 예외로 던짐
+        if (tagRepository.existsByName(validateTagName)) {
+            throw new ServiceMethodException("createTag 에러, 동일한 태그명이 존재합니다. 태그명={}" + tagName);
+        }
+
+        try {
+            //새로운 tag 엔티티 객체 생성
+            Tag tag = Tag.builder()
+                    .name(validateTagName)
                     .status(TagStatus.ACTIVE)
                     .build();
-            Tag saved = tagRepository.save(newRecord);
-            return saved.getId();
+
+            //만들어진 Tag 엔티티 반환
+
+            Tag save = tagRepository.save(tag);
+            log.info("새로운 Tag 생성 완료, 태그명 ={} ",save.getId());
+            return save;
+
         } catch (Exception ex) {
             throw new ServiceMethodException("createTag() Error : " + ex.getMessage());
         }
+    }
+
+    @Override
+    @Transactional
+    public Tag getOrCreateTag(String tagName) {
+        try {
+            //태그 엔티티를 가져와서 반환하거나,
+            // DB에 태그 엔티티가 없으면 새로만들어서 반환
+            Optional<Tag> tagByName = getTagByName(tagName);
+
+            return tagByName.orElseGet(() -> createTag(tagName));
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getOrCreateTag 에러 : " + ex + ex.getMessage());
+        }
+
+    }
+
+    /**
+     * 태그명의 유효성을 검사하는 메서드 입니다.
+     *
+     * <p>
+     * 태그명이 null 이거나 객체가 비어있는 경우 예외로 던집니다.
+     * </p>
+     *
+     * <p>
+     * 태그명 앞뒤 공백을 제거한후 10자 이상이거나, 영어/한글/숫자 외의 문자가
+     * 포함된경우 예외로 던집니다.
+     * </p>
+     *
+     * @param tagName 태그명
+     * @return 앞뒤 공백을 제거한 태그명 {@link String} 객체
+     */
+    private String validateTagName(String tagName) {
+
+        //파라미터 null, 비어있는지 체크
+        if (tagName == null || tagName.isEmpty()) {
+            throw new IllegalArgumentException("validateTagName 메서드 에러, 파라미터가 null 이거나 비었습니다.");
+        }
+
+        //비어있지 않으면, 앞뒤 공백 제거한 객체 생성
+        String trimmedName = tagName.trim();
+
+        //앞뒤 공백 제거한 길이가 10자리 이상이면 예외로 던짐
+        if (trimmedName.length() > 10) {
+            throw new IllegalArgumentException("validateTagName 메서드 에러, 파라미터가 10자를 넘어갑니다. tagName= " + tagName);
+        }
+
+        // 영어, 숫자, 한글, 중간 공백만 허용하는 정규식,
+        if (!trimmedName.matches("[a-zA-Z0-9가-힣 ]+")) {
+            throw new IllegalArgumentException("validateTagName 메서드 에러, 영어, 숫자, 한글 및 중간 공백만 허용됩니다. tagName= " + tagName);
+        }
+
+        //이상 없으면 앞뒤공백 자른 태그이름 반환
+        return trimmedName;
+
+
     }
 
     @Override


### PR DESCRIPTION
# 변경사항
## 요약
- Novel 생성/업데이트 로직 NovelService 에서 NovelEditingService 로 분리(순환참조 문제)
- NovelTag 생성 로직 최적화

## 순환 참조 문제를 피하기 위해 별도의 서비스 계층으로 분리

### NovelEditingService/NovelEditingServiceImpl
- createNovel, updateNovel
  - 기존 NovelService의 메서드를 분리하여 생성

- validateNovelAuthor
  - 작업 요청자와 소설 작가가 동일한지 검증하는 메서드 추가
  - 동일하지 않을 경우 예외를 던짐

- updateNovelIfPresent
  - 주어진 값이 존재하고 유효한 경우, 해당 값을 업데이트하는 메서드 추가
  - 파라미터 `updateFunction`에는 수정할 필드의 업데이트 메서드를, `value`에는 업데이트할 값을 받음
  - `value` 값이 비어있는 경우 메서드 종료

- addTagsToNovel
  - 태그 이름 리스트를 받아 Novel과의 관계를 생성하는 메서드
  - 태그 이름 리스트가 비어있거나 `novelId`가 null인 경우 메서드 종료
  - `novelTagService.createNovelTag()` 메서드 사용

- deletedTagsToNovel
  - 태그 이름 리스트를 받아 Novel과의 관계를 삭제하는 메서드
  - 태그 이름 리스트가 비어있거나 `novelId`가 null인 경우 메서드 종료
  - `novelTagService.deleteNovelTag()` 메서드 사용

- *pdateTagsToNovel
  - 소설의 태그를 업데이트하는 메서드 추가
  - 새로운 태그는 `addTagsToNovel`로 추가
  - 기존 태그는 `deletedTagsToNovel`로 제거

- getNovelTagList
  - 주어진 소설의 태그 목록을 반환하는 메서드 추가
  - 소설과 관계가 있는 태그 이름만 추출하여 리스트로 반환

### NovelService/NovelServiceImpl
- createNovel, updateNovel 메서드 삭제

### NovelCreateDto
- List<String> tagNames 멤버변수 추가

### NovelUpdateDto
- List<String> tagNames 멤버변수 추가

### NovelTagDeleteDto
- String tagName 멤버변수 추가

### NovelController
- NovelEditingService 의존관계 주입

- getNovelsBySorted
  - getNovelsBySearchCondition 로 기능통합 삭제

- createNovel
  - 사용 메서드 novelService.createNovel 에서 novelEditingService.createNovel로 변경


## NovelTag 삭제 로직 수정

### NovelTagServiceImpl
- deleteNovelTag
  - Novel 엔티티 객체 호출 로직 제거(불필요)
  - Tag가 어떤 Novel과도 연관이 없을 때 삭제하는 로직 제거 (단일 책임 원칙 위반)

## NovelTag 생성 로직 수정
### NovelTagService/NovelTagServiceImpl

- createNovelTag
  - 반환 타입을 NovelTagId 에서 Boolean 타입으로 변경
  - 소설에 파라미터로 받은 태그가 이미 등록되어있는 경우 log를 남기고 false 반환, 소설에 파라미터로 받은 태그가 등록되지 않은경우 NovelTag 엔티티를 생성해 DB에 저장한 후 true 반환 하도록 로직 변경

## 태그 생성 로직 수정 및 검증 추가
- String 타입의 태그명을 받아 처리하도록 변경
- 태그명을 받아 DB에서 조회하거나, 없을 경우 새로 생성하는 로직 추가

### TagService/TagServiceImpl
- createTag
  - 파라미터를 DTO에서 String 타입의 tagName으로 변경
  - 반환 타입을 Long에서 Tag 타입으로 변경 (생성된 태그 엔티티 객체 반환)

- getOrCreateTag
  - 태그명을 받아 해당 태그 엔티티 객체를 반환하는 메서드 추가
  - DB에서 태그를 조회해 반환하고, 없을 경우 createTag 메서드를 호출해 태그를 생성한 후 반환

### TagServiceImpl
- validateTagName
  - 태그명을 검증하는 메서드 추가
  - 태그명이 null, 비어있거나, 앞뒤 공백 제거 후 10자 이상이거나, 영어/한글/숫자 외의 문자가 포함된 경우 예외 발생
  - 문제가 없을 경우, 앞뒤 공백을 제거한 태그명을 반환
