### PR TITLE
Novel 검색 로직 서비스 계층 분리 및 구현 클래스 패키지 변경

### DIFF
--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
@@ -3,14 +3,13 @@ package com.ham.netnovel.member.service.impl;
 import com.ham.netnovel.coinChargeHistory.service.CoinChargeHistoryService;
 import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
 import com.ham.netnovel.comment.service.CommentService;
-import com.ham.netnovel.member.MemberRepository;
 import com.ham.netnovel.member.dto.MemberCoinChargeDto;
 import com.ham.netnovel.member.dto.MemberCoinUseHistoryDto;
 import com.ham.netnovel.member.dto.MemberRecentReadDto;
 import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
-import com.ham.netnovel.novel.service.NovelService;
+import com.ham.netnovel.novel.service.NovelSearchService;
 import com.ham.netnovel.reComment.service.ReCommentService;
 import com.ham.netnovel.recentRead.service.RecentReadService;
 import lombok.extern.slf4j.Slf4j;
@@ -32,30 +31,22 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
 
     private final ReCommentService reCommentService;
 
-    private final MemberRepository memberRepository;
 
     private final CoinUseHistoryService coinUseHistoryService;
 
     private final CoinChargeHistoryService coinChargeHistoryService;
 
-    private final NovelService novelService;
+
+    private final NovelSearchService novelSearchService;
 
     private final RecentReadService recentReadService;
 
