### PR TITLE
Novel DTO 및 검색 로직 개선 (멤버 변수 및 DTO 변환 로직 수정)

### DIFF
--- a/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelFavoriteDto.java
@@ -19,7 +19,8 @@ public class NovelFavoriteDto {
     //소설제목
     private String title;
 
-    private NovelType status;
+    private NovelType novelType;
+
 
     //작가이름 작가 엔티티 생성후 사용
     private String authorName;

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
@@ -45,6 +45,8 @@ public class NovelListDto {//랭킹 등 리스트로 소설정보를 전달시 �
 
     private String thumbnailUrl;//섬네일 URL
 
+    private String description;//소설 설명
+
 
 
 

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelSearchRepositoryImpl.java
@@ -61,6 +61,7 @@ public class NovelSearchRepositoryImpl implements NovelSearchRepository {
             var query = jpaQueryFactory.select(Projections.bean(NovelListDto.class,//DTO에 값을 넣어 반환
                             novel.id.as("id"),
                             novel.title.as("title"),
+                            novel.description.as("description"),
                             member.providerId.as("providerId"),
                             member.nickName.as("authorName"),
                             novelMetaData.totalFavorites.as("totalFavorites"),

--- a/src/main/java/com/ham/netnovel/novel/service/impl/NovelSearchServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/novel/service/impl/NovelSearchServiceImpl.java
@@ -169,9 +169,9 @@ public class NovelSearchServiceImpl implements NovelSearchService {
     NovelFavoriteDto convertEntityToFavoriteDto(Novel novel){
 
         //작품의 태그들 가져오기
-        List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
-                .map(novelTag -> novelTag.getTag().getData())
-                .toList();
+//        List<TagDataDto> dataDtoList = novel.getNovelTags().stream()
+//                .map(novelTag -> novelTag.getTag().getData())
+//                .toList();
 
         //AWS cloud front 섬네일 이미지 URL 객체 반환
         String thumbnailUrl = s3Service.generateCloudFrontUrl(novel.getThumbnailFileName(), "mini");
@@ -181,6 +181,7 @@ public class NovelSearchServiceImpl implements NovelSearchService {
                 .thumbnailUrl(String.valueOf(thumbnailUrl))
                 .title(novel.getTitle())
                 .authorName(novel.getAuthor().getNickName())
+                .novelType(novel.getType())
                 .id(novel.getId())
                 .build();
 


### PR DESCRIPTION
# 변경사항

## refacotr : Novel DTO 및 검색 로직 개선 (멤버 변수 및 DTO 변환 로직 수정)

### NovelFavoriteDto
- `status` 멤버 변수를 `novelType`으로 변경

### NovelListDto
- `description` 멤버 변수 추가

### NovelSearchRepositoryImpl
- `findNovelsBySearchConditions`
  - `NovelListDto`의 `description` 멤버 변수가 추가됨에 따라, Novel 엔티티를 DTO로 변환할 때 `description`도 포함되도록 로직 수정

### NovelSearchServiceImpl
- `convertEntityToFavoriteDto`
  - Novel 엔티티를 DTO로 변환할 때 `novelType`을 추가하는 로직을 반영