### PR TITLE
태그 ID 또는 이름으로 태그 정보를 검색하고 전송하는 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/tag/TagController.java
+++ b/src/main/java/com/ham/netnovel/tag/TagController.java
@@ -1,5 +1,7 @@
 package com.ham.netnovel.tag;
 
+import com.ham.netnovel.tag.dto.TagDataDto;
+import com.ham.netnovel.tag.dto.TagFindDto;
 import com.ham.netnovel.tag.service.TagService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +38,7 @@ public class TagController {
      * @return 검색어와 일치하는 태그 이름 목록을 담은 ResponseEntity 객체
      */
     @GetMapping("/tags")
-    public ResponseEntity<?> getTagNamesBySearchWord(@RequestParam(name = "searchWord")String searchWord){
+    public ResponseEntity<?> getTagNamesBySearchWord(@RequestParam(name = "searchWord") String searchWord) {
 
         //태그네임으로 검색
         List<String> tagNamesBySearchWord = tagService.getTagNamesBySearchWord(searchWord);
@@ -44,6 +46,46 @@ public class TagController {
         //검색 결과 반환
         return ResponseEntity.ok(tagNamesBySearchWord);
 
+    }
+
+
+    /**
+     * 태그 이름 또는 태그 ID를 기반으로 태그 정보를 검색하여 반환합니다.
+     * <p>id 나 tagName 이 정확히 일치해야 합니다. 그렇지 않은경우 badRequest를 반환합니다.
+     부분일치 검색은 <b>getTagNamesBySearchWord</b> API를 사용해주세요</p>
+     *
+     * <p>태그 이름이 기본값인 경우 태그 ID로 검색하고, 그렇지 않을 경우 태그 이름으로 검색합니다.
+     * 태그 검색 조건이 비어 있을 경우 오류 응답을 반환합니다.</p>
+
+     *
+     * @param tagName 검색할 태그 이름 (기본값: "defaultName")
+     * @param tagId   검색할 태그 ID (옵션)
+     * @return 검색된 태그 데이터를 담은 ResponseEntity 객체, 검색 조건이 없을 경우 오류 응답 반환
+     */
+
+    @GetMapping("/tags/info")
+    public ResponseEntity<?> getTagInfo(
+            @RequestParam(name = "tagName", required = false, defaultValue = "defaultName") String tagName,
+            @RequestParam(name = "tagId", required = false) Long tagId) {
+        //태그 이름이 기본값, 태그id 가 null 이면 에러 메시지 전송
+        if ("defaultName".equals(tagName) && tagId==null) {
+            return ResponseEntity.badRequest().body("태그 검색 조건이 비어있습니다.");
+        }
+
+        //서비스 로직으로 데이터를 넘기기 위한 DTO 생성
+        TagFindDto build = TagFindDto.builder()
+                .tagName(tagName)
+                .id(tagId)
+                .build();
+        //Tag 정보를 받아옴
+        TagDataDto tagDto = tagService.getTagDto(build);
+
+        //받아온 정보가 없을경우, badRequest 전송
+        if (tagDto.getId() == null) {
+            return ResponseEntity.badRequest().body("태그 정보가 없습니다. 잘못된 요청입니다.");
+        }
+        //정보가 있을경우 DTO 반환
+        return ResponseEntity.ok(tagDto);
     }
 
 }

--- a/src/main/java/com/ham/netnovel/tag/dto/TagFindDto.java
+++ b/src/main/java/com/ham/netnovel/tag/dto/TagFindDto.java
@@ -1,0 +1,17 @@
+package com.ham.netnovel.tag.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class TagFindDto {
+
+    Long id;
+
+    String tagName;
+
+
+}

--- a/src/main/java/com/ham/netnovel/tag/service/TagService.java
+++ b/src/main/java/com/ham/netnovel/tag/service/TagService.java
@@ -2,7 +2,9 @@ package com.ham.netnovel.tag.service;
 
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.tag.Tag;
+import com.ham.netnovel.tag.dto.TagDataDto;
 import com.ham.netnovel.tag.dto.TagDeleteDto;
+import com.ham.netnovel.tag.dto.TagFindDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +13,7 @@ public interface TagService {
 
     /**
      * pk 값으로 Tag 엔티티를 불러오는 메서드 (Null 체크 필수)
+     *
      * @param tagId Tag PK id value
      * @return Optional
      */
@@ -18,10 +21,42 @@ public interface TagService {
 
     /**
      * pk 값으로 Tag 엔티티를 불러오는 메서드 (Null 체크 필수)
+     *
      * @param tagName Tag PK id value
      * @return Optional
      */
     Optional<Tag> getTagByName(String tagName);
+
+
+    /**
+     * 주어진 태그 이름으로 태그를 검색하여 TagDataDto로 변환하여 반환합니다.
+     * 검색 결과가 없을 경우 빈 TagDataDto 객체를 반환합니다.
+     *
+     * @param tagName 검색할 태그 이름
+     * @return 태그 데이터를 담은 {@link  TagDataDto} 객체, 검색 결과가 없을 경우 빈 객체 반환
+     */
+    TagDataDto getTagDtoByName(String tagName);
+
+
+    /**
+     * 주어진 태그 ID로 태그를 검색하여 TagDataDto로 변환하여 반환합니다.
+     * 검색 결과가 없을 경우 빈 TagDataDto 객체를 반환합니다.
+     *
+     * @param tagId 검색할 태그 ID
+     * @return 태그 데이터를 담은 {@link  TagDataDto}객체, 검색 결과가 없을 경우 빈 객체 반환
+     */
+    TagDataDto getTagDtoById(Long tagId);
+
+    /**
+     * 주어진 태그 정보에 따라 태그 데이터 전송 객체(TagDataDto)를 반환합니다.
+     *
+     * <p>이 메서드는 태그 이름이 "defaultName"일 경우 태그 ID를 사용하여
+     * 태그 정보를 검색하고, 그렇지 않으면 태그 이름을 사용하여 검색합니다.</p>
+     *
+     * @param tagFindDto 태그를 찾기 위한 정보가 포함된 {@link TagFindDto} 객체
+     * @return 태그 데이터를 담은 {@link  TagDataDto}객체, 검색 결과가 없을 경우 빈 객체 반환
+     */
+    TagDataDto getTagDto(TagFindDto tagFindDto);
 
 
     /**
@@ -45,11 +80,10 @@ public interface TagService {
      * @param tagName 생성할 태그명 (10자 이하의 한글/숫자/영문으로 구성)
      * @return 생성된 {@link Tag} 엔티티 객체
      * @throws ServiceMethodException 만약 태그명이 이미 존재하거나 예외가 발생할 경우
-     *
      */
     Tag createTag(String tagName);
 
-     /**
+    /**
      * 주어진 태그명을 기준으로 태그를 조회하거나, 존재하지 않으면 새로 생성하는 메서드입니다.
      *
      * <p>태그명이 존재하면 해당 태그를 반환하고, 태그명이 없을 경우 새로운 태그를 생성하여 반환합니다.</p>
@@ -57,12 +91,12 @@ public interface TagService {
      * @param tagName 조회 또는 생성할 태그명 (10자 이하의 한글/숫자/영문으로 구성)
      * @return 기존 또는 새로 생성된 {@link Tag} 엔티티 객체
      * @throws ServiceMethodException 태그 조회 또는 생성 과정에서 발생한 예외
-     *
      */
     Tag getOrCreateTag(String tagName);
 
     /**
      * 등록된 Tag 제거 메서드
+     *
      * @param deleteDto Tag
      */
     void deleteTag(TagDeleteDto deleteDto);


### PR DESCRIPTION
# 변경사항

## feat : 태그 ID 또는 이름으로 태그 정보를 검색하고 전송하는 로직 추가

- ID 값 또는 이름이 정확히 일치해야 함
- 부분 일치 검색은 `getTagNamesBySearchWord` 메서드 사용

### TagFindDto
- 태그 조회를 위한 DTO 생성
- ID와 tagName을 멤버 변수로 가짐

### TagService/TagServiceImpl
- getTagDtoByName
  - 주어진 태그 이름으로 태그를 검색하고, TagDataDto로 변환하여 반환하는 메서드 추가

- getTagDtoById
  - 주어진 태그 ID로 태그를 검색하고, TagDataDto로 변환하여 반환하는 메서드 추가

- getTagDto
  - 주어진 태그 정보에 따라 TagDataDto를 반환하는 메서드 추가
  - 태그명이 기본값인 경우 `getTagDtoById`를 호출하여 ID로 검색, 그렇지 않으면 `getTagDtoByName`을 호출하여 태그명으로 검색하여 DTO 반환

### TagController
- getTagInfo
  - 태그 이름 또는 ID를 기반으로 태그 정보를 검색하여 반환하는 API 추가
  - 쿼리 파라미터로 tagName과 tagId를 받으며, tagName의 기본값은 `defaultName`으로 설정
  - tagName과 tagId 모두 정보가 없거나 검색된 값이 비어 있으면 badRequest 전송
  - 반환된 값이 있으면 HTTP 200 코드와 함께 정보 전송