### PR TITLE
feat: 랭킹 및 메타데이터 스케줄러 설정 수정 및 로그 개선

### DIFF
--- a/src/main/java/com/ham/netnovel/common/batch/job/NovelMetaDataBatchConfig.java
+++ b/src/main/java/com/ham/netnovel/common/batch/job/NovelMetaDataBatchConfig.java
@@ -36,7 +36,7 @@ public class NovelMetaDataBatchConfig {
     private static final long DEFAULT_VIEWS = 0L;//조회수 기본값
     private static final int DEFAULT_FAVORITES = 0;//좋아요수 기본값
     //날짜 기본값
-    private static final LocalDateTime DEFAULT_DATE = LocalDateTime.of(2000, 1, 1, 0, 0);
+    private static final LocalDateTime DEFAULT_DATE = LocalDateTime.of(2020, 1, 1, 0, 0);
     private final NovelMetaDataRepository novelMetaDataRepository;
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;

--- a/src/main/java/com/ham/netnovel/common/scheduler/config/NovelRankingQuartzConfig.java
+++ b/src/main/java/com/ham/netnovel/common/scheduler/config/NovelRankingQuartzConfig.java
@@ -127,40 +127,48 @@ public class NovelRankingQuartzConfig {
     public Trigger novelPreviousDayRankingAtStartTime() {
         return createSingleRunTrigger("novelPreviousDayRankingAtStartTime",
                 novelPreviousDayRankingJobDetail(),//실행시킬 JobDetail
-                3);//딜레이 시간(초)
+                130);//딜레이 시간(초)
     }
 
 
+    /*
+    애플리케이션 시작시 일간 Novel 조회수 랭킹 갱신 Trigger 설정
+    시작 시점부터 150초뒤 일간 Novel 랭킹 갱신
+     */
     @Bean
     public Trigger novelDailyRankingTriggerAtStartTime() {
         return createSingleRunTrigger("novelDailyRankingTriggerAtStartTime",
                 novelDailyRankingJobDetail(),//실행시킬 JobDetail
-                5);//딜레이 시간(초)
+                150);//딜레이 시간(초)
 
 
     }
 
-    //애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
-    //시작 시점부터 10초뒤 주간 Novel 랭킹 갱신
+    /*
+    애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
+    시작 시점부터 180초뒤 주간 Novel 랭킹 갱신
+     */
     @Bean
     public Trigger novelWeeklyRankingTriggerAtStartTime() {
         return createSingleRunTrigger("novelWeeklyRankingTriggerAtStartTime",
                 novelWeeklyRankingJobDetail(),//실행시킬 JobDetail
-                10);//딜레이 시간(초)
+                180);//딜레이 시간(초)
     }
 
-    //애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
-    //시작 시점부터 10초뒤 주간 Novel 랭킹 갱신
+    /*
+    애플리케이션 시작시 주간 Novel 조회수 랭킹 갱신 Trigger 설정
+    시작 시점부터 210초뒤 주간 Novel 랭킹 갱신
+     */
     @Bean
     public Trigger monthlyRankingTriggerAtStartTime() {
         return createSingleRunTrigger("monthlyRankingTriggerAtStartTime",
                 novelMonthlyRankingJobDetail(),//실행시킬 JobDetail
-                15);//딜레이 시간(초)
+                210);//딜레이 시간(초)
     }
 
 
     /**
-     * 애플리케이션 시작시 한번만 실행되는 Trigger 정의 메서드
+     * 애플리케이션 시작시 한번만 실행되는 Trigger 정의 메서드입니다.
      *
      * @param triggerName    트리거 메서드 이름
      * @param jobDetail      실행시킬 jobDetail

--- a/src/main/java/com/ham/netnovel/common/scheduler/job/LatestDateBatchJob.java
+++ b/src/main/java/com/ham/netnovel/common/scheduler/job/LatestDateBatchJob.java
@@ -25,7 +25,7 @@ public class LatestDateBatchJob implements Job {
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
 
-        log.info("소설 최근 업로드 날짜 업데이트 배치 작업 시작");
+        log.info("Novel Meta Data: 최근 업로드 날짜 배치 작업 시작");
         try {
             JobParameters params = new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis()) // 매번 새로운 파라미터 필요
@@ -33,7 +33,7 @@ public class LatestDateBatchJob implements Job {
             // Spring Batch Job 실행
             jobLauncher.run(novelLatestEpisodeAtUpdateJob, params);
 
-            log.info("소설 최근 업로드 날짜 업데이트 배치 작업완료");
+            log.info("Novel Meta Data: 최근 업로드 날짜 배치 작업 완료");
         } catch (Exception e) {
             log.error("LatestDateBatchJob 실행 에러");
             throw new JobExecutionException(e);

--- a/src/main/java/com/ham/netnovel/common/scheduler/job/TotalFavoritesBatchJob.java
+++ b/src/main/java/com/ham/netnovel/common/scheduler/job/TotalFavoritesBatchJob.java
@@ -27,14 +27,14 @@ public class TotalFavoritesBatchJob implements Job {
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
-        log.info("소설 좋아요 메타 데이터 업데이트 배치 작업 시작");
+        log.info("Novel Meta Data: 총 좋아요 배치 작업 시작");
         try {
             JobParameters params = new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis()) // 매번 새로운 파라미터 필요
                     .toJobParameters();
             // Spring Batch Job 실행
             jobLauncher.run(novelTotalFavoritesUpdateJob, params);
-            log.info("소설 좋아요 메타 데이터 업데이트 배치 작업 완료");
+            log.info("Novel Meta Data: 총 좋아요 배치 작업 시작");
         } catch (Exception e) {
             log.error("TotalFavoritesBatchJob 실행 에러");
             throw new JobExecutionException(e);

--- a/src/main/java/com/ham/netnovel/common/scheduler/job/TotalViewsBatchJob.java
+++ b/src/main/java/com/ham/netnovel/common/scheduler/job/TotalViewsBatchJob.java
@@ -29,14 +29,14 @@ public class TotalViewsBatchJob implements Job {
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
-        log.info("배치 작업 시작");
+        log.info("Novel Meta Data: 총 조회수 배치 작업 시작");
         try {
             JobParameters params = new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis()) // 매번 새로운 파라미터 필요
                     .toJobParameters();
             // Spring Batch Job 실행
             jobLauncher.run(novelTotalViewUpdateJob, params);
-            log.info("배치 작업 완료");
+            log.info("Novel Meta Data: 총 조회수 배치 작업 완료");
 
         } catch (Exception e) {
             log.error("TotalViewsBatchJob 실행 에러");


### PR DESCRIPTION
- NovelRankingQuartzConfig
  - 애플리케이션 시작 후 랭킹 스케줄러 실행 시간 조정
    - 어제 랭킹 갱신: 3초 → 130초
    - 일간 랭킹 갱신: 5초 → 150초
    - 주간 랭킹 갱신: 10초 → 180초
    - 월간 랭킹 갱신: 15초 → 210초

- NovelMetaDataQuartzConfig
  - 애플리케이션 시작 시 NovelMetaData의 총 조회수, 총 좋아요 수, 최근 업데이트 일자를 갱신하는 스케줄러 추가

- TotalFavoritesBatchJob, LatestDateBatchJob, TotalViewsBatchJob
  - 실행/종료 로그에 작업명을 추가하여 상세하게 출력

- NovelMetaDataBatchConfig
  - 소설의 최근 업로드 날짜 기본값을 2000년 → 2020년으로 변경