### PR TITLE
댓글 수정 가능 여부 로직 추가 및 에피소드 댓글 반환 기능 통합, 댓글 좋아요 수 집계 로직 개선

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/CommentRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentRepository.java
@@ -39,7 +39,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "where c.episode.id =:episodeId " +
             "and c.status = 'ACTIVE' " + //ACTIVE 상태인 댓글만 가져옴
             "order by (select count(cl) from CommentLike  cl " +//CommentLike 엔티티의 commentId 를 count
-            "where cl.comment.id = c.id) desc ")//좋아요 순으로 내림차순으로 정렬(좋아요 많은 댓글이 위로옴)
+            "where cl.comment.id = c.id and cl.likeType ='LIKE') desc ")//좋아요 순으로 내림차순으로 정렬(좋아요 많은 댓글이 위로옴)
 //날짜순으로 역정렬, 최신순이 위로옴
     List<Comment> findByEpisodeIdByCommentLikes(@Param("episodeId") Long episodeId, Pageable pageable);
 

--- a/src/main/java/com/ham/netnovel/comment/data/CommentSortOrder.java
+++ b/src/main/java/com/ham/netnovel/comment/data/CommentSortOrder.java
@@ -1,0 +1,7 @@
+package com.ham.netnovel.comment.data;
+
+public enum CommentSortOrder {
+    RECENT,
+    LIKES
+
+}

--- a/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
+++ b/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,6 +39,9 @@ public class CommentEpisodeListDto {//뷰에 반환할때 사용하는 DTO
     @Min(0)
     //싫어요 수
     private int disLikes;
+
+
+    boolean isEditable;//수정/삭제 가능여부
 
     //댓글에 달린 대댓글 목록
 

--- a/src/main/java/com/ham/netnovel/comment/service/CommentService.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.ham.netnovel.comment.service;
 
 import com.ham.netnovel.comment.Comment;
+import com.ham.netnovel.comment.data.CommentSortOrder;
 import com.ham.netnovel.comment.dto.CommentCreateDto;
 import com.ham.netnovel.comment.dto.CommentDeleteDto;
 import com.ham.netnovel.comment.dto.CommentEpisodeListDto;
 import com.ham.netnovel.comment.dto.CommentUpdateDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.member.dto.MemberCommentDto;
 import org.springframework.data.domain.Pageable;
 
@@ -51,22 +53,22 @@ public interface CommentService {
     List<MemberCommentDto> getMemberCommentList(String providerId,Pageable pageable);
 
 
-
     /**
-     * Episode에 달린 댓글과 대댓글을 최신순으로 반환하는 메서드
-     * @param episodeId episode의 PK값
-     * @return CommentEpisodeListDto List 형태로 반환
+     * 주어진 에피소드에 대한 댓글 목록을 정렬 기준에 따라 가져옵니다.
+     *
+     * <p>
+     * 정렬 기준은 `최신순` 또는 `추천순` 이며, 이를 기준으로 댓글을 가져옵니다.
+     * 댓글 작성자와 접속유저가 동일하면 DTO의 <b>isEditAble</b> 값을 true로 반환합니다.
+     * </p>
+     *
+     * @param episodeId  댓글을 가져올 에피소드의 ID
+     * @param pageable   페이징 정보
+     * @param providerId 접속한 유저의 정보, 로그인을 안한경우 <b>NON_LOGIN</b> 할당
+     * @param sortOrder  댓글을 정렬할 기준 (예: 최신순, 좋아요순)
+     * @return 에피소드 댓글정보를 담는 {@link CommentEpisodeListDto} 객체 리스트
+     * @throws ServiceMethodException 댓글을 가져오는 중 오류가 발생한 경우
      */
-    List<CommentEpisodeListDto> getEpisodeCommentListByRecent(Long episodeId, Pageable pageable);
-
-
-    /**
-     * Episode에 달린 댓글과 대댓글을 좋아요 순으로 반환하는 메서드
-     * @param episodeId episode의 PK값
-     * @return CommentEpisodeListDto List 형태로 반환
-     */
-    List<CommentEpisodeListDto> getEpisodeCommentListByLikes(Long episodeId, Pageable pageable);
-
+    List<CommentEpisodeListDto> getEpisodeComment(Long episodeId, Pageable pageable, String providerId, CommentSortOrder sortOrder);
 
 
     /**
@@ -75,6 +77,7 @@ public interface CommentService {
      * @return List 댓글과 대댓글 정보를 담은 DTO List
      */
     List<CommentEpisodeListDto> getNovelCommentListByRecent(Long novelId,Pageable pageable);
+
 
     /**
      * Novel에 달린 댓글과 대댓글을 좋아요 순으로 반환하는 메서드

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
@@ -28,6 +28,8 @@ public class ReCommentListDto {
     //싫어요 수
     private int disLikes;
 
+    boolean isEditable;//수정/삭제 가능여부
+
     private LocalDateTime createdAt;
 
 


### PR DESCRIPTION
# 변경사항

## feat: 댓글 수정 가능 여부 로직 추가 및 에피소드 댓글 반환 기능 통합

###  ReCommentListDto, CommentEpisodeListDto
- `isEditable` 멤버변수 추가, 접속 유저와 작성자가 동일할 경우 true 반환

###  CommentController
- getEpisodeComments
  - authentication 파라미터 추가, 인증 없을 시 `NON_LOGIN` 할당

### CommentSortOrder
- 댓글 정렬 기준을 위한 enum 클래스 추가 (`RECENT`, `LIKES`)

###  CommentService/CommentServiceImpl
- `getEpisodeCommentListByRecent`, `getEpisodeCommentListByLikes` 삭제, `getEpisodeComment`로 기능 통합

- 정렬 기준에 따라 에피소드 댓글 반환 (`CommentSortOrder` 사용)

###  CommentServiceImpl
- convertToCommentEpisodeListDto
  - providerId 파라미터 추가, `isEditable` 할당 로직 추가

- convertReCommentsToDtoList: 대댓글 변환 및 List로 반환하는 로직 리팩터링

## refactor : 댓글 좋아요 수 집계 로직 수정
### CommentRepository
- findByEpisodeIdByCommentLikes
  - 댓글 감정 표현 집계 방식을 `좋아요`만 집계하도록 변경
