### PR TITLE
댓글, 대댓글 로직 에러 수정 및 dto 프로퍼티 변경

### DIFF
--- a/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/comment/service/CommentServiceImpl.java
@@ -229,7 +229,7 @@ public class CommentServiceImpl implements CommentService {
                         .map(reComment -> ReCommentListDto.builder()
                                 .nickName(reComment.getMember().getNickName())
                                 .content(reComment.getContent())
-                                .reCommentId(reComment.getId())
+                                .id(reComment.getId())
                                 .createdAt(reComment.getCreatedAt())
                                 .updatedAt(reComment.getUpdatedAt())
                                 .likes(reComment.getTotalLikes())//댓글에 달린 싫어요 수
@@ -281,7 +281,7 @@ public class CommentServiceImpl implements CommentService {
             ReCommentListDto dto = ReCommentListDto.builder()
                     .nickName(reComment.getMember().getNickName())
                     .content(reComment.getContent())
-                    .reCommentId(reComment.getId())
+                    .id(reComment.getId())
                     .createdAt(reComment.getCreatedAt())
                     .updatedAt(reComment.getUpdatedAt())
                     .likes(reComment.getTotalLikes())//댓글에 달린 싫어요 수

--- a/src/main/java/com/ham/netnovel/member/dto/MemberCommentDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberCommentDto.java
@@ -23,6 +23,9 @@ public class MemberCommentDto {
     //타입, 댓글인지 대댓글인지 저장
     private CommentType type;
 
+    //대댓글일 경우 상위 댓글의 id. 댓글이면 null 값
+    private Long commentId;
+
     private String novelTitle;//소설제목
 
     private Long novelId;

--- a/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/member/service/impl/MemberMyPageServiceImpl.java
@@ -61,7 +61,7 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
                         reCommentService.getMemberReCommentList(providerId, pageable).stream()
                 )
                 //멤버변수인 생성 시간을 기준으로 재정렬
-                .sorted(Comparator.comparing(MemberCommentDto::getCreateAt).reversed())
+                .sorted(Comparator.comparing(MemberCommentDto::getCreatedAt).reversed())
                 // 정렬된 스트림을 리스트 형태로 수집하여 반환
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
+++ b/src/main/java/com/ham/netnovel/reComment/dto/ReCommentListDto.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 public class ReCommentListDto {
 
-    private Long reCommentId;
+    private Long id;
 
     private String content;
 

--- a/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepositoryImpl.java
+++ b/src/main/java/com/ham/netnovel/reComment/repository/ReCommentSearchRepositoryImpl.java
@@ -41,7 +41,6 @@ public class ReCommentSearchRepositoryImpl implements ReCommentSearchRepository 
         QNovel novel = QNovel.novel;
         QComment comment = QComment.comment;
 
-
         //원하는 값을 찾아와 DTO에 할당하여 반환
         return jpaQueryFactory.select(
                         reComment.id,
@@ -52,7 +51,8 @@ public class ReCommentSearchRepositoryImpl implements ReCommentSearchRepository 
                         reCommentLike.likeType.when(LikeType.LIKE).then(1).otherwise(0).sum(), // as 없이 사용
                         reCommentLike.likeType.when(LikeType.DISLIKE).then(1).otherwise(0).sum(), // as 없이 사용
                         novel.title,
-                         novel.id
+                        novel.id,
+                        comment.id
                 )
                 .from(reComment)
                 .join(reComment.comment, comment)
@@ -74,6 +74,7 @@ public class ReCommentSearchRepositoryImpl implements ReCommentSearchRepository 
                         .disLikes(Optional.ofNullable(tuple.get(6, Integer.class)).orElse(0)) // null 방지
                         .isEditable(true)
                         .type(CommentType.RECOMMENT)
+                        .commentId(tuple.get(comment.id))
                         .build()).toList();
 
     }

--- a/src/main/java/com/ham/netnovel/reComment/service/ReCommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/reComment/service/ReCommentServiceImpl.java
@@ -109,13 +109,13 @@ public class ReCommentServiceImpl implements ReCommentService {
         try {
             //대댓글 작성한 유저 정보
             String providerId = reComment.getMember().getProviderId();
-            //대댓글의 Id 값
-            Long reCommentId = reComment.getComment().getId();
+            //대댓글에 mapping된 댓글의 Id 값
+            Long commentId = reComment.getComment().getId();
 
             //대댓글 삭제 요청자와 댓글 작성자가 일치하는지 확인
             //대댓글 삭제 댓글 mapping된 댓글이 일치하는지 확인
             if (providerId.equals(commentDeleteDto.getProviderId())
-                    && Objects.equals(reCommentId, commentDeleteDto.getReCommentId())) {
+                    && Objects.equals(commentId, commentDeleteDto.getCommentId())) {
                 //대댓글을 삭제 상태로 변경
                 reComment.changeReStatus(CommentStatus.DELETED_BY_USER);
                 //변경된 레코드 DB에 저장

--- a/src/main/java/com/ham/netnovel/reComment/service/ReCommentServiceImpl.java
+++ b/src/main/java/com/ham/netnovel/reComment/service/ReCommentServiceImpl.java
@@ -136,7 +136,7 @@ public class ReCommentServiceImpl implements ReCommentService {
                     .stream().map(reComment -> ReCommentListDto.builder()
                             .nickName(reComment.getMember().getNickName())
                             .content(reComment.getContent())
-                            .reCommentId(reComment.getComment().getId())
+                            .id(reComment.getComment().getId())
                             .updatedAt(reComment.getUpdatedAt())
                             .build())
                     .sorted(Comparator.comparing(ReCommentListDto::getCreatedAt).reversed())


### PR DESCRIPTION
# fix: 대댓글 삭제 시 댓글 id 검증 로직 에러

 - 대댓글 삭제 api 로직에서 삭제 dto의 댓글 id, 멤버 id를 검증하는 로직에서 에러.
 - 대댓글의 mapping된 댓글을 검증해야 하는데, 대댓글 id를 dto의 댓글 id와 비교하고 있었음.

# feat: MemberCommentDto 대댓글일 경우 연결된 댓글 id 프로퍼티 반환.
- 내 댓글 보기에서 받아오는 대댓글의 경우. 
- 수정, 삭제 기능을 구현하려면 대댓글에 매핑된 댓글 id 또한 필요함.
- 그래서 MemberCommentDto가 댓글이면 commentId = null, 대댓글이면 commentId = 매핑된 댓글 id로 전달함.
- QueryDsl까지 수정했습니다. 확인 부탁합니다.

# fix: getMemberCommentAndReCommentList 메서드 MemberCommentDto getCreateAt => getCreatedAt 오타 수정

# refactor: ReCommentListDto의 reCommentId => id로 프로퍼티명 변경

- 에피소드에서 댓글을 가져올 때 dto에서 대댓글 데이터 또한 dto list로 가져옴.
- 이때 대댓글 dto의 id 프로퍼티 이름이 reCommentId 이므로 통일성을 위해서 id로 변경.