### PR TITLE
댓글 감정 표현 로직 수정, DTO null 체크 메시지 추가, 서비스 및 컨트롤러 설명 보강

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/CommentController.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentController.java
@@ -49,16 +49,15 @@ public class CommentController {
      * @return ResponseEntity 처리 결과를 Httpstatus와 메시지에 담아 전송
      */
     @PostMapping("/comments")
-    public ResponseEntity<String> createComment(@Valid @RequestBody CommentCreateDto commentCreateDto,
-                                                BindingResult bindingResult,
-                                                Authentication authentication) {
+    public ResponseEntity<String> createComment(
+            @Valid @RequestBody CommentCreateDto commentCreateDto,
+            BindingResult bindingResult,
+            Authentication authentication) {
 
-        //CommentCreateDto Validation 에러가 있을경우 badRequest 전송
+        //클라이언트에서 보낸 데이터 유효성 검사, 에러가 있을경우 에러메시지 전송
         if (bindingResult.hasErrors()) {
-            log.error("createComment API 에러발생 ={}", bindingResult.getFieldError());
-            //에러 메시지들 List에 담음
-            List<String> errorMessages = ValidationErrorHandler.handleValidationErrors(bindingResult);
-            //에러 메시지 body에 담아 전송
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrorMessages(
+                    bindingResult, "createComment");
             return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
         }
 
@@ -156,6 +155,7 @@ public class CommentController {
      * 에피소드에 달린 댓글과 대댓글 정보를 전송하는 API
      * 댓글은 좋아요 순으로 정렬하여 전송
      * 댓글과 대댓글 DTO는 엔티티PK, content(내용), nickName(작성자닉네임), updatedAt(마지막으로 업데이트한 시각)을 멤버변수로 가짐
+     *
      * @return ResponseEntity 댓글 내용을 CommentListDto의 List 형태로 반환
      */
     @GetMapping("/episodes/{episodeId}/comments")
@@ -163,20 +163,18 @@ public class CommentController {
             @PathVariable(name = "episodeId") Long episodeId,
             @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
-            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize){
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
 
         //Pageable 객체 생성, null 이거나 음수면 예외로 던짐
         Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
 
         if (sortBy.equals("recent")) {
             //특정 episode에 달린 댓글 정보를 List에 담음. 최신순으로 정렬
-            return ResponseEntity.ok(commentService.getEpisodeCommentListByRecent(episodeId,pageable));
-        }
-        else if (sortBy.equals("likes")) {
+            return ResponseEntity.ok(commentService.getEpisodeCommentListByRecent(episodeId, pageable));
+        } else if (sortBy.equals("likes")) {
             //특정 episode에 달린 댓글 정보를 List에 담음. 좋아요 순으로 정렬
-            return ResponseEntity.ok(commentService.getEpisodeCommentListByLikes(episodeId,pageable));
-        }
-        else {
+            return ResponseEntity.ok(commentService.getEpisodeCommentListByLikes(episodeId, pageable));
+        } else {
             //정렬 값이 없으면 예외 발생
             throw new IllegalArgumentException("postNovelComments: invalid sortBy option");
         }
@@ -185,6 +183,7 @@ public class CommentController {
     /**
      * Novel(소설) Episode 에 달린 댓글과 대댓글 정보를 전송하는 API
      * 댓글은 최신 순으로 정렬
+     *
      * @return CommentEpisodeListDto 댓글과 대댓글 정보를 담는 객체
      */
     @GetMapping("/novels/{novelId}/comments")
@@ -192,21 +191,18 @@ public class CommentController {
             @PathVariable(name = "novelId") Long novelId,
             @RequestParam(name = "sortBy", defaultValue = "recent") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
-            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
-    ) {
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
 
         //Pageable 객체 생성, null 이거나 음수면 예외로 던짐
         Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
 
         if (sortBy.equals("recent")) {
             //특정 Novel의 모든 Episode에 달린 댓글,대댓글 정보를 List에 담음, 댓글은 최신순으로 정렬
-            return ResponseEntity.ok(commentService.getNovelCommentListByRecent(novelId,pageable));
-        }
-        else if (sortBy.equals("likes")) {
+            return ResponseEntity.ok(commentService.getNovelCommentListByRecent(novelId, pageable));
+        } else if (sortBy.equals("likes")) {
             //특정 Novel의 모든 Episode에 달린 댓글,대댓글 정보를 List에 담음, 댓글은 좋아요순으로 정렬
-            return ResponseEntity.ok(commentService.getNovelCommentListByLikes(novelId,pageable));
-        }
-        else {
+            return ResponseEntity.ok(commentService.getNovelCommentListByLikes(novelId, pageable));
+        } else {
             //정렬 값이 없으면 예외 발생
             throw new IllegalArgumentException("getNovelComments: invalid sortBy option");
         }

--- a/src/main/java/com/ham/netnovel/comment/dto/CommentCreateDto.java
+++ b/src/main/java/com/ham/netnovel/comment/dto/CommentCreateDto.java
@@ -18,7 +18,7 @@ public class CommentCreateDto {
 
 
     //댓글 내용
-    @NotBlank
+    @NotBlank(message = "댓글을 입력해 주세요!")
     @Size(max = 300,message = "댓글은 300자 이하로 작성해주세요!")
     private String content;
 

--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -50,14 +50,15 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     @Override
     public void createComment(CommentCreateDto commentCreateDto) {
-        log.info("댓글정보={}", commentCreateDto.toString());
-        //Member 엔티티 조회, null이면 예외로 던짐
-        Member member = memberService.getMember(commentCreateDto.getProviderId())
-                .orElseThrow(() -> new NoSuchElementException("Member 정보 없음"));
 
         //Member 엔티티 조회, null이면 예외로 던짐
+        Member member = memberService.getMember(commentCreateDto.getProviderId())
+                .orElseThrow(() -> new NoSuchElementException("createComment 에러, Member 정보가 없습니다."
+                        +commentCreateDto.getProviderId()));
+        //Episode 엔티티 조회, null이면 예외로 던짐
         Episode episode = episodeService.getEpisode(commentCreateDto.getEpisodeId())
-                .orElseThrow(() -> new NoSuchElementException("Episode 정보 없음"));
+                .orElseThrow(() -> new NoSuchElementException("createComment 에러, Episode 정보가 없습니다."
+                        +commentCreateDto.getEpisodeId()));
 
         try {
             //Comment 엔티티 생성

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentCreateDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentCreateDto.java
@@ -17,8 +17,8 @@ public class ReCommentCreateDto {
 
 
     //댓글 내용
-    @NotBlank
-    @Size(max = 300,message = "댓글은 300자 이하로 작성해주세요!")
+    @NotBlank(message = "대댓글을 입력해 주세요!")
+    @Size(max = 300,message = "대댓글은 300자 이하로 작성해주세요!")
     private String content;
 
     //원본 댓글 Id값

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentUpdateDto.java
@@ -15,8 +15,8 @@ import lombok.ToString;
 @Setter
 public class ReCommentUpdateDto {
 
-    @NotBlank
-    @Size(max = 300,message = "댓글은 300자 이하로 작성해주세요!")
+    @NotBlank(message = "대댓글을 입력해 주세요!")
+    @Size(max = 300,message = "대댓글은 300자 이하로 작성해주세요!")
     private String content;
 
 

--- a/src/main/java/com/ham/netnovel/reComment/service/ReCommentService.java
+++ b/src/main/java/com/ham/netnovel/reComment/service/ReCommentService.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.reComment.service;
 
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import com.ham.netnovel.reComment.ReComment;
 import com.ham.netnovel.reComment.dto.ReCommentCreateDto;
@@ -9,6 +10,7 @@ import com.ham.netnovel.reComment.dto.ReCommentUpdateDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public interface ReCommentService {
@@ -21,22 +23,46 @@ public interface ReCommentService {
     Optional<ReComment> getReComment(Long reCommentId);
 
     /**
-     * 유저가 작성한 대댓글을 DB에 저장하는 메서드
-     * @param reCommentCreateDto
+     * 대댓글을 생성하는 메서드입니다.
+     *
+     * <p>주어진 {@link ReCommentCreateDto} 정보를 바탕으로
+     * Member 엔티티와 Comment 엔티티 조회후, 이상이 없으면 대댓글을 생성하고 저장합니다.</p>
+     *
+     * @param reCommentCreateDto 대댓글 생성에 필요한 정보를 담고 있는 {@link ReCommentCreateDto} 객체
+     * @throws NoSuchElementException 주어진 providerId 또는 commentId에 해당하는
+     *         회원이나 댓글 정보가 존재하지 않을 경
+     * @throws ServiceMethodException 서비스 메서드 처리 중 에러가 발생한 경우
      */
     void createReComment(ReCommentCreateDto reCommentCreateDto);
 
 
     /**
-     * 대댓글을 수정하는 메서드
-     * @param reCommentUpdateDto
+     * 대댓글의 내용을 업데이트하는 메서드 입니다.
+     * <p> 대댓글이 DB에 존재하는지 여부와
+     * 해당 대댓글을 작성한 유저와 수정 요청 유저가 동일한지 확인한 후,
+     * 대댓글의 내용을 변경후 DB에 저장합니다. </p>
+     *
+     ** @param reCommentUpdateDto 업데이트할 대댓글의 정보가 담긴 {@link ReCommentUpdateDto} 객체
+     * @throws NoSuchElementException 대댓글 ID에 해당하는 대댓글이 없을 경우 발생
+     * @throws IllegalArgumentException 대댓글 작성자와 수정 요청자가 다르거나, 댓글 ID가 일치하지 않을 경우 발생
+     * @throws ServiceMethodException 데이터베이스 저장 중 오류가 발생한 경우 발생
      */
     void updateReComment(ReCommentUpdateDto reCommentUpdateDto);
 
 
     /**
-     * 댓글의 상태를 삭제상태로 바꾸는 메서드
-     * @param commentDeleteDto 삭제 요청된 댓글(comment)의 정보를 담는 DTO
+     * 대댓글을 삭제 상태로 변경하는 메서드입니다.
+     *
+     * <p>주어진 {@link ReCommentDeleteDto} 정보를 바탕으로,
+     * 대댓글이 DB에 존재하는지 여부와
+     * 해당 대댓글을 작성한 유저와 삭제 요청 유저가 동일한지 확인한 후,
+     * 대댓글의 상태를 삭제된 상태로 변경후 DB에 저장합니다. </p>
+     *
+     *
+     ** @param commentDeleteDto 삭제상태로 변경할 대댓글의 정보가 담긴 {@link ReCommentUpdateDto} 객체
+     * @throws NoSuchElementException 대댓글 ID에 해당하는 대댓글이 없을 경우 발생
+     * @throws IllegalArgumentException 대댓글 작성자와 삭제 요청자가 다르거나, 댓글 ID가 일치하지 않을 경우 발생
+     * @throws ServiceMethodException 데이터베이스 저장 중 오류가 발생한 경우 발생
      */
     void deleteReComment(ReCommentDeleteDto commentDeleteDto);
 

--- a/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/recentRead/service/RecentReadServiceImpl.java
@@ -98,12 +98,13 @@ public class RecentReadServiceImpl implements RecentReadService {
         try {
             return recentReadRepository.findByMemberProviderId(providerId, pageable)
                     .stream()
+                    //소설 정보를 DTO로 변환해서 List 객체로  반환
                     .map(recentRead -> {
                         Episode episode = recentRead.getEpisode();//에피소드 엔티티 객체에 저장
                         Novel novel = recentRead.getNovel();//노벨 엔티티 객체에 저장
                         return MemberRecentReadDto.builder()//DTO로 변환하여 반환
-                                .novelId(novel.getId())
-                                .novelTitle(novel.getTitle())
+                                .id(novel.getId())
+                                .title(novel.getTitle())
                                 .novelType(novel.getType())
                                 .authorName(novel.getAuthor().getNickName())
                                 .episodeTitle(episode.getTitle())
@@ -118,6 +119,9 @@ public class RecentReadServiceImpl implements RecentReadService {
         }
 
     }
+
+
+
 
 
 }


### PR DESCRIPTION
# 변경사항

## feat: 댓글 감정 표현 기능 로직 수정
- 유저가 댓글에 대한 감정 표현 기록이 없으면 새로 생성.
- 유저가 댓글에 대해 감정 표현을 했으나, 현재 요청과 다른 감정 표현(좋아요/싫어요)을 할 경우 에러 메시지를 발송.
- 현재 요청과 동일한 감정 표현(예를들어 과거 좋아요, 현재도 좋아요)일 경우 DB에서 감정 표현을 삭제

### CommentLikeService
- toggleCommentLikeStatus
  - 유저가 댓글에 대한 감정 표현 기록이 없으면 새로운 `CommentLike`를 생성하여 저장 후`true를 반환
  - 유저가 댓글에 대한 감정 표현을 했으나, 현재 요청과 다른 감정 표현(좋아요/싫어요)을 할 경우 로그에 기록하고 false를 반환
  - 현재 요청과 동일한 경우(과거 좋아요, 현재도 좋아요) DB에서 감정 표현을 삭제한 후 true를 반환

### CommentLikeController
- toggleCommentLikeStatus
  - 댓글 감정 표현 저장 실패 시, BadRequest 로 에러 메시지를 전송하도록 변경

## refactor: DTO null 체크 기본 메시지 추가
### CommentCreateDto, ReCommentCreateDto, ReCommentUpdateDto
- 멤버 변수 content에 `@NotBlank` 애너테이션에 대한 기본 메시지를 추가

## refactor:서비스,컨트롤러 클래스 설명 보강 및 ReCommentController 어노테이션 추가

### ReCommentController
- @controller 및 @RequestMapping("/api") 어노테이션 추가
- API 관련 Javadoc 주석 추가

### ReCommentService, ReCommentServiceImpl
- 엔티티 생성 방식을 기존 생성자에서 Builder 패턴으로 변경
- 메서드에 Javadoc 설명 추가

### CommentServiceImpl
- 예외 처리 로직을 더 구체적으로 개선

### CommentController
- 클라이언트가 보낸 파라미터가 유효하지 않을 경우 에러 메시지를 전송하는 로직 수정

### RecentReadServiceImpl
- getMemberRecentReads 메서드
  - MemberRecentReadDto 멤버 변수명 변경에 따른 Builder 패턴 코드 수정