### PR TITLE
Novel DTO 멤버 변수명 통일 및 유저 선호작 반환 메서드 리팩토링

### DIFF
--- a/src/main/java/com/ham/netnovel/member/dto/MemberRecentReadDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberRecentReadDto.java
@@ -20,16 +20,15 @@ import java.util.List;
 public class MemberRecentReadDto {
 
 
-    private Long novelId;
+    private Long id;
 
-    private String novelTitle;
+    private String title;
 
     //연재정보
     private NovelType novelType;
 
     //작가명
     private String authorName;
-
 
     //최근본 에피소드 제목
     private String episodeTitle;
@@ -39,6 +38,9 @@ public class MemberRecentReadDto {
 
     //업데이트시간
     private LocalDateTime updatedAt;
+
+
+    private String thumbnailUrl;//섬네일 URL
 
 
 

--- a/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
+++ b/src/main/java/com/ham/netnovel/member/service/MemberMyPageService.java
@@ -13,12 +13,31 @@ import java.util.List;
 public interface MemberMyPageService {
 
 
-
+    /**
+     * 유저의 댓글과 대댓글 목록을 조회합니다.
+     *
+     * <p>이 메서드는 주어진 사용자 ID에 대한 댓글과 대댓글을 가져와
+     * 두 목록을 합친 후, 생성 시간을 기준으로 최신순으로 정렬하여 반환합니다.</p>
+     *
+     * @param providerId 유저 정보
+     * @param pageable 페이지 정보와 정렬 정보를 담고 있는 {@link Pageable} 객체
+     * @return 사용자의 댓글과 대댓글 정보를 담고 있는 {@link MemberCommentDto} 타입의 {@link List} 객체입니다.
+     */
     List<MemberCommentDto> getMemberCommentAndReCommentList(String providerId,Pageable pageable);
 
-    List<NovelFavoriteDto> getFavoriteNovelsByMember(String providerId);
 
-//    List<FavoriteNovelListDto> getMemberFavoriteNovel
+    /**
+     * 사용자의 providerId로, 선호하는 소설 목록을 반환하는 메서드 입니다..
+     *
+     * <p>주어진 providerId의 유효성을 검사한 후,
+     * 해당 사용자가 좋아요를 누른 소설의 목록을 {@link NovelFavoriteDto} 형태로 반환합니다.</p>
+     *
+     * @param providerId 사용자의 정보 (providerId)
+     * @return 사용자가 선호하는 소설의 정보 리스트,
+     * {@link NovelFavoriteDto} 타입 객체를  {@link List} 타입으로 반환
+     * @throws IllegalArgumentException providerId가 유효하지 않은 경우 예외처리
+     */
+    List<NovelFavoriteDto> getFavoriteNovelsByMember(String providerId);
 
 
     /**
@@ -42,11 +61,15 @@ public interface MemberMyPageService {
 
 
     /**
-     * 유저의 최근 열람 기록을 반환하는 메서드
-     * 소설 정보와, 해당 소설의 최근 열람 에피소드 정보를 반환
+     * 유저의 최근 열람 기록을 반환하는 메서드 입니다.
+     *
+     * <p>이 메서드는 사용자의 최근 읽은 소설 목록을 반환하며,
+     * 업데이트 시간에 따라 최신순으로 정렬합니다.</p>
+     *
      * @param providerId 유저 정보
-     * @param pageable
-     * @return List MemberRecentReadDto 형태로 반환, 소설, 에피소드 정보를 포함
+     * @param pageable 페이지 정보와 정렬 정보를 담고 있는 {@link Pageable} 객체
+     * @return 사용자의 최근 읽은 소설 정보를 담고 있는 {@link MemberRecentReadDto} 타입의 {@link List} 객체
+     * @throws IllegalArgumentException providerId가 유효하지 않은 경우 예외처리
      */
     List<MemberRecentReadDto> getMemberRecentReadInfo(String providerId, Pageable pageable);
 

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
@@ -67,17 +67,7 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
     }
 
 
-    /**
-     * 사용자의 providerId로, 선호하는 소설 목록을 반환하는 메서드 입니다..
-     *
-     * <p>주어진 providerId의 유효성을 검사한 후,
-     * 해당 사용자가 좋아요를 누른 소설의 목록을 {@link NovelFavoriteDto} 형태로 반환합니다.</p>
-     *
-     * @param providerId 사용자의 정보 (providerId)
-     * @return 사용자가 선호하는 소설의 정보 리스트,
-     * {@link NovelFavoriteDto} 타입 객체를  {@link List} 타입으로 반환
-     * @throws IllegalArgumentException providerId가 유효하지 않은 경우 예외처리
-     */
+
     @Override
     public List<NovelFavoriteDto> getFavoriteNovelsByMember(String providerId) {
         //유저 providerId 유효성 검사

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
@@ -67,20 +67,24 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
     }
 
 
-    //ToDo Author 엔티티 생성 후, 작가 정보도 DTO에 담아서 반환
+    /**
+     * 사용자의 providerId로, 선호하는 소설 목록을 반환하는 메서드 입니다..
+     *
+     * <p>주어진 providerId의 유효성을 검사한 후,
+     * 해당 사용자가 좋아요를 누른 소설의 목록을 {@link NovelFavoriteDto} 형태로 반환합니다.</p>
+     *
+     * @param providerId 사용자의 정보 (providerId)
+     * @return 사용자가 선호하는 소설의 정보 리스트,
+     * {@link NovelFavoriteDto} 타입 객체를  {@link List} 타입으로 반환
+     * @throws IllegalArgumentException providerId가 유효하지 않은 경우 예외처리
+     */
     @Override
     public List<NovelFavoriteDto> getFavoriteNovelsByMember(String providerId) {
         //유저 providerId 유효성 검사
         validateProviderId(providerId, "getFavoriteNovelsByMember");
+        //유저의 선호 작품 DTO 로 반환
+        return novelSearchService.getFavoriteNovels(providerId);
 
-        return novelSearchService.getFavoriteNovels(providerId)
-                .stream()
-                .map(novel -> NovelFavoriteDto.builder()
-                        .novelId(novel.getId())
-                        .title(novel.getTitle())
-                        .status(novel.getType())
-                        .build()
-                ).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -224,16 +224,17 @@ public class NovelController {
     /**
      * 유저가 소설(Novel)의 변경된 내용을 업데이트하는 API
      *
-     * @param novelUpdateDto        novelId, title, desc, providerId를 담은 객체
+     * @param novelUpdateDto novelId, title, desc, providerId를 담은 객체
      * @param bindingResult  DTO 유효성 검사 정보, 에러 발생시 객체에 에러가 담김
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
     @PutMapping("/novels/{novelId}")
-    public ResponseEntity<String> updateNovel(@PathVariable("novelId") Long novelId,
-                                              @Valid @RequestBody NovelUpdateDto novelUpdateDto,
-                                              BindingResult bindingResult,
-                                              Authentication authentication) throws AccessDeniedException {
+    public ResponseEntity<String> updateNovel(
+            @PathVariable("novelId") Long novelId,
+            @Valid @RequestBody NovelUpdateDto novelUpdateDto,
+            BindingResult bindingResult,
+            Authentication authentication) throws AccessDeniedException {
 
         if (bindingResult.hasErrors()) {
             List<String> errorMessages = ValidationErrorHandler.handleValidationErrorMessages(
@@ -242,26 +243,22 @@ public class NovelController {
             return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
         }
 
-        log.info("정보={}",novelUpdateDto.toString());
-
-
         //유저 인증. 없으면 badRequest 응답. 있으면 CustomOAuth2User 타입캐스팅.
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
-        //DTO에 유저 정보(providerId) 값 저장
+        //DTO에 유저 정보(providerId) 값 할당
         novelUpdateDto.setAccessorProviderId(principal.getName());
-
+        //DTO 에 novelId 값 할당
         novelUpdateDto.setNovelId(novelId);
 
-        //업데이트
+        //업데이트 결과 반환
         Boolean result = novelEditingService.updateNovel(novelUpdateDto);
 
-        if (result){
+        if (result) {
             return ResponseEntity.ok("작품 업데이트 완료.");
-        }else {
+        } else {
             return ResponseEntity.internalServerError().body("작품 업데이트 실패, 관리자에게 문의해주세요");
         }
     }
-
 
 
     /**
@@ -269,10 +266,9 @@ public class NovelController {
      *
      * <p>사용자의 인증 정보를 확인하고, 인증된 사용자만 작품 삭제 요청을 처리할 수 있습니다.</p>
      *
-     * @param novelId 삭제할 소설의 ID (PathVariable을 통해 전달됨)
+     * @param novelId        삭제할 소설의 ID (PathVariable을 통해 전달됨)
      * @param authentication 현재 인증된 사용자 정보
      * @return 성공적으로 삭제되었을 경우 "작품 삭제 완료." 메시지를 포함한 HTTP 200 응답
-     *
      */
     @DeleteMapping("/novels/{novelId}")
     public ResponseEntity<String> deleteNovel(@PathVariable("novelId") Long novelId,

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
@@ -14,7 +14,7 @@ public class NovelFavoriteDto {
 
 
     //소설PK
-    private Long novelId;
+    private Long id;
 
     //소설제목
     private String title;

--- a/src/main/java/com/ham/netnovel/novel/service/NovelSearchService.java
+++ b/src/main/java/com/ham/netnovel/novel/service/NovelSearchService.java
@@ -1,8 +1,8 @@
 package com.ham.netnovel.novel.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
-import com.ham.netnovel.novel.Novel;
 import com.ham.netnovel.novel.data.NovelSearchType;
+import com.ham.netnovel.novel.dto.NovelFavoriteDto;
 import com.ham.netnovel.novel.dto.NovelListDto;
 import org.springframework.data.domain.Pageable;
 
@@ -54,7 +54,7 @@ public interface NovelSearchService {
 
 
     /**
-     * 주어진 기간에 따라 소설의 랭킹을 조회하여 해당 페이지의 소설 정보를 반환합니다.
+     * 주어진 기간에 따라 소설의 랭킹을 조회하여 해당 페이지의 소설 정보를 반환하는 메서드 입니다.
      *
      * <p>이 메서드는 다음과 같은 작업을 수행합니다:</p>
      * <ul>
@@ -77,10 +77,14 @@ public interface NovelSearchService {
 
 
     /**
-     * 유저의 선호작 Novel 리스트 반환.
-     * @param providerId 유저 PK 값.
-     * @return List<Novel>
+     * 사용자의 선호 작품 목록을 조회하여 DTO로 변환한 후 반환하는 메서드입니다.
+     * <p>주어진 사용자 ID로 해당 사용자가 선호하는 작품 목록을 조회하고,
+     * 조회한 목록을 DTO로 변환하여 반환합니다. </p>
+     * @param providerId 사용자의 OAuth2 provider ID (예: 구글, 네이버 등)
+     * @return 사용자가 선호하는 작품 목록을 {@link NovelFavoriteDto} 의 {@link List}형태로 반환
+     * @throws ServiceMethodException 작업중 중 예외 발생 시 예외를 던집니다.
+     *
      */
-    List<Novel> getFavoriteNovels(String providerId);
+    List<NovelFavoriteDto> getFavoriteNovels(String providerId);
 
 }


### PR DESCRIPTION
# 변경사항

## refactor: Novel 관련 DTO 멤버 변수명 수정


### NovelFavoriteDto
- novelId를 id로 변경
###  MemberRecentReadDto
- novelId를 id로, novelTitle을 title로 변경하고 thumbnailUrl 추가

## refactor: 유저의 선호작 반환 메서드 로직 개선
- DTO 반환 로직을 NovelSearchService 로 옮겨 가독성 향상

### MemberMyPageServiceImpl
- getFavoriteNovelsByMember
  - Novel 엔티티를 NovelFavoriteDto 로 변환하는 로직 삭제

### NovelSearchService/NovelSearchServiceImpl
- getFavoriteNovels
  - 반환 타입 List<Novel> 에서 List<NovelFavoriteDto> 로 변경
  - Novel 엔티티를 직접 반환하는 대신 DTO 객체로 변환하여 반환하도록 수정

### NovelSearchServiceImpl
- convertEntityToFavoriteDto
  - Novel 엔티티를 NovelFavoriteDto 로 변환하는 메서드 추가


## refactor: Javadoc 주석 추가 및 불필요한 주석과 로깅 코드 제거
### MemberController, MemberMyPageService, NovelController
- Javadoc 주석 추가
- 불필요한 주석 및 로깅 코드 제거
