### PR TITLE
유저가 작성한 댓글 및 대댓글 조회 기능 QueryDSl로 구현 및 적용, 비즈니스 로직 리팩토링

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/CommentRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.comment;
 
+import com.ham.netnovel.comment.repository.CommentSearchRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentSearchRepository {
 
     /**
      * 유저가 작성한 댓글을 모두찾아 반환하는 메서드
@@ -15,8 +16,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
      * @param providerId 유저의 providerId 값
      * @return List Comment 엔티티 List로 반환
      */
-    @Query("select c from Comment c " +//Episode 테이블과 join(N:1)
-            "join fetch c.member m " +//Member 테이블과 join(N:1)
+    @Query("select c from Comment c " +
+            "join fetch c.member m " +//Episode 테이블과 join(N:1)
+            "join fetch c.episode e " +//Episode 테이블과 join(N:1)
             "where m.providerId =:providerId " +
             "order by c.createdAt DESC ")//생성 시간으로 내림차순 정렬
 //날짜순으로 역정렬, 최신순이 위로옴

--- a/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
+++ b/src/main/java/com/ham/netnovel/comment/dto/CommentEpisodeListDto.java
@@ -17,7 +17,7 @@ public class CommentEpisodeListDto {//뷰에 반환할때 사용하는 DTO
 
 
     //댓글 PK
-    private Long commentId;
+    private Long id;
 
     //댓글내용
     private String content;

--- a/src/main/java/com/ham/netnovel/comment/repository/CommentSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/comment/repository/CommentSearchRepository.java
@@ -1,0 +1,14 @@
+package com.ham.netnovel.comment.repository;
+
+import com.ham.netnovel.member.dto.MemberCommentDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CommentSearchRepository {
+
+
+
+    List<MemberCommentDto> findCommentByMember(String providerId, Pageable pageable);
+
+}

--- a/src/main/java/com/ham/netnovel/comment/repository/CommentSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/repository/CommentSearchRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.ham.netnovel.comment.repository;
+
+
+import com.ham.netnovel.comment.QComment;
+import com.ham.netnovel.comment.data.CommentType;
+import com.ham.netnovel.commentLike.QCommentLike;
+import com.ham.netnovel.commentLike.data.LikeType;
+import com.ham.netnovel.episode.QEpisode;
+import com.ham.netnovel.member.dto.MemberCommentDto;
+import com.ham.netnovel.novel.QNovel;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+public class CommentSearchRepositoryImpl implements CommentSearchRepository {
+
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Autowired
+    public CommentSearchRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    @Override
+    public List<MemberCommentDto> findCommentByMember(String providerId, Pageable pageable) {
+
+
+        QComment comment = QComment.comment;
+        QEpisode episode = QEpisode.episode;
+        QCommentLike commentLike = QCommentLike.commentLike;
+        QNovel novel = QNovel.novel;
+
+        return jpaQueryFactory.select(
+                        comment.id,
+                        comment.content,
+                        comment.createdAt,
+                        episode.id,
+                        episode.title,
+                        commentLike.likeType.when(LikeType.LIKE).then(1).otherwise(0).sum(), // as 없이 사용
+                        commentLike.likeType.when(LikeType.DISLIKE).then(1).otherwise(0).sum(), // as 없이 사용
+                        novel.title,
+                        novel.id
+
+                )
+                .from(comment)
+                .join(comment.episode, episode)
+                .join(comment.episode.novel, novel)
+                .leftJoin(comment.commentLikes, commentLike) // 좋아요/싫어요 테이블 조인
+                .where(comment.member.providerId.eq(providerId))
+                .groupBy(comment.id)
+                .fetch()
+                .stream()
+                .map(tuple -> MemberCommentDto.builder()
+                        .id(tuple.get(comment.id))
+                        .content(tuple.get(comment.content))
+                        .episodeId(tuple.get(episode.id))
+                        .episodeTitle(tuple.get(episode.title))
+                        .createdAt(tuple.get(comment.createdAt))
+                        .novelTitle(tuple.get(novel.title))
+                        .novelId(tuple.get(novel.id))
+                        .likes(Optional.ofNullable(tuple.get(5, Integer.class)).orElse(0)) // 좋아요수 할당null 방지
+                        .disLikes(Optional.ofNullable(tuple.get(6, Integer.class)).orElse(0)) // 싫어요수 할당 null 방지
+                        .isEditable(true)
+                        .type(CommentType.COMMENT)
+                        .build()).toList();
+
+    }
+}

--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -5,7 +5,6 @@ import com.ham.netnovel.comment.Comment;
 import com.ham.netnovel.comment.CommentRepository;
 import com.ham.netnovel.comment.CommentStatus;
 import com.ham.netnovel.comment.data.CommentSortOrder;
-import com.ham.netnovel.comment.data.CommentType;
 import com.ham.netnovel.comment.dto.CommentCreateDto;
 import com.ham.netnovel.comment.dto.CommentDeleteDto;
 import com.ham.netnovel.comment.dto.CommentEpisodeListDto;
@@ -219,7 +218,7 @@ public class CommentServiceImpl implements CommentService {
                 .nickName(comment.getMember().getNickName())//작성자 닉네임
                 .episodeTitle(comment.getEpisode().getTitle())//에피소드 제목
                 .content(comment.getContent())
-                .commentId(comment.getId())
+                .id(comment.getId())
                 .updatedAt(comment.getUpdatedAt())
                 .createdAt(comment.getCreatedAt())
                 .likes(comment.getTotalLikes())//댓글에 달린  좋아요 수
@@ -250,7 +249,7 @@ public class CommentServiceImpl implements CommentService {
                 .nickName(comment.getMember().getNickName())//작성자 닉네임
                 .episodeTitle(comment.getEpisode().getTitle())//에피소드 제목
                 .content(comment.getContent())
-                .commentId(comment.getId())
+                .id(comment.getId())
                 .updatedAt(comment.getUpdatedAt())
                 .createdAt(comment.getCreatedAt())
                 .likes(comment.getTotalLikes())//댓글에 달린  좋아요 수

--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -139,32 +139,16 @@ public class CommentServiceImpl implements CommentService {
 
     }
 
-    //ToDo 댓글 페이지네이션
     @Override
     @Transactional(readOnly = true)
     public List<MemberCommentDto> getMemberCommentList(String providerId, Pageable pageable) {
-
         try {
-            //유저가 작성한 댓글이 있으면, DTO로 변환해서 반환
-            return commentRepository.findByMember(providerId, pageable)
-                    .stream()
-                    .map(comment -> MemberCommentDto.builder()
-                            .type(CommentType.COMMENT)//타입지정
-                            .id(comment.getId())
-                            .content(comment.getContent())
-                            .createAt(comment.getCreatedAt())
-                            .updatedAt(comment.getUpdatedAt())
-                            .build())
-                    //생성시간 역순으로 정렬(최신 댓글이 먼저 나오도록)
-                    .sorted(Comparator.comparing(MemberCommentDto::getCreateAt).reversed())
-                    .collect(Collectors.toList());
-
-        } catch (Exception e) {
-            throw new ServiceMethodException("getMemberCommentList 메서드 에러 발생"); // 예외 던지기
+            return commentRepository.findCommentByMember(providerId, pageable);
+        } catch (Exception ex) {
+            throw new ServiceMethodException("getMemberCommentList 메서드 에러 발생" + ex + ex.getMessage()); // 예외 던지기
         }
 
     }
-
 
 
     @Override
@@ -199,7 +183,7 @@ public class CommentServiceImpl implements CommentService {
                     .sorted(Comparator.comparing(CommentEpisodeListDto::getCreatedAt).reversed())
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            throw new ServiceMethodException("getMemberCommentList 메서드 에러 발생"); // 예외 던지기
+            throw new ServiceMethodException("getNovelCommentListByRecent 메서드 에러 발생"); // 예외 던지기
         }
 
     }
@@ -215,7 +199,7 @@ public class CommentServiceImpl implements CommentService {
                     .sorted(Comparator.comparing(CommentEpisodeListDto::getLikes).reversed())
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            throw new ServiceMethodException("getMemberCommentList 메서드 에러 발생"); // 예외 던지기
+            throw new ServiceMethodException("getNovelCommentListByLikes 메서드 에러 발생"); // 예외 던지기
         }
 
     }

--- a/src/main/java/com/ham/netnovel/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/ham/netnovel/episode/repository/EpisodeRepository.java
@@ -1,12 +1,14 @@
-package com.ham.netnovel.episode;
+package com.ham.netnovel.episode.repository;
 
+import com.ham.netnovel.episode.Episode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
-public interface EpisodeRepository extends JpaRepository<Episode,Long>, EpisodeCustomRepository {
+public interface EpisodeRepository extends JpaRepository<Episode,Long>, EpisodeSearchRepository {
 
     @Query("select e from Episode e " +
             "join fetch e.novel n " +
@@ -18,5 +20,6 @@ public interface EpisodeRepository extends JpaRepository<Episode,Long>, EpisodeC
     @Query("SELECT e FROM Episode e " +
             "WHERE e.novel.id = :novelId AND e.chapter = :chapter")
     Optional<Episode> findByNovelAndChapter(@Param("novelId") Long novelId, @Param("chapter") Integer chapter);
+
 
 }

--- a/src/main/java/com/ham/netnovel/episode/repository/EpisodeSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/episode/repository/EpisodeSearchRepository.java
@@ -1,10 +1,11 @@
-package com.ham.netnovel.episode;
+package com.ham.netnovel.episode.repository;
 
+import com.ham.netnovel.episode.Episode;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-public interface EpisodeCustomRepository {
+public interface EpisodeSearchRepository {
 
 
     List<Episode> findEpisodesByConditions(String sortBy, Long novelId , Pageable pageable);

--- a/src/main/java/com/ham/netnovel/episode/repository/EpisodeSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/repository/EpisodeSearchRepositoryImpl.java
@@ -1,5 +1,7 @@
-package com.ham.netnovel.episode;
+package com.ham.netnovel.episode.repository;
 
+import com.ham.netnovel.episode.Episode;
+import com.ham.netnovel.episode.QEpisode;
 import com.ham.netnovel.novel.QNovel;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -11,11 +13,11 @@ import java.util.List;
 
 
 @Repository
-public class EpisodeCustomRepositoryImpl implements EpisodeCustomRepository {
+public class EpisodeSearchRepositoryImpl implements EpisodeSearchRepository {
 
     private final JPQLQueryFactory jpaQueryFactory;
 
-    public EpisodeCustomRepositoryImpl(JPQLQueryFactory jpaQueryFactory) {
+    public EpisodeSearchRepositoryImpl(JPQLQueryFactory jpaQueryFactory) {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeManagementServiceImpl.java
@@ -5,7 +5,7 @@ import com.ham.netnovel.common.exception.EpisodeNotPurchasedException;
 import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.episode.Episode;
-import com.ham.netnovel.episode.EpisodeRepository;
+import com.ham.netnovel.episode.repository.EpisodeRepository;
 import com.ham.netnovel.episode.data.EpisodeStatus;
 import com.ham.netnovel.episode.data.IndexDirection;
 import com.ham.netnovel.episode.dto.EpisodeDetailDto;

--- a/src/main/java/com/ham/netnovel/episode/service/EpisodeServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/episode/service/EpisodeServiceImpl.java
@@ -7,7 +7,7 @@ import com.ham.netnovel.common.exception.ServiceMethodException;
 import com.ham.netnovel.common.message.RedisMessagePublisher;
 import com.ham.netnovel.common.utils.TypeValidationUtil;
 import com.ham.netnovel.episode.Episode;
-import com.ham.netnovel.episode.EpisodeRepository;
+import com.ham.netnovel.episode.repository.EpisodeRepository;
 import com.ham.netnovel.episode.data.EpisodeStatus;
 import com.ham.netnovel.episode.dto.*;
 import com.ham.netnovel.novel.Novel;

--- a/src/main/java/com/ham/netnovel/member/dto/MemberCommentDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberCommentDto.java
@@ -2,7 +2,7 @@ package com.ham.netnovel.member.dto;
 
 
 import com.ham.netnovel.comment.data.CommentType;
-import com.ham.netnovel.reComment.dto.ReCommentListDto;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,21 +16,35 @@ import java.time.LocalDateTime;
 public class MemberCommentDto {
     //유저가 작성한 댓글,대댓글을 반환할때 사용하는 DTO
 
-
+    //댓글, 대댓글의 Id
+    private Long id;
+    //댓글, 대댓글의 내용
+    private String content;
     //타입, 댓글인지 대댓글인지 저장
     private CommentType type;
 
-    //댓글, 대댓글의 Id
-    private Long id;
+    private String novelTitle;//소설제목
 
-    //댓글, 대댓글의 내용
-    private String content;
+    private Long novelId;
 
-    private LocalDateTime createAt;
+    private String episodeTitle;//에피소드 제목
+
+    private Long episodeId;//에피소드 아이디
+
+    //생성시간
+    private LocalDateTime createdAt;
+
+    @Min(0)
+    //좋아요 수
+    private int likes;
+    @Min(0)
+    //싫어요 수
+    private int disLikes;
+
+    boolean isEditable;//수정/삭제 가능여부
 
 
-    //최종 수정일
-    private LocalDateTime updatedAt;
+
 
 
 

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -70,7 +70,7 @@ public class NovelController {
             @RequestParam(name = "sortBy", defaultValue = "view") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "100") Integer pageSize,
-            @RequestParam(name = "tagId", required = false) String ids) {
+            @RequestParam(name = "tagIds", required = false) String ids) {
 
         List<Long> idList = new ArrayList<>();
         //"," 로 구분된 tag 들을 분리하여 List 객체에 담음

--- a/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
+++ b/src/main/java/com/ham/netnovel/novel/repository/NovelRepository.java
@@ -15,7 +15,8 @@ public interface NovelRepository extends JpaRepository<Novel, Long>, NovelSearch
             "join fetch n.author m " +
             "left join fetch n.novelMetaData nm " +
             "left join fetch n.novelAverageRating nr " +
-            "where m.providerId =:providerId")
+            "where m.providerId =:providerId " +
+            "and n.status = 'ACTIVE'")
     List<Novel> findNovelsByMember(@Param("providerId") String providerId);
 
 

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentDeleteDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentDeleteDto.java
@@ -1,22 +1,21 @@
 package com.ham.netnovel.reComment.dto;
 
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Builder
 @Getter
 @Setter
+@ToString
 public class ReCommentDeleteDto {
 
 
 
-    @NotNull
     private Long commentId;
 
-    @NotNull
     private Long reCommentId;
 
 

--- a/src/main/java/com/ham/netnovel/reComment/repository/ReCommentRepository.java
+++ b/src/main/java/com/ham/netnovel/reComment/repository/ReCommentRepository.java
@@ -1,5 +1,6 @@
-package com.ham.netnovel.reComment;
+package com.ham.netnovel.reComment.repository;
 
+import com.ham.netnovel.reComment.ReComment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ReCommentRepository extends JpaRepository<ReComment, Long> {
+public interface ReCommentRepository extends JpaRepository<ReComment, Long>, ReCommentSearchRepository {
 
 
     @Query("select r from ReComment r " +

--- a/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepository.java
+++ b/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepository.java
@@ -1,0 +1,14 @@
+package com.ham.netnovel.reComment.repository;
+
+import com.ham.netnovel.member.dto.MemberCommentDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ReCommentSearchRepository {
+
+
+
+    List<MemberCommentDto> findReCommentByMember(String providerId, Pageable pageable);
+
+}

--- a/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.ham.netnovel.reComment.repository;
+
+import com.ham.netnovel.comment.QComment;
+import com.ham.netnovel.comment.data.CommentType;
+import com.ham.netnovel.commentLike.data.LikeType;
+import com.ham.netnovel.episode.QEpisode;
+import com.ham.netnovel.member.dto.MemberCommentDto;
+import com.ham.netnovel.novel.QNovel;
+import com.ham.netnovel.reComment.QReComment;
+import com.ham.netnovel.reComment.QReCommentLike;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+public class ReCommentSearchRepositoryImpl implements ReCommentSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Autowired
+    public ReCommentSearchRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberCommentDto> findReCommentByMember(String providerId, Pageable pageable) {
+
+
+        QReComment reComment = QReComment.reComment;
+        QEpisode episode = QEpisode.episode;
+        QReCommentLike reCommentLike = QReCommentLike.reCommentLike;
+        QNovel novel = QNovel.novel;
+        QComment comment = QComment.comment;
+
+
+        //원하는 값을 찾아와 DTO에 할당하여 반환
+        return jpaQueryFactory.select(
+                        reComment.id,
+                        reComment.content,
+                        reComment.createdAt,
+                        episode.id,
+                        episode.title,
+                        reCommentLike.likeType.when(LikeType.LIKE).then(1).otherwise(0).sum(), // as 없이 사용
+                        reCommentLike.likeType.when(LikeType.DISLIKE).then(1).otherwise(0).sum(), // as 없이 사용
+                        novel.title,
+                         novel.id
+                )
+                .from(reComment)
+                .join(reComment.comment, comment)
+                .join(reComment.comment.episode, episode)
+                .leftJoin(reComment.reCommentLikes, reCommentLike) // 좋아요/싫어요 테이블 조인
+                .where(reComment.member.providerId.eq(providerId))
+                .groupBy(reComment.id)
+                .fetch()
+                .stream()
+                .map(tuple -> MemberCommentDto.builder()//DTO로 변환
+                        .id(tuple.get(reComment.id))
+                        .content(tuple.get(reComment.content))
+                        .episodeId(tuple.get(episode.id))
+                        .episodeTitle(tuple.get(episode.title))
+                        .createdAt(tuple.get(reComment.createdAt))
+                        .novelTitle(tuple.get(novel.title))
+                        .novelId(tuple.get(novel.id))
+                        .likes(Optional.ofNullable(tuple.get(5, Integer.class)).orElse(0)) // null 방지
+                        .disLikes(Optional.ofNullable(tuple.get(6, Integer.class)).orElse(0)) // null 방지
+                        .isEditable(true)
+                        .type(CommentType.RECOMMENT)
+                        .build()).toList();
+
+    }
+
+
+}

--- a/src/main/java/com/ham/netnovel/recentRead/RecentReadRepository.java
+++ b/src/main/java/com/ham/netnovel/recentRead/RecentReadRepository.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.recentRead;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -9,6 +10,12 @@ import java.util.List;
 public interface RecentReadRepository extends JpaRepository<RecentRead,RecentReadId> {
 
 
+    @Query("select rr " +
+            "from RecentRead rr " +
+            "join fetch rr.member m " +
+            "join fetch rr.episode e " +
+            "where rr.member.providerId =:providerId " +
+            "order by rr.createdAt desc ")
     List<RecentRead> findByMemberProviderId(@Param("providerId") String providerId,
                                             Pageable pageable);
 


### PR DESCRIPTION
# 변경사항

## feat: 유저가 작성한 댓글 및 대댓글 조회 기능 QueryDSl로 구현
### CommentRepository
- `CommentSearchRepository` 상속 추가

### CommentSearchRepository/CommentSearchRepositoryImpl
- QueryDSL을 사용한 댓글 검색 DAO 클래스 추가
- `findCommentByMember`
  - 유저가 작성한 댓글 목록을 반환하는 메서드
  - QueryDSL로 구현
  - 반환 타입: `MemberCommentDto`

### CommentServiceImpl
- `getMemberCommentList`
  - 유저의 댓글을 조회하는 로직을 `commentRepository.findByMember`에서 `commentRepository.findCommentByMember`로 변경

### ReCommentRepository
- `repository` 패키지로 이동
- `ReCommentSearchRepository` 상속 추가

### ReCommentSearchRepository/ReCommentSearchRepositoryImpl
- QueryDSL을 사용한 대댓글 검색 DAO 클래스 추가
- `findReCommentByMember`
  - 유저가 작성한 대댓글 목록을 반환하는 메서드
  - QueryDSL로 구현
  - 반환 타입: `MemberCommentDto`

### CommentServiceImpl
- `getMemberCommentList`
  - 유저의 댓글 조회 로직을 `commentRepository.findByMember`에서 `commentRepository.findCommentByMember`로 변경



## refactor: 검색 조건에 따른 소설 조회 쿼리 파라미터명 수정
### NovelController
- getNovelsBySearchCondition
  - 쿼리파라미터명 `tagId` 에서 tagIds 로 수정

## refactor: 유저 소설 조회 시 상태 조건 ACTIVE 추가
### NovelRepository
- findNovelsByMember
  - JPQL 쿼리문 조건에 status = `ACTIVE` 조건 추가

## refactor: 로직 변경에 따른 DTO 필드 수정
### ReCommentDeleteDto
- 멤버변수 NotNull 제거

### MemberCommentDto
- 멤버변수로 `type` `novelTitle` `novelId` `episodeTitle` `createdAt` `likes` `disLikes` `isEditable` 추가

### CommentEpisodeListDto
- 멤버변수 `commentId` `id` 로 변경


## fix: Episode DAO 클래스 패키지 이동 및 클래스명 변경
### EpisodeSearchRepositoryImpl, EpisodeSearchRepository
- repository 패키지로 이동
- EpisodeCustomRepository 에서 클래스명 변경

### EpisodeRepository
- repository 패키지로 이동

### EpisodeServiceImpl, EpisodeManagementServiceImpl
- DAO 클래스 패키지 위치 변경으로 import문 수정


## fix: RecentRead 관련 서비스 및 리포지토리 리팩토링 및 성능 개선
### RecentReadServiceImpl
- getMemberRecentReads
  - DTO 변환 로직 메서드 리팩터링

- convertToMemberRecentReadDto
  - DTO 변환로직 메서드 리팩토링
  - 섬네일을 AWS S3 주소형태로 변환하는 로직 추가

### RecentReadRepository
- findByMemberProviderId
  - fetch join 으로 성능 개선
  - `createdAt` 로 정렬하는 쿼리문 추가

## refactor: DTO 멤버 변수명 변경에 따른 코드 수정
### CommentServiceImpl
- convertToCommentEpisodeListDto, convertToCommentEpisodeListDto
  - CommentEpisodeListDto 생성 로직에서 `commentId` 에서 `id` 로 코드 변경