### PR TITLE
유저의 정산 내역을 반환하는 로직 추가

### DIFF
--- a/src/main/java/com/ham/netnovel/settlement/SettlementController.java
+++ b/src/main/java/com/ham/netnovel/settlement/SettlementController.java
@@ -3,13 +3,17 @@ package com.ham.netnovel.settlement;
 import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
 import com.ham.netnovel.common.utils.Authenticator;
+import com.ham.netnovel.common.utils.PageableUtil;
+import com.ham.netnovel.settlement.dto.SettlementHistoryDto;
 import com.ham.netnovel.settlement.service.SettlementService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -58,7 +62,7 @@ public class SettlementController {
      *
      * <p>
      * 유저가 자신이 작성한 소설의 수익에 대한 정산을 요청할 경우, 정산 요청을 생성합니다.
-
+     * <p>
      * 정산 정보 생성에 성공한 경우, HTTP 200 OK와 함께 성공 메시지를 전송합니다.
      * 만약 이미 요청 중인 정산 정보가 있다면, HTTP 400 Bad Request와 함께 에러 메시지를 반환합니다.
      * </p>
@@ -74,11 +78,49 @@ public class SettlementController {
 
         boolean result = settlementService.processSettlementRequest(principal.getName());
 
+        //결과에 따라 메시지 전송
         if (result) {
             return ResponseEntity.ok("정산 신청 성공!");
         } else {
             return ResponseEntity.badRequest().body("이미 요청된 정산내역이 있습니다.");
         }
+
+    }
+
+
+    /**
+     * 사용자의 정산 내역을 페이지네이션하여 반환하는 API 입니다.
+     *
+     * <p>
+     * 페이지 번호와 페이지 크기를 쿼리 파라미터로 받아 사용자의 정산 내역을 가져오며,
+     * 페이지 크기는 최대 100으로 제한됩니다. 인증 정보가 유효하지 않은 경우 예외가 발생합니다.
+     * </p>
+     *
+     * @param pageNumber 페이지 번호 (기본값: 0)
+     * @param pageSize 페이지 크기 (기본값: 10, 최대 100)
+     * @param authentication 사용자 인증 정보
+     * @return ResponseEntity {@link SettlementHistoryDto} 리스트로 사용자의 정산 내역
+     */
+    @GetMapping("/api/settlements/history")
+    public ResponseEntity<?> getSettlementHistory(
+            @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize,
+            Authentication authentication) {
+        //유저 인증정보 검증
+        CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //페이지 사이즈 수 제한
+        if (pageSize > 100) {
+            pageSize = 100;
+        }
+        //페이지네이션 객체 생성
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
+
+        //유저의 정산 내역을 가져옴
+        List<SettlementHistoryDto> settlementHistory = settlementService.getSettlementHistory(principal.getName(), pageable);
+
+        //정산 내역 반환
+        return ResponseEntity.ok(settlementHistory);
 
     }
 

--- a/src/main/java/com/ham/netnovel/settlement/SettlementRepository.java
+++ b/src/main/java/com/ham/netnovel/settlement/SettlementRepository.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.settlement;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface SettlementRepository extends JpaRepository<Settlement,Long> {
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 
 
     /**
@@ -22,8 +23,8 @@ public interface SettlementRepository extends JpaRepository<Settlement,Long> {
      *
      * @param memberId 유저의 고유 식별자 (memberId), null이 아닐 경우에만 유효합니다.
      * @return {@link Optional}로 래핑된 {@link LocalDateTime} 객체.
-     *         정산 받은 날짜가 존재하는 경우 그 날짜를 포함하고,
-     *         정산 기록이 없는 경우 {@code Optional.empty()}를 반환합니다.
+     * 정산 받은 날짜가 존재하는 경우 그 날짜를 포함하고,
+     * 정산 기록이 없는 경우 {@code Optional.empty()}를 반환합니다.
      */
     @Query("select max(st.createdAt) " +
             "from Settlement  st " +
@@ -40,13 +41,23 @@ public interface SettlementRepository extends JpaRepository<Settlement,Long> {
      *
      * @param memberId 유저의 고유 식별자 (memberId), null이 아닐 경우에만 유효합니다.
      * @return 요청된 정산 내역을 담고 있는 {@link List} 객체.
-     *         요청된 정산이 없는 경우 빈 리스트를 반환합니다.
+     * 요청된 정산이 없는 경우 빈 리스트를 반환합니다.
      */
     @Query("select st " +
             "from Settlement st " +
             "where st.member.id = :memberId " +
             "and st.status = 'REQUESTED'  ")
     List<Settlement> findRequestedByMember(@Param("memberId") Long memberId);
+
+
+    //유저 정보와 페이지네이션 정보로 정산 내역을 조회하는 메서드
+    @Query("select  st " +
+            "from Settlement  st " +
+            "join fetch st.novel n " +
+            "where st.member.id = :memberId " +
+            "order by st.createdAt desc ")//최근생성일부터
+    List<Settlement> findSettlementsByMember(@Param("memberId") Long memberId,
+                                             Pageable pageable);
 
 
 }

--- a/src/main/java/com/ham/netnovel/settlement/dto/SettlementHistoryDto.java
+++ b/src/main/java/com/ham/netnovel/settlement/dto/SettlementHistoryDto.java
@@ -1,0 +1,29 @@
+package com.ham.netnovel.settlement.dto;
+
+
+import com.ham.netnovel.settlement.SettlementStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@Builder
+public class SettlementHistoryDto {
+
+
+    private Integer coinCount;
+
+    //정산수익(단위 원)
+    private Integer revenue;
+
+    private SettlementStatus status;
+
+    private String  createdAt;//정산신청날짜
+
+    private String  completionDate;  // 정산 완료일
+
+    private String novelTitle;
+
+}

--- a/src/main/java/com/ham/netnovel/settlement/service/SettlementService.java
+++ b/src/main/java/com/ham/netnovel/settlement/service/SettlementService.java
@@ -2,7 +2,10 @@ package com.ham.netnovel.settlement.service;
 
 
 import com.ham.netnovel.coinUseHistory.dto.NovelRevenueDto;
+import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.settlement.Settlement;
+import com.ham.netnovel.settlement.dto.SettlementHistoryDto;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -60,6 +63,24 @@ public interface SettlementService {
      * @throws IllegalArgumentException 유저가 작성한 소설이 없을 경우
      */
     boolean processSettlementRequest(String providerId);
+
+
+    /**
+     * 유저의 소설 정산 내역을 가져와 리스트로 반환하는 메서드 입니다.
+     *
+     * <p>
+     * 사용자 정보가 없을 경우 예외를 던지며, 사용자 정보가 올바른 경우 정산 기록을
+     * 페이지네이션 정보에 따라 DTO로 변환해 반환합니다.</p>
+     * <p>반환되는 DTO의 날짜 형식은 "년-월-일 시:분"입니다.</p>
+     *
+     * @param providerId 유저의 고유 식별자 (providerId)
+     * @param pageable 페이지 정보 {@link Pageable} 객체
+     * @return {@link SettlementHistoryDto} 리스트로 유저의 정산 내역
+     * @throws IllegalArgumentException providerId가 null이거나 비어 있는 경우
+     * @throws NoSuchElementException 주어진 providerId에 해당하는 유저 정보가 없는 경우
+     * @throws ServiceMethodException 정산 내역을 가져오는 중 발생한 나머지 예외
+     */
+    List<SettlementHistoryDto> getSettlementHistory(String providerId, Pageable pageable);
 
 
 }


### PR DESCRIPTION
# 변경 사항

## feat:유저의 정산 내역을 반환하는 로직 추가

### SettlementController
- getSettlementHistory
  - 사용자의 정산 내역을 페이지네이션하여 반환하는 API 추가.
  - 페이지네이션 정보와 인증 정보를 서비스 계층에 전달하여 정산 정보를 조회하고 반환.
  - 유저 인증 정보가 없을 경우 에러 메시지 반환.

### SettlementHistoryDto
- 유저의 정산 내역을 반환하기 위한 DTO 클래스 추가.

### SettlementService/SettlementServiceImpl
- getSettlementHistory
  - 유저의 소설 정산 내역을 리스트로 반환하는 메서드 추가.
  - 페이지네이션 정보와 유저의 providerId를 이용해 정산 내역을 조회하여 DTO로 반환.
  - DTO의 시간 형식은 연-월-일 시:분 형태로 반환.

### SettlementRepository
- findSettlementsByMember
  - 유저의 ID 값과 페이지네이션 정보를 이용해 DB에서 정산 내역을 조회하는 메서드 추가.
  - 반환 값은 최근 생성일 기준으로 내림차순 정렬.