### PR TITLE
Tag 검색 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/tag/TagController.java
+++ b/src/main/java/com/ham/netnovel/tag/TagController.java
@@ -1,0 +1,49 @@
+package com.ham.netnovel.tag;
+
+import com.ham.netnovel.tag.service.TagService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequestMapping("/api")
+
+public class TagController {
+
+    private final TagService tagService;
+
+    public TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+
+
+    /**
+     * 주어진 검색어를 기반으로 태그 이름 목록을 반환하는 API입니다.
+     * <p>
+     * 검색어를 포함하는 태그의 이름을 List로 받아 전송합니다.
+     * </p>
+     * <p>
+     * 만약 검색어 길이가 10자를 넘어가거나, 비어있으면 빈 리스트를 반환합니다.
+     * </p>
+     *
+     * @param searchWord 검색할 태그의 일부 또는 전체 이름
+     * @return 검색어와 일치하는 태그 이름 목록을 담은 ResponseEntity 객체
+     */
+    @GetMapping("/tags")
+    public ResponseEntity<?> getTagNamesBySearchWord(@RequestParam(name = "searchWord")String searchWord){
+
+        //태그네임으로 검색
+        List<String> tagNamesBySearchWord = tagService.getTagNamesBySearchWord(searchWord);
+
+        //검색 결과 반환
+        return ResponseEntity.ok(tagNamesBySearchWord);
+
+    }
+
+}

--- a/src/main/java/com/ham/netnovel/tag/TagRepository.java
+++ b/src/main/java/com/ham/netnovel/tag/TagRepository.java
@@ -1,7 +1,10 @@
 package com.ham.netnovel.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
@@ -9,6 +12,21 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     //unique 속성의 name 프로퍼티로 Tag 조회
     Optional<Tag> findByName(String name);
+
+    /**
+     * 주어진 검색어를 기반으로 태그 이름 목록을 조회하는 메서드 입니다.
+     * <p>
+     * 태그 이름이 검색어를 포함하는 경우에 해당하는 태그 이름을 반환합니다.
+     * 검색어는 부분 일치로 검색됩니다.
+     * </p>
+     *
+     * @param searchWord 검색할 태그의 일부 또는 전체 이름
+     * @return 검색어와 일치하는 태그 이름 목록
+     */
+    @Query("select t.name " +
+            "from Tag t " +
+            "where t.name like %:searchWord%")
+    List<String> findBySearchWord(@Param("searchWord")String searchWord);
 
     //unique 속성의 name 값 중복 확인
     boolean existsByName(String name);

--- a/src/main/java/com/ham/netnovel/tag/service/TagService.java
+++ b/src/main/java/com/ham/netnovel/tag/service/TagService.java
@@ -4,6 +4,7 @@ import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.tag.Tag;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagService {
@@ -21,6 +22,18 @@ public interface TagService {
      * @return Optional
      */
     Optional<Tag> getTagByName(String tagName);
+
+
+    /**
+     * 주어진 검색어를 기반으로 태그 이름 목록을 반환하는 메서드입니다.
+     * <p>
+     * 검색어에 포함된 특수 문자를 제거하고, 검색어가 비어있거나 10자를 초과할 경우 빈 리스트를 반환합니다.
+     * </p>
+     *
+     * @param searchWord 검색할 태그의 일부 또는 전체 이름
+     * @return 검색어와 일치하는 태그 이름 목록. 검색어가 유효하지 않은 경우 빈 리스트 반환.
+     */
+    List<String> getTagNamesBySearchWord(String searchWord);
 
 
     /**

--- a/src/main/java/com/ham/netnovel/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/tag/service/TagServiceImpl.java
@@ -1,15 +1,17 @@
 package com.ham.netnovel.tag.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.tag.Tag;
 import com.ham.netnovel.tag.TagRepository;
 import com.ham.netnovel.tag.TagStatus;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -34,6 +36,23 @@ public class TagServiceImpl implements TagService {
     @Transactional(readOnly = true)
     public Optional<Tag> getTagByName(String tagName) {
         return tagRepository.findByName(tagName);
+    }
+
+
+    @Override
+    public List<String> getTagNamesBySearchWord(String searchWord) {
+
+        //파라미터 검증, SQL injection 에 사용되는 특수문자 제거,
+        String validateSearchWord = TypeValidationUtil.validateSearchWord(searchWord);
+
+        //검색어가 비어있거나 10자를 넘어가는 경우 빈리스트 반환
+        if (validateSearchWord.isEmpty()|| validateSearchWord.length()>10){
+            return Collections.emptyList();
+        }
+
+        //검색어 기반으로 태그 검색하여 반환
+        return tagRepository.findBySearchWord(validateSearchWord);
+
     }
 
     @Override


### PR DESCRIPTION
# 변경사항
### TagRepository
- findBySearchWord
  - 검색어를 바탕으로 태그 이름이 부분 일치하는 레코드의 태그 이름을 반환하는 메서드 추가
  - 반환 타입은 `List<String>`.

### TagService / TagServiceImpl
- getTagNamesBySearchWord
  - 검색어의 유효성 검사를 수행한 후, 검색어와 부분 일치하는 태그 이름을 반환하는 메서드 추가.
  - SQL injection 공격에 사용되는 특수 문자를 제거한 후 DAO 메서드 호출.
  - 검색어가 10자 이상이거나 비어있으면 빈 리스트를 반환.

### TagController
- Tag 컨트롤러 계층 추가:

- getTagNamesBySearchWord:
  - 검색어와 일치하는 태그 이름 목록을 담은 `ResponseEntity` 객체를 반환하는 API 추가.