-
-    public MemberMyPageServiceImpl(CommentService commentService,
-                                   ReCommentService reCommentService,
-                                   MemberRepository memberRepository,
-                                   CoinUseHistoryService coinUseHistoryService,
-                                   CoinChargeHistoryService coinChargeHistoryService,
-                                   NovelService novelService,
-                                   RecentReadService recentReadService) {
+    public MemberMyPageServiceImpl(CommentService commentService, ReCommentService reCommentService, CoinUseHistoryService coinUseHistoryService, CoinChargeHistoryService coinChargeHistoryService, NovelSearchService novelSearchService, RecentReadService recentReadService) {
         this.commentService = commentService;
         this.reCommentService = reCommentService;
-        this.memberRepository = memberRepository;
         this.coinUseHistoryService = coinUseHistoryService;
         this.coinChargeHistoryService = coinChargeHistoryService;
-        this.novelService = novelService;
+        this.novelSearchService = novelSearchService;
         this.recentReadService = recentReadService;
     }
 
@@ -82,7 +73,7 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
         //유저 providerId 유효성 검사
         validateProviderId(providerId, "getFavoriteNovelsByMember");
 
-        return novelService.getFavoriteNovels(providerId)
+        return novelSearchService.getFavoriteNovels(providerId)
                 .stream()
                 .map(novel -> NovelFavoriteDto.builder()
                         .novelId(novel.getId())

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelDeleteDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelDeleteDto.java
@@ -13,6 +13,5 @@ public class NovelDeleteDto {
     @NotNull
     private Long novelId;
 
-    @NotNull
     private String accessorProviderId;
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
@@ -27,6 +27,7 @@ public class NovelFavoriteDto {
     //작가 provider ID 작가 엔티티 생성후 사용
     private String authorProviderId;
 
+    private String thumbnailUrl;//섬네일 URL
 
 
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
@@ -15,10 +15,8 @@ import java.util.List;
 @AllArgsConstructor
 public class NovelUpdateDto {
 
-    @NotNull
     private Long novelId;
 
-    @NotNull
     private String accessorProviderId;
 
     @Size(max = 30)

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
@@ -13,8 +13,10 @@ public interface NovelRepository extends JpaRepository<Novel, Long>, NovelSearch
 
     @Query("select n from Novel n " +
             "join fetch n.author m " +
-            "where m.id = :memberId")
-    List<Novel> findNovelsByMember(@Param("memberId") Long id);
+            "left join fetch n.novelMetaData nm " +
+            "left join fetch n.novelAverageRating nr " +
+            "where m.providerId =:providerId")
+    List<Novel> findNovelsByMember(@Param("providerId") String providerId);
 
 
 

--- a/src/main/java/com/ham/netnovel/novel/service/NovelEditingService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelEditingService.java
@@ -8,6 +8,7 @@ import com.ham.netnovel.novel.dto.NovelUpdateDto;
 import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 
+//소설 생성/업데이트 관련 로직을 담는 서비스계층
 public interface NovelEditingService {
 
     /**

--- a/src/main/java/com/ham/netnovel/novel/service/NovelSearchService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelSearchService.java
@@ -1,0 +1,86 @@
+package com.ham.netnovel.novel.service;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.data.NovelSearchType;
+import com.ham.netnovel.novel.dto.NovelListDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface NovelSearchService {
+
+    /**
+     * 주어진 정렬 기준과 페이지 정보를 바탕으로 소설 목록을 조회하는 메서드입니다.
+     *
+     * <p>
+     * 이 메서드는 기본적으로 소설 목록을 조회수 기준으로 정렬합니다.
+     * </p>
+     *
+     * <p>
+     * 사용자가 제공한 정렬 기준에 따라, 소설 목록을 좋아요 순 또는 최신순으로 정렬할 수 있습니다.
+     * 조회된 소설 목록의 썸네일 URL은 S3 서비스의 CloudFront URL로 변환됩니다.
+     * </p>
+     * @param sortOrder 소설 목록의 정렬 기준을 나타내는 문자열입니다.
+     *                  "favorites"는 좋아요 순, "latest"는 최신순, 기본값은 "view"로 조회수 순입니다.
+     * @param pageable 페이지 정보 및 페이징 조건을 포함하는 {@link Pageable} 객체입니다.
+     *
+     * @return List<NovelListDto> 소설 목록을 포함한 DTO 리스트를 반환합니다.
+     *         각 소설의 썸네일 URL은 CloudFront URL로 변환되어 반환됩니다.
+     * @throws ServiceMethodException 검색 중 예외 발생 시 예외를 던집니다.
+     */
+    List<NovelListDto> getNovelsBySearchCondition(String sortOrder, Pageable pageable, List<Long> tagIds);
+
+
+    /**
+     * 검색어를 기반으로 소설 목록을 검색하여 반환합니다.
+     * <p>
+     * 검색된 소설 정보를 NovelListDto로 변환하여 페이징 처리된 결과를 반환합니다.
+     * 조회된 소설 목록의 썸네일 URL은 S3 서비스의 CloudFront URL로 변환됩니다.
+     * </p>
+     *
+     * @param searchWord 유저가 입력한  검색어 {@link String} 객체
+     * @param pageable 페이지 정보 및 페이징 조건을 포함하는 {@link Pageable} 객체입니다.
+     * @return List<NovelListDto> 소설 목록을 포함한 DTO 리스트를 반환합니다.
+     *         각 소설의 썸네일 URL은 CloudFront URL로 변환되어 반환됩니다.     *
+
+     * @throws ServiceMethodException 검색 중 예외 발생 시 예외를 던집니다.
+     */
+    List<NovelListDto> getNovelsBySearchWord(String searchWord,
+                                             NovelSearchType novelSearchType,
+                                             Pageable pageable);
+
+
+
+
+    /**
+     * 주어진 기간에 따라 소설의 랭킹을 조회하여 해당 페이지의 소설 정보를 반환합니다.
+     *
+     * <p>이 메서드는 다음과 같은 작업을 수행합니다:</p>
+     * <ul>
+     *     <li>페이지 번호와 페이지 크기를 사용하여 데이터의 시작 인덱스와 끝 인덱스를 계산합니다.</li>
+     *     <li>Redis에서 주어진 기간에 해당하는 소설 랭킹 데이터를 가져옵니다.</li>
+     *     <li>가져온 데이터에서 소설 ID를 추출합니다.</li>
+     *     <li>추출한 소설 ID를 사용하여 소설 엔티티를 조회하고, 랭킹 순서로 정렬하여 DTO로 변환합니다.</li>
+     * </ul>
+     *
+     * <p>작업 중 예외가 발생하면 {@link ServiceMethodException}이 발생합니다.</p>
+     *
+     * @param period 소설 랭킹을 조회할 기간. "daily", "weekly", "monthly" 중 하나로 지정합니다.
+     * @param pageable 페이지 정보. 페이지 번호와 페이지 크기를 포함합니다.
+     * @return 주어진 페이지와 기간에 해당하는 소설 정보를 담은 {@link List}입니다.
+     * @throws ServiceMethodException 메서드 실행 중 오류가 발생한 경우 발생합니다.
+     */
+    List<NovelListDto> getNovelsByRanking(String period, Pageable pageable);
+
+
+
+
+    /**
+     * 유저의 선호작 Novel 리스트 반환.
+     * @param providerId 유저 PK 값.
+     * @return List<Novel>
+     */
+    List<Novel> getFavoriteNovels(String providerId);
+
+}

--- a/src/main/java/com/ham/netnovel/novel/service/impl/NovelEditingServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/impl/NovelEditingServiceImpl.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.novel.service;
+package com.ham.netnovel.novel.service.impl;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.Member;
@@ -10,6 +10,7 @@ import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.novel.dto.NovelCreateDto;
 import com.ham.netnovel.novel.dto.NovelUpdateDto;
 import com.ham.netnovel.novel.repository.NovelRepository;
+import com.ham.netnovel.novel.service.NovelEditingService;
 import com.ham.netnovel.novelTag.dto.NovelTagCreateDto;
 import com.ham.netnovel.novelTag.dto.NovelTagDeleteDto;
 import com.ham.netnovel.novelTag.service.NovelTagService;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+//소설 생성/업데이트 관련 로직을 담는 서비스계층
 
 @Service
 @Slf4j
@@ -132,6 +134,12 @@ public class NovelEditingServiceImpl implements NovelEditingService {
                     .map(String::trim)
                     .distinct()//중복제거
                     .toList();
+
+            for (String newTagName : newTagNames) {
+                log.info("태그정보들 ={}",newTagName);
+                log.info("------------------------------------");
+
+            }
 
             //소설과 연결된 Tag들의 이름을 List 객체로 가져옴
             List<String> novelTagList = getNovelTagList(novel);

--- a/src/main/java/com/ham/netnovel/novel/service/impl/NovelSearchServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/impl/NovelSearchServiceImpl.java
@@ -1,0 +1,176 @@
+package com.ham.netnovel.novel.service.impl;
+
+import com.ham.netnovel.common.exception.ServiceMethodException;
+import com.ham.netnovel.common.utils.TypeValidationUtil;
+import com.ham.netnovel.novel.Novel;
+import com.ham.netnovel.novel.data.NovelSearchType;
+import com.ham.netnovel.novel.data.NovelSortOrder;
+import com.ham.netnovel.novel.dto.NovelListDto;
+import com.ham.netnovel.novel.repository.NovelRepository;
+import com.ham.netnovel.novel.service.NovelSearchService;
+import com.ham.netnovel.novelRanking.service.NovelRankingService;
+import com.ham.netnovel.s3.S3Service;
+import com.ham.netnovel.tag.dto.TagDataDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+//랭킹, 유저의선호작품, 검색어로 검색 등 소설을 특정한 조건으로 가져오는 로직을 담는 서비스계층
+@Service
+@Slf4j
+public class NovelSearchServiceImpl implements NovelSearchService {
+
+
+    private final NovelRepository novelRepository;
+
+    private final S3Service s3Service;
+
+    private final NovelRankingService novelRankingService;
+
+    public NovelSearchServiceImpl(NovelRepository novelRepository, S3Service s3Service, NovelRankingService novelRankingService) {
+        this.novelRepository = novelRepository;
+        this.s3Service = s3Service;
+        this.novelRankingService = novelRankingService;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NovelListDto> getNovelsBySearchCondition(String sortOrder,
+                                                         Pageable pageable,
+                                                         List<Long> tagIds) {
+        //정렬 디폴드값은 조회수
+        NovelSortOrder novelSortOrder = NovelSortOrder.VIEWCOUNT;
+        //파라미터에 따라 정렬 방법 변경
+        switch (sortOrder) {
+            case "favorites" -> novelSortOrder = NovelSortOrder.FAVORITES;
+            case "latest" -> novelSortOrder = NovelSortOrder.LATEST;
+        }
+        try {
+            List<NovelListDto> novelListDtos = novelRepository.findNovelsBySearchConditions(novelSortOrder, pageable, tagIds);
+            return generateThumbnailUrls(novelListDtos);
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getNovelsBySearchCondition 메서드 에러" + ex + ex.getMessage());
+
+        }
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public List<NovelListDto> getNovelsBySearchWord(String searchWord, NovelSearchType novelSearchType, Pageable pageable) {
+
+
+        //SQL Injection 공격 방지, 주석문자 긴공백 제거
+        String validateWord = TypeValidationUtil.validateSearchWord(searchWord);
+
+        try {
+            List<NovelListDto> novelListDtos;
+            // 검색 타입에 따른 검색 로직 처리
+            switch (novelSearchType) {
+                //작가이름 검색
+                case AUTHOR_NAME -> novelListDtos = novelRepository.findByAuthorName(validateWord, pageable);
+                //소설제목 검색
+                default -> novelListDtos = novelRepository.findBySearchWord(validateWord, pageable);
+            }
+            return generateThumbnailUrls(novelListDtos);
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getNovelsBySearchWord 메서드 에러" + ex.getMessage());
+        }
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NovelListDto> getNovelsByRanking(String period, Pageable pageable) {
+        try {
+            // 페이지 번호와 페이지 크기를 사용해 데이터의 시작 인덱스를 계산
+            int startIndex = pageable.getPageNumber() * pageable.getPageSize();
+            // 데이터의 끝 인덱스를 계산 (시작 인덱스 + 페이지 크기 - 1)
+            int endIndex = startIndex + pageable.getPageSize() - 1;
+
+            // Redis에서 주어진 기간(period)에 해당하는 소설 랭킹 데이터를 가져옴
+            // 기간은 daily, weekly, monthly 중 하나로 전달
+            // startIndex와 endIndex를 사용해 Redis에서 가져올 데이터 범위를 설정
+            // 리턴되는 리스트는 각 소설의 ID와 랭킹 정보를 포함하는 맵(Map)의 리스트임
+            List<Map<String, Object>> rankingFromRedis = novelRankingService.getNovelRankingFromRedis(period, startIndex, endIndex);
+
+
+            // 현재 페이지에 해당하는 소설 ID를 추출
+            List<Long> novelIds = new ArrayList<>();
+            for (Map<java.lang.String, Object> rankingDatas : rankingFromRedis) {
+                // 랭킹 데이터에서 "novelId" 값을 추출하여 novelIds 리스트에 추가
+                novelIds.add((Long) rankingDatas.get("novelId"));
+            }
+
+            // 소설 엔티티를 조회한 후, 랭킹 순서대로 정렬하고 DTO로 변환하여 반환
+            // JPA는 기본적으로 ID 순으로 정렬하므로, 랭킹 순서대로 정렬
+            return novelRepository.findByNovelIds(novelIds)
+                    .stream()
+                    .sorted(Comparator.comparing(novel -> novelIds.indexOf(novel.getId()))) // 랭킹 순서로 정렬(JPA는 엔티티 id 순서로 정렬함)
+                    .map(this::convertEntityToListDto)//엔티티 DTO로 변환
+                    .collect(Collectors.toList());
+
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getNovelsByRanking 메서드 에러 발생" + ex.getMessage());
+
+        }
+
+    }
+    //단순히 엔티티 List만 반환하는 메서드
+    //Null체크, DTO 변환은 MemberMyPageService에서 진행
+    @Override
+    @Transactional(readOnly = true)
+    public List<Novel> getFavoriteNovels(java.lang.String providerId) {
+        try {
+            return novelRepository.findFavoriteNovelsByMember(providerId);
+        } catch (Exception ex) {//예외 발생시 처리
+            throw new ServiceMethodException("getFavoriteNovels 메서드 에러 발생", ex.getCause());
+        }
+    }
+
+
+    /**
+     * 랭킹과 같이 대량의 소설정보를 전달시 사용하는 DTO로 변환하는 메서드 입니다.
+     *
+     * @param novel 소설 엔티티
+     * @return NovelListDto
+     */
+    NovelListDto convertEntityToListDto(Novel novel) {
+        //작품의 태그들 가져오기
+        List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
+                .map(novelTag -> novelTag.getTag().getData())
+                .toList();
+
+        //AWS cloud front 섬네일 이미지 URL 객체 반환
+        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName(), "mini");
+
+        //DTO 반환
+        return NovelListDto.builder()
+                .thumbnailUrl(String.valueOf(thumbnailUrl))
+                .title(novel.getTitle())
+                .authorName(novel.getAuthor().getNickName())
+                .id(novel.getId())
+                .totalFavorites(novel.getFavorites().size())
+                .tags(dataDtoList).build();
+    }
+
+
+
+    //섬네일 파일 이미지 이름으로, CloudFront URL을 생성하는 메서드
+    private List<NovelListDto> generateThumbnailUrls(List<NovelListDto> novelListDtos) {
+
+        return novelListDtos.stream()
+                .peek(novelListDto -> {
+                    String cloudFrontUrl = s3Service.
+                            generateCloudFrontUrl(novelListDto.getThumbnailUrl(), "mini");//소설 섬네일 URL 생성
+                    novelListDto.setThumbnailUrl(cloudFrontUrl);//DTO에 섬네일 URL 할당
+                }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ham/netnovel/novel/service/impl/NovelServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/impl/NovelServiceImpl.java
@@ -1,20 +1,13 @@
-package com.ham.netnovel.novel.service;
+package com.ham.netnovel.novel.service.impl;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
-import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.episode.Episode;
-import com.ham.netnovel.member.Member;
-import com.ham.netnovel.member.data.MemberRole;
-import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.novel.Novel;
-import com.ham.netnovel.novel.data.NovelSearchType;
-import com.ham.netnovel.novel.data.NovelSortOrder;
 import com.ham.netnovel.novel.repository.NovelRepository;
 import com.ham.netnovel.novel.data.NovelStatus;
-import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.novel.dto.*;
+import com.ham.netnovel.novel.service.NovelService;
 import com.ham.netnovel.novelAverageRating.NovelAverageRating;
-import com.ham.netnovel.novelRanking.service.NovelRankingService;
 import com.ham.netnovel.s3.S3Service;
 import com.ham.netnovel.tag.dto.TagDataDto;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.math.BigDecimal;
 import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
@@ -35,19 +27,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class NovelServiceImpl implements NovelService {
     private final NovelRepository novelRepository;
-
-    private final NovelRankingService novelRankingService;
-
     private final S3Service s3Service;
 
 
     @Autowired
-    public NovelServiceImpl(NovelRepository novelRepository, NovelRankingService novelRankingService, S3Service s3Service ) {
+    public NovelServiceImpl(NovelRepository novelRepository, S3Service s3Service) {
         this.novelRepository = novelRepository;
-        this.novelRankingService = novelRankingService;
         this.s3Service = s3Service;
     }
-
 
     @Override
     @Transactional(readOnly = true)
@@ -68,6 +55,7 @@ public class NovelServiceImpl implements NovelService {
                 .toList();
     }
 
+    //정산 계산시 사용
     @Override
     public List<Long> getNovelIdsByAuthor(String providerId) {
         if (providerId ==null || providerId.isEmpty()){
@@ -110,8 +98,7 @@ public class NovelServiceImpl implements NovelService {
     public NovelInfoDto getNovelInfo(Long novelId) {
         //Novel DB 데이터 검증
         Novel targetNovel = novelRepository.findById(novelId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 Novel 입니다."));
-
+                .orElseThrow(() -> new NoSuchElementException("getNovelInfo 에러, Novel 정보가 없습니다 novel id="+novelId));
         try {
             return convertEntityToInfoDto(targetNovel);
         } catch (Exception ex) {
@@ -119,26 +106,6 @@ public class NovelServiceImpl implements NovelService {
         }
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<NovelInfoDto> getNovelsRecent(Pageable pageable) {
-        List<Novel> recentNovels = novelRepository.findByLatestEpisodes(pageable);
-        return recentNovels.stream()
-                .map(this::convertEntityToInfoDto)
-                .toList();
-    }
-
-    //단순히 엔티티 List만 반환하는 메서드
-    //Null체크, DTO 변환은 MemberMyPageService에서 진행
-    @Override
-    @Transactional(readOnly = true)
-    public List<Novel> getFavoriteNovels(java.lang.String providerId) {
-        try {
-            return novelRepository.findFavoriteNovelsByMember(providerId);
-        } catch (Exception ex) {//예외 발생시 처리
-            throw new ServiceMethodException("getFavoriteNovels 메서드 에러 발생", ex.getCause());
-        }
-    }
 
     @Override
     @Transactional(readOnly = true)
@@ -148,50 +115,13 @@ public class NovelServiceImpl implements NovelService {
                     .stream()
                     .map(Novel::getId)
                     .collect(Collectors.toList());
-
         } catch (Exception ex) {
             throw new ServiceMethodException("getRatedNovelIds 메서드 에러 발생", ex.getCause());
 
         }
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<NovelListDto> getNovelsByRanking(java.lang.String period, Pageable pageable) {
-        try {
-            // 페이지 번호와 페이지 크기를 사용해 데이터의 시작 인덱스를 계산
-            int startIndex = pageable.getPageNumber() * pageable.getPageSize();
-            // 데이터의 끝 인덱스를 계산 (시작 인덱스 + 페이지 크기 - 1)
-            int endIndex = startIndex + pageable.getPageSize() - 1;
 
-            // Redis에서 주어진 기간(period)에 해당하는 소설 랭킹 데이터를 가져옴
-            // 기간은 daily, weekly, monthly 중 하나로 전달
-            // startIndex와 endIndex를 사용해 Redis에서 가져올 데이터 범위를 설정
-            // 리턴되는 리스트는 각 소설의 ID와 랭킹 정보를 포함하는 맵(Map)의 리스트임
-            List<Map<java.lang.String, Object>> rankingFromRedis = novelRankingService.getNovelRankingFromRedis(period, startIndex, endIndex);
-
-
-            // 현재 페이지에 해당하는 소설 ID를 추출
-            List<Long> novelIds = new ArrayList<>();
-            for (Map<java.lang.String, Object> rankingDatas : rankingFromRedis) {
-                // 랭킹 데이터에서 "novelId" 값을 추출하여 novelIds 리스트에 추가
-                novelIds.add((Long) rankingDatas.get("novelId"));
-            }
-
-            // 소설 엔티티를 조회한 후, 랭킹 순서대로 정렬하고 DTO로 변환하여 반환
-            // JPA는 기본적으로 ID 순으로 정렬하므로, 랭킹 순서대로 정렬
-            return novelRepository.findByNovelIds(novelIds)
-                    .stream()
-                    .sorted(Comparator.comparing(novel -> novelIds.indexOf(novel.getId()))) // 랭킹 순서로 정렬(JPA는 엔티티 id 순서로 정렬함)
-                    .map(this::convertEntityToListDto)//엔티티 DTO로 변환
-                    .collect(Collectors.toList());
-
-        } catch (Exception ex) {
-            throw new ServiceMethodException("getNovelsByRanking 메서드 에러 발생" + ex.getMessage());
-
-        }
-
-    }
 
     @Override
     @Transactional
@@ -200,7 +130,6 @@ public class NovelServiceImpl implements NovelService {
         if (file.isEmpty() || novelId == null || providerId == null) {
             throw new IllegalArgumentException("saveNovelThumbnail 메서드 에러, 파라미터가 null 입니다.");
         }
-
         /*
         Novel 엔티티를 DB에서 찾아옴
         만약 Novel 엔티티가 Null 이거나, 작가정보와 섬네일 업로드 요청자 정보가 일치하지 않는경우 예외로 던짐
@@ -243,7 +172,6 @@ public class NovelServiceImpl implements NovelService {
 
     @Override
     public Map<Long, Integer> getNovelWithTotalFavorites(Pageable pageable) {
-
         try {
             return novelRepository.findNovelTotalFavorite(pageable)
                     .stream()
@@ -252,11 +180,9 @@ public class NovelServiceImpl implements NovelService {
                                     object -> ((Number) object[1]).intValue()
                             )
                     );
-
         } catch (Exception ex) {
             throw new ServiceMethodException("getNovelWithTotalFavorites 메서드 에러" + ex + ex.getMessage());
         }
-
 
     }
 
@@ -275,98 +201,6 @@ public class NovelServiceImpl implements NovelService {
             throw new ServiceMethodException("getNovelWithLatestEpisodeCreateTime 메서드 에러" + ex + ex.getMessage());
         }
     }
-
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<NovelListDto> getNovelsBySearchCondition(String sortOrder,
-                                                         Pageable pageable,
-                                                         List<Long> tagIds) {
-        //정렬 디폴드값은 조회수
-        NovelSortOrder novelSortOrder = NovelSortOrder.VIEWCOUNT;
-        //파라미터에 따라 정렬 방법 변경
-        switch (sortOrder) {
-            case "favorites" -> novelSortOrder = NovelSortOrder.FAVORITES;
-            case "latest" -> novelSortOrder = NovelSortOrder.LATEST;
-        }
-
-        try {
-            return novelRepository.findNovelsBySearchConditions(novelSortOrder, pageable, tagIds)
-                    .stream()
-                    .peek(novelListDto -> {
-                        String cloudFrontUrl = s3Service.
-                                generateCloudFrontUrl(novelListDto.getThumbnailUrl(),
-                                        "mini");//소설 섬네일 URL 생성
-                        novelListDto.setThumbnailUrl(cloudFrontUrl);//DTO에 섬네일 URL 할당
-                    }).collect(Collectors.toList());
-
-        } catch (Exception ex) {
-            throw new ServiceMethodException("getNovelsBySearchCondition 메서드 에러" + ex + ex.getMessage());
-
-        }
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<NovelListDto> getNovelsBySearchWord(String searchWord, NovelSearchType novelSearchType, Pageable pageable) {
-
-
-        //SQL Injection 공격 방지, 주석문자 긴공백 제거
-        String validateWord = TypeValidationUtil.validateSearchWord(searchWord);
-
-        try {
-            List<NovelListDto> novelListDtos;
-            // 검색 타입에 따른 검색 로직 처리
-            switch (novelSearchType) {
-                //작가이름 검색
-                case AUTHOR_NAME -> novelListDtos = novelRepository.findByAuthorName(validateWord, pageable);
-                //소설제목 검색
-                default -> novelListDtos = novelRepository.findBySearchWord(validateWord, pageable);
-            }
-            return generateThumbnailUrls(novelListDtos);
-
-        } catch (Exception ex) {
-            throw new ServiceMethodException("getNovelsBySearchWord 메서드 에러" + ex.getMessage());
-        }
-    }
-
-    //섬네일 파일 이미지 이름으로, CloudFront URL을 생성하는 메서드
-    private List<NovelListDto> generateThumbnailUrls(List<NovelListDto> novelListDtos) {
-
-        return novelListDtos.stream()
-                .peek(novelListDto -> {
-                    String cloudFrontUrl = s3Service.
-                            generateCloudFrontUrl(novelListDto.getThumbnailUrl(), "mini");//소설 섬네일 URL 생성
-                    novelListDto.setThumbnailUrl(cloudFrontUrl);//DTO에 섬네일 URL 할당
-                }).collect(Collectors.toList());
-    }
-
-
-    /**
-     * 랭킹과 같이 대량의 소설정보를 전달시 사용하는 DTO로 변환하는 메서드 입니다.
-     *
-     * @param novel 소설 엔티티
-     * @return NovelListDto
-     */
-    NovelListDto convertEntityToListDto(Novel novel) {
-        //작품의 태그들 가져오기
-        List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
-                .map(novelTag -> novelTag.getTag().getData())
-                .toList();
-
-        //AWS cloud front 섬네일 이미지 URL 객체 반환
-        String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName(), "mini");
-
-        //DTO 반환
-        return NovelListDto.builder()
-                .thumbnailUrl(String.valueOf(thumbnailUrl))
-                .title(novel.getTitle())
-                .authorName(novel.getAuthor().getNickName())
-                .id(novel.getId())
-                .totalFavorites(novel.getFavorites().size())
-                .tags(dataDtoList).build();
-    }
-
 
     NovelInfoDto convertEntityToInfoDto(Novel novel) {
         //평균 별점 레코드가 없으면 0점짜리 새로 생성


### PR DESCRIPTION
# 변경사항

## refactor: Novel 검색 로직 서비스 계층 분리 및 구현 클래스 패키지 변경

### NovelSearchService/NovelSearchServiceImpl
- Novel 검색 관련 메서드를 `NovelService`에서 분리하여 별도의 `NovelSearchService`와 그 구현체 `NovelSearchServiceImpl` 생성.
  - 분리된 메서드:
    - `getNovelsBySearchCondition`
    - `getNovelsBySearchWord`
    - `getNovelsByRanking`
    - `getFavoriteNovels`

- `NovelServiceImpl`에서 다음 메서드 분리:
  - `generateThumbnailUrls`
  - `convertEntityToListDto`

### NovelService/NovelServiceImpl
- `NovelService`에서 검색 관련 메서드 삭제
  - `getNovelsBySearchCondition`
  - `getNovelsBySearchWord`
  - `getNovelsByRanking`
  - `getFavoriteNovels`
- `NovelServiceImpl` 패키지 위치 변경:
  - 기존 `service` 패키지에서 `impl` 패키지로 이동.
- `generateThumbnailUrls`, `convertEntityToListDto` 메서드 삭제.

### NovelEditingServiceImpl
- `NovelEditingServiceImpl` 패키지 위치를 기존 `service`에서 `impl`로 변경.

### MemberMyPageServiceImpl
- Novel 검색 로직을 `novelService`에서 `novelSearchService`로 분리하며 코드 리팩터링.

### NovelController
- 사용하지 않는 주석 삭제.
- Novel 검색 로직을 `novelSearchService`로 분리하여 코드 리팩터링.
- `updateNovel`: 서비스 계층 로직과 연결.
- `deleteNovel`: 서비스 계층 로직과 연결.

### NovelDeleteDto
- `accessorProviderId` 멤버 변수에서 `@NotNull` 어노테이션 제거.

### NovelFavoriteDto
- `thumbnailUrl` 멤버 변수 추가.

### NovelUpdateDto
- `accessorProviderId`, `novelId` 멤버 변수에서 `@NotNull` 어노테이션 제거.


## refactor : findNovelsByMember 쿼리문 최적화

### NovelRepository
- `findNovelsByMember` 메서드 쿼리 최적화
  - `NovelMetaData`와 `NovelAverageRating`을 `join fetch`하여 쿼리 성능 향상.
  - 불필요한 쿼리 호출을 줄여 쿼리문 수 감소