### PR TITLE
소설의 수익을 전달하는 DTO 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/coinUseHistory/dto/NovelRevenueDto.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/dto/NovelRevenueDto.java
@@ -1,0 +1,42 @@
+package com.ham.netnovel.coinUseHistory.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NovelRevenueDto {
+
+    @NotNull
+    private Long novelId;
+
+    @NotNull
+    private String novelTitle;
+
+    @NotNull
+    private String providerId;//작가 정보
+
+    @NotNull
+    private Integer totalCoins;
+
+
+    // 정산 기간을 명확히 하기 위한 필드, 정산시작일
+    @NotNull
+    private LocalDate settlementStartDate;
+    // 정산 기간을 명확히 하기 위한 필드, 정산마지막일(정산신청일 전날)
+    @NotNull
+    private LocalDate settlementEndDate;
+
+
+    public NovelRevenueDto(Long novelId, String novelTitle, Integer totalCoins) {
+        this.novelId = novelId;
+        this.novelTitle = novelTitle;
+        this.totalCoins = totalCoins;
+    }
+}


### PR DESCRIPTION
# 변경사항

### NovelRevenueDto
- 소설 수익 정보를 전달할때 사용하는 DTO 추가
- novelId, novelTitle, providerId(작가정보), totalCoins(총 벌어들인 코인 수), settlementStartDate(수익산정 시작 날자),settlementEndDate(수익산정 마지막 날짜) 를 멤버변수로 가짐