### PR TITLE
OAuth2 관련 클래스 패키지 이동(common 패키지) 및 로그인 성공 핸들러 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.favoriteNovel;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.favoriteNovel.service.FavoriteNovelService;
 import lombok.extern.slf4j.Slf4j;
@@ -30,10 +30,15 @@ public class FavoriteNovelController {
      * @return ResponseEntity true, false 리턴
      */
     @GetMapping("/members/me/favorites/check")
-    public ResponseEntity<Boolean> checkIfFavorite(
+    public ResponseEntity<?> checkIfFavorite(
             Authentication authentication,
             @RequestParam(name = "novelId") Long novelId
     ) {
+
+        if (authentication==null){
+            return ResponseEntity.ok("로그인 정보 없음");
+        }
+
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
 

--- a/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
+++ b/src/main/java/com/ham/netnovel/coinChargeHistory/CoinChargeHistoryController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.coinChargeHistory;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.coinChargeHistory.dto.CoinChargeCreateDto;
 import com.ham.netnovel.coinChargeHistory.service.CoinChargeHistoryService;
 import com.ham.netnovel.common.utils.Authenticator;

--- a/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryController.java
+++ b/src/main/java/com/ham/netnovel/coinUseHistory/CoinUseHistoryController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.coinUseHistory;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.coinUseHistory.dto.CoinUseCreateDto;
 import com.ham.netnovel.coinUseHistory.service.CoinUseHistoryService;
 import com.ham.netnovel.common.utils.Authenticator;

--- a/src/main/java/com/ham/netnovel/comment/CommentController.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentController.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.comment;
 
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.comment.dto.CommentCreateDto;
 import com.ham.netnovel.comment.dto.CommentDeleteDto;
 import com.ham.netnovel.comment.dto.CommentEpisodeListDto;
@@ -21,7 +21,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @Controller
 @Slf4j

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLikeController.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLikeController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.commentLike;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
 import com.ham.netnovel.commentLike.service.CommentLikeService;
 import com.ham.netnovel.common.utils.Authenticator;

--- a/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,40 @@
+package com.ham.netnovel.common.OAuth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final RequestCache requestCache = new HttpSessionRequestCache();
+
+
+    //TODO 리다이렉트 URL 도메인으로 변경 필수!!!
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+//        SavedRequest savedRequest = requestCache.getRequest(request, response);
+
+        String redirectUrl = request.getSession().getAttribute("redirectUrl") != null
+                ? (String) request.getSession().getAttribute("redirectUrl")
+                : "http://localhost:5173/";//
+
+        // 로그인 성공 시 세션에 저장된 URL로 리다이렉트
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+}
+
+
+
+
+//}

--- a/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuth2User.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuth2User.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth;
 
 import com.ham.netnovel.member.data.Gender;
 import com.ham.netnovel.member.data.MemberRole;

--- a/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuthUserService.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/CustomOAuthUserService.java
@@ -1,5 +1,7 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth;
 
+import com.ham.netnovel.common.OAuth.dto.NaverOAuthResponse;
+import com.ham.netnovel.common.OAuth.dto.OAuth2Response;
 import com.ham.netnovel.member.data.MemberRole;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.member.dto.MemberCreateDto;

--- a/src/main/java/com/ham/netnovel/common/OAuth/OAuthLoginController.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/OAuthLoginController.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/com/ham/netnovel/common/OAuth/dto/GoogleOAuthResponse.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/dto/GoogleOAuthResponse.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth.dto;
 
 import com.ham.netnovel.member.OAuthProvider;
 import com.ham.netnovel.member.data.Gender;

--- a/src/main/java/com/ham/netnovel/common/OAuth/dto/NaverOAuthResponse.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/dto/NaverOAuthResponse.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth.dto;
 
 import com.ham.netnovel.member.OAuthProvider;
 import com.ham.netnovel.member.data.Gender;

--- a/src/main/java/com/ham/netnovel/common/OAuth/dto/OAuth2Response.java
+++ b/src/main/java/com/ham/netnovel/common/OAuth/dto/OAuth2Response.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.OAuth;
+package com.ham.netnovel.common.OAuth.dto;
 
 
 import com.ham.netnovel.member.OAuthProvider;

--- a/src/main/java/com/ham/netnovel/common/config/SecurityConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.ham.netnovel.common.config;
 
-import com.ham.netnovel.OAuth.CustomOAuthUserService;
+import com.ham.netnovel.common.OAuth.CustomOAuth2SuccessHandler;
+import com.ham.netnovel.common.OAuth.CustomOAuthUserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -17,115 +17,46 @@ public class SecurityConfig {
 
     private final CustomOAuthUserService customOAuthUserService;
 
-    public SecurityConfig(CustomOAuthUserService customOAuthUserService) {
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
+    public SecurityConfig(CustomOAuthUserService customOAuthUserService, CustomOAuth2SuccessHandler customOAuth2SuccessHandler) {
         this.customOAuthUserService = customOAuthUserService;
+        this.customOAuth2SuccessHandler = customOAuth2SuccessHandler;
     }
 
     //서블릿 필터 무시 URL 정적 리소스 등록 필수
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/static/**", "/css/**", "/js/**", "/images/**","/favicon**");
+        return (web) -> web.ignoring().requestMatchers("/static/**", "/css/**", "/js/**", "/images/**", "/favicon**");
     }
 
     @Bean
-        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-            //CSRF disable, 테스트 상태에서만 disable 상태로 유지
-            http.csrf(AbstractHttpConfigurer::disable);
+        //CSRF disable, 테스트 상태에서만 disable 상태로 유지
+        http.csrf(AbstractHttpConfigurer::disable);
 
-            //From 로그인 방식 disable
-            http.formLogin((login) -> login.disable());
+        //From 로그인 방식 disable
+        http.formLogin((login) -> login.disable());
 
         //oauth2 방식 로그인사용
-        http.oauth2Login(oauth2Login->
-                        oauth2Login
-                                .loginPage("/login")
-                                .userInfoEndpoint(userInfoEndPoint ->
-                                        userInfoEndPoint.userService(customOAuthUserService))
+        http.oauth2Login(oauth2Login -> oauth2Login
+                .loginPage("/login")
+                .userInfoEndpoint(userInfoEndPoint ->
+                        userInfoEndPoint.userService(customOAuthUserService))
+                .successHandler(customOAuth2SuccessHandler)
         );
 
 
         //사용자 인증 URL 설정
         http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/","/login**", "/api/**").permitAll()//인증 예외 URL
+                .requestMatchers("/", "/login**", "/api/**", "/api/novels/**").permitAll()//인증 예외 URL
                 .anyRequest().authenticated()
         );
 
 
-         return http.build();
+        return http.build();
     }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-//
-//    /*
-//    서블릿 필터 무시하는 메서드
-//    정적 리소스 서블릿 필터 적용 제외
-//     */
-////    @Bean
-////    public WebSecurityCustomizer webSecurityCustomizer() {
-////        return (web) -> web.ignoring().requestMatchers("/static/**", "/css/**", "/js/**", "/images/**");
-////    }
-//
-//
-//    /*
-//    서블릿 필터 설정
-//     */
-//    @Bean
-//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-//
-//        //세션설정 : STATELESS (JWT 사용)
-//        http.sessionManagement((session) -> session
-//                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-//        );
-//
-//        //CSRF disable, 테스트 상태에서만 disable 상태로 유지
-//        http.csrf((csrf) -> csrf.disable());
-//
-//        //form 로그인 방식 disable(OAuth 소셜 로그인 사용)
-//        http.formLogin((login) -> login.disable());
-//
-//        http.authorizeHttpRequests((authorize) ->
-//                authorize.requestMatchers("/**").permitAll()
-//        );
-////
-////        http.authorizeRequests(authorizeRequests ->
-////                authorizeRequests
-////                        //사용자 인증 없이 접속 가능한 URI 설정
-////                        .requestMatchers(
-////                                "/",
-////                                "/home/**",
-////                                "/login/**",
-////                                "/error",
-////                                "/test/**",
-////                                "/images/**"
-////                        ).permitAll()
-////                        .anyRequest().authenticated()
-////        );
-//
-//
-//
-//        return http.build();
-//
-//
-//    }
-//
-//
-
-
-    }
+}

--- a/src/main/java/com/ham/netnovel/common/message/SseController.java
+++ b/src/main/java/com/ham/netnovel/common/message/SseController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.common.message;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/ham/netnovel/common/utils/Authenticator.java
+++ b/src/main/java/com/ham/netnovel/common/utils/Authenticator.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.common.utils;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.episode;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.PageableUtil;
@@ -23,7 +23,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.member;
 
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.member.dto.*;
 import com.ham.netnovel.member.service.MemberMyPageService;

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.novel;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.PageableUtil;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;

--- a/src/main/java/com/ham/netnovel/novelRating/NovelRatingController.java
+++ b/src/main/java/com/ham/netnovel/novelRating/NovelRatingController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.novelRating;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import com.ham.netnovel.novelRating.dto.NovelRatingSaveDto;

--- a/src/main/java/com/ham/netnovel/reComment/ReCommentController.java
+++ b/src/main/java/com/ham/netnovel/reComment/ReCommentController.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.reComment;
 
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.reComment.dto.ReCommentCreateDto;
 import com.ham.netnovel.reComment.dto.ReCommentDeleteDto;
 import com.ham.netnovel.reComment.dto.ReCommentListDto;
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeController.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.reCommentLike;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.common.utils.ValidationErrorHandler;
 import com.ham.netnovel.reCommentLike.service.ReCommentLikeService;

--- a/src/main/java/com/ham/netnovel/settlement/SettlementController.java
+++ b/src/main/java/com/ham/netnovel/settlement/SettlementController.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.settlement;
 
-import com.ham.netnovel.OAuth.CustomOAuth2User;
+import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.settlement.service.SettlementService;


### PR DESCRIPTION
# 변경사항

## refactor: OAuth2 관련 클래스 패키지 이동


### OAuth2 관련 클래스 이동
- common 패키지로 이동한 클래스:
CustomOAuth2User, CustomOAuthUserService, GoogleOAuthResponse, NaverOAuthResponse, OAuth2Response, OAuthLoginController

### 패키지 이동에 따른 import 문 수정
- 영향을 받은 컨트롤러 및 클래스:
Authenticator, CoinChargeHistoryController, CoinUseHistoryController, CommentController, EpisodeController, FavoriteNovelController, MemberController, NovelController, ReCommentController, SettlementController, SseController, 등


## refactor: 로그인 성공 핸들러 추가
#### SecurityConfig
- CustomOAuth2SuccessHandler를 의존성 주입(DI) 방식으로 적용
- 로그인 로직에 successHandler 추가

#### CustomOAuth2SuccessHandler 추가
- OAuth2 로그인 성공 시 처리하는 핸들러 클래스 추가
  - onAuthenticationSuccess 메서드
    - 로그인 성공 시 도메인 최상단으로 리다이렉트
    - 배포 시 도메인 변경 필요