### PR TITLE
댓글 감정표현 처리 로직 및 에러 메시지 개선, LikeType 패키지 위치 변경

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/Comment.java
+++ b/src/main/java/com/ham/netnovel/comment/Comment.java
@@ -2,12 +2,11 @@ package com.ham.netnovel.comment;
 
 
 import com.ham.netnovel.commentLike.CommentLike;
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeType;
 import com.ham.netnovel.episode.Episode;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.reComment.ReComment;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
+++ b/src/main/java/com/ham/netnovel/commentLike/CommentLike.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.commentLike;
 
 
 import com.ham.netnovel.comment.Comment;
+import com.ham.netnovel.commentLike.data.LikeType;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/src/main/java/com/ham/netnovel/commentLike/data/LikeResult.java
+++ b/src/main/java/com/ham/netnovel/commentLike/data/LikeResult.java
@@ -1,0 +1,10 @@
+package com.ham.netnovel.commentLike.data;
+
+public enum LikeResult {
+
+    CREATION ,
+    DELETION ,
+    FAILURE
+
+
+}

--- a/src/main/java/com/ham/netnovel/commentLike/data/LikeType.java
+++ b/src/main/java/com/ham/netnovel/commentLike/data/LikeType.java
@@ -1,4 +1,4 @@
-package com.ham.netnovel.commentLike;
+package com.ham.netnovel.commentLike.data;
 
 public enum LikeType {//좋아요 타입
     LIKE,//좋아요

--- a/src/main/java/com/ham/netnovel/commentLike/dto/CommentLikeToggleDto.java
+++ b/src/main/java/com/ham/netnovel/commentLike/dto/CommentLikeToggleDto.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.commentLike.dto;
 
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeType;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 

--- a/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
+++ b/src/main/java/com/ham/netnovel/commentLike/service/CommentLikeService.java
@@ -1,19 +1,25 @@
 package com.ham.netnovel.commentLike.service;
 
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeResult;
 import com.ham.netnovel.commentLike.dto.CommentLikeToggleDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
+
+import java.util.NoSuchElementException;
 
 public interface CommentLikeService {
 
 
 
     /**
-     * 댓글의 좋아요 상태를 저장하는 메서드
-     * 좋아요 누른 기록이 없으면, 새로운 엔티티를 만들어 DB에 저장 후 true 반환
-     * 좋아요 누른 기록이 있으면, DB에서 정보 삭제 후 false 반환
-     * @param commentLikeToggleDto 유저 정보, 댓글정보, 좋아요타입을 멤버변수로 갖는 DTO
-     * @return boolean 좋아요 상태 저장시 true, 삭제시 false 반환
+     * 댓글에 대한 좋아요 또는 싫어요 상태를 전환하는 메소드입니다.
+     *
+     * 이 메소드는 주어진 댓글 ID와 사용자 ID를 기반으로 댓글 감정 표현을 추가하거나 삭제합니다.
+     *
+     * @param commentLikeToggleDto 댓글,대댓글,유저정보를 전달하는 {@link CommentLikeToggleDto} 객체
+     * @return LikeResult          감정 표현 상태를 나타내는 열거형 값 {@code CREATION} {@code DELETION} {@code FAILURE} 중 하나
+     * @throws NoSuchElementException 주어진 providerId 또는 commentId에 해당하는 멤버 또는 댓글을 찾을 수 없는 경우
+     * @throws ServiceMethodException 서비스 메서드 처리 중 에러가 발생한 경우
      */
-    boolean toggleCommentLikeStatus(CommentLikeToggleDto commentLikeToggleDto);
+    LikeResult toggleCommentLikeStatus(CommentLikeToggleDto commentLikeToggleDto);
 
 }

--- a/src/main/java/com/ham/netnovel/reComment/ReComment.java
+++ b/src/main/java/com/ham/netnovel/reComment/ReComment.java
@@ -3,7 +3,7 @@ package com.ham.netnovel.reComment;
 
 import com.ham.netnovel.comment.Comment;
 import com.ham.netnovel.comment.CommentStatus;
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeType;
 import com.ham.netnovel.member.Member;
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/src/main/java/com/ham/netnovel/reComment/ReCommentLike.java
+++ b/src/main/java/com/ham/netnovel/reComment/ReCommentLike.java
@@ -1,6 +1,6 @@
 package com.ham.netnovel.reComment;
 
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeType;
 import com.ham.netnovel.member.Member;
 import com.ham.netnovel.reCommentLike.ReCommentLikeId;
 import jakarta.persistence.*;

--- a/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeToggleDto.java
+++ b/src/main/java/com/ham/netnovel/reCommentLike/ReCommentLikeToggleDto.java
@@ -1,7 +1,7 @@
 package com.ham.netnovel.reCommentLike;
 
 
-import com.ham.netnovel.commentLike.LikeType;
+import com.ham.netnovel.commentLike.data.LikeType;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 


### PR DESCRIPTION
# 변경사항

## feat : 댓글 감정표현 처리 로직 및 에러 메시지 개선
### CommentLikeController
- toggleCommentLikeStatus
  - 댓글 감정표현 생성시 true 삭제시 false, 이미 감정표현을 상태에서 다른 감정표현 선택시 HTTP 400 에러메시지 전달하도록 수정

### LikeResult
- 댓글 감정표현 상태를 나타내기 위한 enum 클래스 추가
- CREATION(생성), DELETION(삭제),FAILURE(실패) 3가지 상태를 가짐

### CommentLikeService/CommentLikeServiceImpl
- toggleCommentLikeStatus
  - 반환값 타입을 `LikeResult` 로 변경
  - 댓글에 대한 감정표현 생성시 CREATION, 삭제시 DELETION , 실패시 FAILURE 반환

## refactor: LikeType 패키지 위치 변경에 따른 import 구문 수정

- commentLike 에 commentLike.data 로 변경

### Comment,CommentController, CommentLike, CommentLikeToggleDto, ReCommentLike, ReComment, ReCommentLikeToggleDto
- LikeType 패키지 위치 변경으로 import문 수정