### PR TITLE
docs: Swagger 어노테이션 추가로 API 문서화 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
 
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 }
 
 

--- a/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
+++ b/src/main/java/com/ham/netnovel/FavoriteNovel/FavoriteNovelController.java
@@ -3,6 +3,13 @@ package com.ham.netnovel.favoriteNovel;
 import com.ham.netnovel.common.OAuth.CustomOAuth2User;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.favoriteNovel.service.FavoriteNovelService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api")
 @Slf4j
+@Tag(name = "FavoriteNovel", description = "구독한 소설 관련 작업")
 public class FavoriteNovelController {
 
     private final Authenticator authenticator;
@@ -25,17 +33,31 @@ public class FavoriteNovelController {
 
     /**
      * 해당 작품이 선호작이 되어 있는지 확인하는 api
+     *
      * @param authentication 유저 인증 보안
-     * @param novelId 작품 PK id
+     * @param novelId        작품 PK id
      * @return ResponseEntity true, false 리턴
      */
+    @Operation(summary = "선호작 여부 확인", description = "해당 소설이 사용자의 선호작으로 설정되어 있는지 확인합니다.",
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", example = "123", required = true)
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공적으로 선호작 여부를 반환(true:이미등록된경우, false:등록되지 않은경우) ",
+                    content = @Content(mediaType = "application/json",  schema = @Schema(implementation = Boolean.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """)))
+    })
     @GetMapping("/members/me/favorites/check")
     public ResponseEntity<?> checkIfFavorite(
             Authentication authentication,
             @RequestParam(name = "novelId") Long novelId
     ) {
 
-        if (authentication==null){
+        if (authentication == null) {
             return ResponseEntity.ok("로그인 정보 없음");
         }
 
@@ -50,10 +72,24 @@ public class FavoriteNovelController {
 
     /**
      * 해당 작품의 선호작 여부를 바꾸는 api
+     *
      * @param authentication 유저 인증 보안
-     * @param novelId 작품 PK id
+     * @param novelId        작품 PK id
      * @return ResponseEntity true, false 리턴
      */
+
+    @Operation(summary = "선호작 여부 변경", description = "해당 소설의 선호작 상태를 변경합니다. 이미 선호작품에 등록된경우, DB에서 삭제합니다.",
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", example = "123", required = true)
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공적으로 선호작 상태를 변경하고 반환",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """)))})
     @PostMapping("/members/me/favorites/{novelId}")
     public ResponseEntity<Boolean> toggleFavorite(
             Authentication authentication,
@@ -64,7 +100,6 @@ public class FavoriteNovelController {
 
         //유저가 좋아요 누른 소설 반환
         Boolean isFavorite = favoriteNovelService.toggleFavoriteNovel(principal.getName(), novelId);
-//        Boolean isFavorite = favoriteNovelService.toggleFavoriteNovel("test1", novelId);
         return ResponseEntity.ok(isFavorite);
     }
 }

--- a/src/main/java/com/ham/netnovel/common/config/SecurityConfig.java
+++ b/src/main/java/com/ham/netnovel/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
 
         //사용자 인증 URL 설정
         http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/", "/login**", "/api/**", "/api/novels/**").permitAll()//인증 예외 URL
+                .requestMatchers("/", "/login**", "/api/**", "/api/novels/**", "/v3/**", "/swagger-ui/**")
+                .permitAll() // Swagger 관련 경로 추가
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/ham/netnovel/episode/EpisodeController.java
+++ b/src/main/java/com/ham/netnovel/episode/EpisodeController.java
@@ -13,6 +13,13 @@ import com.ham.netnovel.episode.dto.EpisodeListItemDto;
 import com.ham.netnovel.episode.dto.*;
 import com.ham.netnovel.episode.service.EpisodeManagementService;
 import com.ham.netnovel.episode.service.EpisodeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +35,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @Slf4j
+@Tag(name = "Episode", description = "에피소드 관련된 작업")
+
 public class EpisodeController {
     private final EpisodeService episodeService;
     private final EpisodeManagementService episodeManagementService;
@@ -55,19 +64,40 @@ public class EpisodeController {
      * @response 401 UNAUTHORIZED 사용자가 인증되지 않은 경우
      * @response 402 PAYMENT REQUIRED 사용자가 에피소드를 구매하지 않은 경우
      */
+    @Operation(
+            summary = "특정 에피소드 상세 정보 조회",
+            description = """
+                        특정 에피소드의 상세 정보를 반환합니다. 
+                        - 무료 에피소드는 인증 없이 조회 가능
+                        - 유료 에피소드는 인증 및 결제 내역 확인 필요
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 상세 정보 반환 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EpisodeDetailDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(유료회차 조회시 필요)",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """))),
+            @ApiResponse(responseCode = "402", description = "에피소드 구매 내역 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Payment Required", "message": "에피소드를 구매해야 합니다.", "status": 402 }
+                                    """)))
+    })
     @GetMapping("/episodes/{episodeId}")
     public ResponseEntity<?> getEpisodeDetail(
             Authentication authentication,
             @PathVariable Long episodeId
     ) {
-
-
         // authentication(유저 인증 정보)가 null일 경우, providerId에 "NON_LOGIN" 값을 할당
         // (비로그인 사용자의 무료 에피소드 조회를 위한 값)
         String providerId;
         if (authentication == null) {
             providerId = "NON_LOGIN";
-        }else {
+        } else {
             CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
             providerId = principal.getName();
         }
@@ -84,12 +114,43 @@ public class EpisodeController {
     }
 
 
+    @Operation(
+            summary = "이전 또는 다음 에피소드 조회",
+            description = """
+                        특정 에피소드 기준으로 이전 또는 다음 에피소드를 조회합니다.
+                        - 방향 옵션: NEXT(다음), PREVIOUS(이전)
+                        - 인증 및 구매 내역 확인 필요
+                    """,
+            parameters = {
+                    @Parameter(name = "episodeId", description = "에피소드의 ID", example = "123", required = true),
+                    @Parameter(name = "direction", description = "조회 방향 (NEXT: 다음 에피소드, PREV: 이전 에피소드)")
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EpisodeDetailDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """))),
+            @ApiResponse(responseCode = "402", description = "에피소드 구매 내역 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Payment Required", "message": "에피소드를 구매해야 합니다.", "status": 402 }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "에피소드가 존재하지 않음(잘못된 episodeID 입력)",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Not Found", "message": "에피소드가 존재하지 않습니다.", "status": 404 }
+                                    """)))
+    })
     @GetMapping("/episodes/{episodeId}/beside")
     public ResponseEntity<?> getEpisodeBeside(
             Authentication authentication,
             @PathVariable Long episodeId,
-            @RequestParam(defaultValue = "NEXT") IndexDirection direction
-    ) {
+            @RequestParam(defaultValue = "NEXT") IndexDirection direction) {
         //유저 인증 정보가 없으면 401 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
 
@@ -104,6 +165,32 @@ public class EpisodeController {
         }
     }
 
+
+    @Operation(
+            summary = "소설의 모든 에피소드 목록 조회",
+            description = """
+                        특정 소설에 속한 에피소드 목록을 조회합니다.
+                        - 정렬 옵션: recent(최신순), likes(좋아요순)
+                        - 페이지네이션 지원
+                    """,
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", example = "123", required = true),
+                    @Parameter(name = "sortBy", description = "정렬조건(recent:최신순, likes:좋아요순)"),
+                    @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작"),
+                    @Parameter(name = "pageSize", description = "페이지 크기, 기본값 10")
+
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EpisodeListItemDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Bad Request", "message": "정렬 기준은 'recent' 또는 'likes' 중 하나여야 합니다.", "status": 400 }
+                                    """)))
+    })
     @GetMapping("/novels/{novelId}/episodes")
     public ResponseEntity<List<EpisodeListItemDto>> getEpisodesByNovel(
             @PathVariable(name = "novelId") Long novelId,
@@ -122,6 +209,16 @@ public class EpisodeController {
     }
 
 
+    @Operation(
+            summary = "소설의 에피소드 수 조회",
+            description = "특정 소설의 에피소드 수와 관련된 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 수 정보 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EpisodeListInfoDto.class))),
+            @ApiResponse(responseCode = "404", description = "소설 또는 에피소드 정보가 존재하지 않음")
+    })
     @GetMapping("/novels/{novelId}/episodes/info")
     public ResponseEntity<EpisodeListInfoDto> getEpisodesCountByNovel(
             @PathVariable(name = "novelId") Long novelId
@@ -143,6 +240,25 @@ public class EpisodeController {
      * @param authentication   현재 사용자의 인증 상태를 포함하는 인증 객체.
      * @return {@code ResponseEntity<String>} 에피소드 업데이트 결과를 담고 있는 응답 객체 반환
      */
+
+    @Operation(
+            summary = "새로운 에피소드 생성",
+            description = "새로운 에피소드를 생성합니다. 요청 본문에 에피소드 생성 정보를 포함해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 생성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "ok"))),
+            @ApiResponse(responseCode = "400", description = "파라미터 유효성 검사 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Bad Request", "message": "에피소드는 최대 10000 자까지 작성 가능합니다!", "status": 400 }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """))),})
     @PostMapping("/novels/{novelId}/episodes")
     public ResponseEntity<String> createEpisode(
             @PathVariable(name = "novelId") Long novelId,
@@ -185,15 +301,43 @@ public class EpisodeController {
      * @return {@code ResponseEntity<String>} 에피소드 업데이트 결과를 담고 있는 응답 객체 반환
      */
 
+
+    @Operation(
+            summary = "기존 에피소드 업데이트",
+            description = "기존 에피소드 정보를 수정합니다. 요청 본문에 업데이트 정보를 포함해야 합니다.",
+            parameters = {
+                    @Parameter(name = "episodeId", description = "에피소드 ID", example = "1", required = true)
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 업데이트 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "ok"))),
+            @ApiResponse(responseCode = "400", description = "파라미터 유효성 검사 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Bad Request", "message": "에피소드는 최대 10000 자까지 작성 가능합니다!", "status": 400 }
+                                    """))), @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(type = "object", example = """
+                                { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                            """))),})
     @PostMapping("/episodes/{episodeId}")
     public ResponseEntity<String> updateEpisode(
             @PathVariable(name = "episodeId") Long episodeId,
             @Valid @RequestBody EpisodeUpdateDto episodeUpdateDto,
-            Authentication authentication
-    ) {
+            BindingResult bindingResult,
+            Authentication authentication) {
 
         //유저인증정보 체크
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
+
+        //EpisodeUpdateDto Validation 에러가 있을경우 badRequest 전송
+        if (bindingResult.hasErrors()) {
+            List<String> errorMessages = ValidationErrorHandler.handleValidationErrorMessages(
+                    bindingResult,
+                    "updateEpisode");
+            return ResponseEntity.badRequest().body(String.join(", ", errorMessages));
+        }
 
         episodeUpdateDto.setEpisodeId(episodeId);//DTO에 novelId 정보 할당
         episodeUpdateDto.setProviderId(principal.getName());//DTO에 유저 정보 할당.
@@ -218,6 +362,21 @@ public class EpisodeController {
      * @param authentication 현재 사용자의 인증 상태를 포함하는 인증 객체.
      * @return {@code ResponseEntity<String>} 에피소드 업데이트 결과를 담고 있는 응답 객체 반환
      */
+
+    @Operation(summary = "에피소드 삭제 API", description = "에피소드를 삭제 상태로 변경합니다.",
+            parameters = {
+                    @Parameter(name = "episodeId", description = "에피소드 ID", example = "1", required = true)
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "에피소드 삭제 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "ok"))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                        { "error": "Unauthorized", "message": "로그인 정보가 없습니다.", "status": 401 }
+                                    """)))
+    })
     @DeleteMapping("/episodes/{episodeId}")
     public ResponseEntity<String> deleteEpisode(
             @PathVariable(name = "episodeId") Long episodeId,

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeCreateDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeCreateDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.episode.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -10,21 +11,27 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "에피소드 생성시, 정보를 나타내는 DTO")
+
 public class EpisodeCreateDto {
 
+    @Schema(description = "에피소드가 포함된 소설의 ID", example = "1")
     private Long novelId;
 
     @NotNull
     @Size(min = 1, max = 100,message = "제목은 최대 100 자까지 작성 가능합니다!")//최대 100자까지 제한
+    @Schema(description = "에피소드 제목", example = "첫 번째 이야기")
     private String title;
 
     @NotNull
     @Size(min = 1, max = 10000,message = "에피소드는 최대 10000 자까지 작성 가능합니다!")//최대 10000자까지 제한
+    @Schema(description = "에피소드 내용", example = "이야기의 상세 내용이 여기에 포함됩니다.")
     private String content;//내용
 
     @NotNull
+    @Schema(description = "에피소드 가격정책 ID", example = "1")
     private Long costPolicyId;
 
-
+    @Schema(description = "작가의 Provider ID", example = "user123")
     private String providerId;//에피소드 생성 요청자 정보
 }

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeDetailDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeDetailDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.episode.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,15 +12,21 @@ import lombok.ToString;
 @Setter
 @Getter
 @ToString
+@Schema(description = "에피소드 상세 정보를 나타내는 DTO")
+
 public class EpisodeDetailDto {
     @NotNull
+    @Schema(description = "에피소드 ID", example = "1")
+
     private Long episodeId;
 
     //제목
     @NotNull
+    @Schema(description = "에피소드 제목", example = "첫 번째 이야기")
     private String title;
 
     //내용
     @NotNull
+    @Schema(description = "에피소드 내용", example = "이야기의 상세 내용이 여기에 포함됩니다.")
     private String content;
 }

--- a/src/main/java/com/ham/netnovel/episode/dto/EpisodeUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/episode/dto/EpisodeUpdateDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.episode.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -11,20 +12,26 @@ import lombok.ToString;
 @Setter
 @ToString
 @Builder
+@Schema(description = "에피소드 수정시 정보를 나타내는 DTO")
+
 public class EpisodeUpdateDto {
 
     private Long episodeId;
 
     @NotNull
     @Size(min = 1, max = 100,message = "제목은 최대 100 자까지 작성 가능합니다!")//최대 100자까지 제한
+    @Schema(description = "에피소드 제목", example = "첫 번째 이야기")
     private String title;
 
     @NotNull
     @Size(min = 1, max = 10000,message = "에피소드는 최대 10000 자까지 작성 가능합니다!")//최대 10000자까지 제한
+    @Schema(description = "에피소드 내용", example = "이야기의 상세 내용이 여기에 포함됩니다.")
     private String content;
 
     @NotNull
+    @Schema(description = "에피소드 가격정책 ID", example = "1")
     private Long costPolicyId;
 
+    @Schema(description = "작가의 Provider ID", example = "user123")
     private String providerId;//에피소드 업데이트 요청자 정보
 }

--- a/src/main/java/com/ham/netnovel/member/MemberController.java
+++ b/src/main/java/com/ham/netnovel/member/MemberController.java
@@ -8,6 +8,13 @@ import com.ham.netnovel.member.service.MemberMyPageService;
 import com.ham.netnovel.member.service.MemberService;
 import com.ham.netnovel.common.utils.Authenticator;
 import com.ham.netnovel.novel.dto.NovelFavoriteDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +35,8 @@ import java.util.stream.Collectors;
 @Controller
 @Slf4j
 @RequestMapping("/api")
+@Tag(name = "Member", description = "유저와 관련된 작업")
+
 public class MemberController {
 
     private final Authenticator authenticator;
@@ -56,6 +65,12 @@ public class MemberController {
      */
     @GetMapping("/members/me/mypage")
     @ResponseBody
+    @Operation(summary = "유저 마이페이지 정보조회 API", description = "마이페이지에 필요한 정보들을 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자의 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"error\": \"Unauthorized\", \"message\": \"로그인 정보가 없습니다.\", \"status\": 401}")))})
     public ResponseEntity<MemberMyPageDto> showMyPage(
             Authentication authentication) {
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
@@ -74,11 +89,16 @@ public class MemberController {
      * @param authentication    유저의 인증 정보
      * @return ResponseEntity 요청 결과를 담은 응답 객체
      */
-    //Todo 송민규: Edit Profile 페이지를 구성하여 Nickname, Email, Gender을 일괄적으로 수정할 수 있도록 기능을 확장하는 건 어떨까요?
+    @Operation(summary = "닉네임 변경 API", description = "유저의 닉네임을 변경합니다.")
     @PatchMapping("/members/me/nickname")
-    public ResponseEntity<?> updateNickname(@Valid @RequestBody ChangeNickNameDto changeNickNameDto,
-                                            BindingResult bindingResult,
-                                            Authentication authentication) {
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터")
+    })
+    public ResponseEntity<?> updateNickname(
+            @Valid @RequestBody ChangeNickNameDto changeNickNameDto,
+            BindingResult bindingResult,
+            Authentication authentication) {
 
         //ChangeNickNameDto Validation 에러가 있을경우 badRequest 전송
         if (bindingResult.hasErrors()) {
@@ -129,6 +149,19 @@ public class MemberController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity 댓글과 대댓글의 정보 리스트를 담은 응답 객체
      */
+    @Operation(summary = "댓글 및 대댓글 조회", description = "사용자가 작성한 댓글 및 대댓글 목록을 조회합니다.",
+    parameters = {
+            @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0"),
+            @Parameter(name = "pageSize", description = "페이지 크기 기본값 10", example = "10")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 댓글 및 대댓글 목록을 반환"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            { "error": "Unauthorized","message": "로그인 정보가 없습니다.","status": 401}
+                                    """)))
+    })
     @GetMapping("/members/me/comments")
     public ResponseEntity<?> getMemberCommentList(
             Authentication authentication,
@@ -157,9 +190,16 @@ public class MemberController {
      *
      * @param authentication 사용자 인증 정보를 담고 있는 Authentication 객체입니다.
      * @return 인증된 사용자의 선호 소설 목록을 포함하는 ResponseEntity를 반환하며,
-     *         인증되지 않은 경우에는 bad request 응답을 반환합니다.
+     * 인증되지 않은 경우에는 bad request 응답을 반환합니다.
      * @throws AuthenticationCredentialsNotFoundException 유저의 인증정보가 없는경우
      */
+    @Operation(summary = "선호 소설 목록 조회", description = "인증된 사용자의 선호 소설 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 선호 소설 목록을 반환"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"error\": \"Unauthorized\", \"message\": \"로그인 정보가 없습니다.\", \"status\": 401}")))
+    })
     @GetMapping("/members/me/favorites")
     public ResponseEntity<?> getFavoriteNovels(Authentication authentication) {
 
@@ -183,13 +223,26 @@ public class MemberController {
      * 최신순으로 정렬된 {@link MemberCoinUseHistoryDto} 객체 목록으로 반환합니다.</p>
      *
      * @param authentication 사용자 인증 정보를 담고 있는 {@link Authentication} 객체
-     * @param pageNumber 페이지 번호를 나타내는 정수값, 기본값은 0
-     * @param pageSize 페이지 크기를 나타내는 정수값, 기본값은 10
+     * @param pageNumber     페이지 번호를 나타내는 정수값, 기본값은 0
+     * @param pageSize       페이지 크기를 나타내는 정수값, 기본값은 10
      * @return 사용자의 코인 사용 기록을 담고 있는 {@link MemberCoinUseHistoryDto} 타입의 {@link List} 객체를
-     *         포함한 {@link ResponseEntity}를 반환합니다.
-     * @throws IllegalArgumentException 페이지 번호나 페이지 크기가 유효하지 않을 경우
+     * 포함한 {@link ResponseEntity}를 반환합니다.
+     * @throws IllegalArgumentException                   페이지 번호나 페이지 크기가 유효하지 않을 경우
      * @throws AuthenticationCredentialsNotFoundException 유저 인증정보가 유효하지 않은경우
      */
+
+    @Operation(summary = "코인 사용 기록 조회", description = "인증된 사용자의 코인 사용 내역을 조회합니다."
+            , parameters = {
+            @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0"),
+            @Parameter(name = "pageSize", description = "페이지 크기, 기본값 10", example = "10")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 코인 사용 내역을 반환",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberCoinUseHistoryDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"error\": \"Unauthorized\", \"message\": \"로그인 정보가 없습니다.\", \"status\": 401}")))})
+
     @GetMapping("/members/me/coin-use-history")
     public ResponseEntity<?> getMemberCoinUseHistory(
             Authentication authentication,
@@ -216,18 +269,30 @@ public class MemberController {
      * 최신순으로 정렬된 {@link MemberCoinChargeDto} 객체 목록으로 반환합니다.</p>
      *
      * @param authentication 사용자 인증 정보를 담고 있는 {@link Authentication} 객체
-     * @param pageNumber 페이지 번호를 나타내는 정수값, 기본값은 0
-     * @param pageSize 페이지 크기를 나타내는 정수값, 기본값은 10
+     * @param pageNumber     페이지 번호를 나타내는 정수값, 기본값은 0
+     * @param pageSize       페이지 크기를 나타내는 정수값, 기본값은 10
      * @return 사용자의 코인 충전 기록을 담고 있는 {@link MemberCoinChargeDto} 타입의 {@link List} 객체를
-     *         포함한 {@link ResponseEntity}를 반환합니다.
-     * @throws IllegalArgumentException 페이지 번호나 페이지 크기가 유효하지 않을 경우
+     * 포함한 {@link ResponseEntity}를 반환합니다.
+     * @throws IllegalArgumentException                   페이지 번호나 페이지 크기가 유효하지 않을 경우
      * @throws AuthenticationCredentialsNotFoundException 유저 인증정보가 유효하지 않은경우
      */
+
+    @Operation(summary = "코인 충전 기록 조회", description = "인증된 사용자의 코인 충전 내역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 코인 사용 내역을 반환",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberCoinChargeDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"error\": \"Unauthorized\", \"message\": \"로그인 정보가 없습니다.\", \"status\": 401}")))
+    })
+    @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0")
+    @Parameter(name = "pageSize", description = "페이지 크기, 기본값 10", example = "10")
     @GetMapping("/members/me/coin-charge-history")
     public ResponseEntity<List<MemberCoinChargeDto>> getMemberCoinChargeHistory(
             Authentication authentication,
             @RequestParam(defaultValue = "0") int pageNumber,
             @RequestParam(defaultValue = "10") int pageSize) {
+
         //유저 인증 정보가 없으면 badRequest 응답, 정보가 있으면  CustomOAuth2User로 타입캐스팅
         CustomOAuth2User principal = authenticator.checkAuthenticate(authentication);
         //Pageable 객체 생성, null 이거나 음수면 예외로 던짐
@@ -238,6 +303,7 @@ public class MemberController {
         return ResponseEntity.ok(memberCoinChargeHistory);
 
     }
+
     /**
      * 유저가 최근 읽은 작품 기록 열람을 요청하면, body에 담아 전송하는 API입니다.
      *
@@ -245,13 +311,21 @@ public class MemberController {
      * 최신순으로 정렬된 {@link MemberRecentReadDto} 객체 목록으로 반환합니다.</p>
      *
      * @param authentication 사용자 인증 정보를 담고 있는 {@link Authentication} 객체
-     * @param pageNumber 페이지 번호를 나타내는 정수값, 기본값은 0
-     * @param pageSize 페이지 크기를 나타내는 정수값, 기본값은 10
+     * @param pageNumber     페이지 번호를 나타내는 정수값, 기본값은 0
+     * @param pageSize       페이지 크기를 나타내는 정수값, 기본값은 10
      * @return 사용자의 최근 읽은 작품 기록을 담고 있는 {@link MemberRecentReadDto} 타입의 {@link List} 객체를
-     *         포함한 {@link ResponseEntity}를 반환합니다.
-     * @throws IllegalArgumentException 페이지 번호나 페이지 크기가 유효하지 않을 경우
+     * 포함한 {@link ResponseEntity}를 반환합니다.
+     * @throws IllegalArgumentException                   페이지 번호나 페이지 크기가 유효하지 않을 경우
      * @throws AuthenticationCredentialsNotFoundException 유저 인증 정보가 유효하지 않을 경우
      */
+
+    @Operation(summary = "최근 읽은 작품 기록 조회", description = "인증된 사용자의 최근 읽은 작품 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 최근 읽은 작품 목록을 반환"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자일경우")
+    })
+    @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0")
+    @Parameter(name = "pageSize", description = "페이지 크기, 기본값 10", example = "10")
     @GetMapping("/members/me/recent-read")
     public ResponseEntity<List<MemberRecentReadDto>> getMemberRecentRead(
             Authentication authentication,

--- a/src/main/java/com/ham/netnovel/member/dto/ChangeNickNameDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/ChangeNickNameDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -11,13 +12,16 @@ import org.hibernate.validator.constraints.Range;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "닉네임 변경 DTO")
 public class ChangeNickNameDto {
 
+    @Schema(description = "유저의 Provider ID", example = "user123")
     private String providerId;
 
     @NotBlank(message = "새 닉네임은 비워둘 수 없습니다.")
     @Size(min = 2, max = 20, message = "닉네임은 2~20자로 작성해 주세요")
     @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "닉네임은 한글 또는 영문으로 작성해주세요")
+    @Schema(description = "유저의 새로운 닉네임, 한글 또는 영문", example = "에드워드김")
     private String newNickName;
 
 

--- a/src/main/java/com/ham/netnovel/member/dto/MemberCoinChargeDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberCoinChargeDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -12,19 +13,24 @@ import java.time.LocalDateTime;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "유저의 코인 충전 기록 DTO")
+
 public class MemberCoinChargeDto {
 
 
+    @Schema(description = "유저의 Provider ID", example = "user123")
     private String providerId;
 
 
+    @Schema(description = "충전된 코인의 양", example = "100")
     @NotNull
     private Integer coinAmount;
 
+    @Schema(description = "충전된 날짜 및 시간", example = "2024-12-25T15:30:00")
     @NotNull
     private LocalDateTime createdAt;
 
-
+    @Schema(description = "결제 금액", example = "100000")
     @NotNull
     private BigDecimal payment;
 

--- a/src/main/java/com/ham/netnovel/member/dto/MemberMyPageDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberMyPageDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.member.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
@@ -9,15 +10,16 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Schema(description = "유저 마이페이지 정보 DTO")
 public class MemberMyPageDto {
 
-    //닉네임
+    @Schema(description = "유저의 닉네임", example = "JohnDoe")
     private String nickName;
 
-    //코인 갯수
+    @Schema(description = "유저가 보유한 코인 수", example = "1000")
     private Integer coinCount;
 
-    //현재 로그인한 OAuth 이메일
+    @Schema(description = "유저의 이메일 주소", example = "john@naver.com")
     private String email;
 
 

--- a/src/main/java/com/ham/netnovel/member/dto/MemberRecentReadDto.java
+++ b/src/main/java/com/ham/netnovel/member/dto/MemberRecentReadDto.java
@@ -3,6 +3,7 @@ package com.ham.netnovel.member.dto;
 
 import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.tag.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -17,29 +18,31 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Schema(description = "유저가 최근 읽은 작품에 대한 정보 DTO")
 public class MemberRecentReadDto {
 
-
+    @Schema(description = "소설 ID", example = "123")
     private Long id;
 
+    @Schema(description = "소설 제목", example = "마법사의 후예")
     private String title;
 
-    //연재정보
+    @Schema(description = "소설의 연재 상태", example = "ONGOING")
     private NovelType novelType;
 
-    //작가명
+    @Schema(description = "작가 이름", example = "김춘배")
     private String authorName;
 
-    //최근본 에피소드 제목
+    @Schema(description = "최근 읽은 에피소드 제목", example = "1화 - 시작의 장")
     private String episodeTitle;
 
-    //최근본 에피소드 id, 리다이렉트시 사용
+    @Schema(description = "최근 읽은 에피소드 ID", example = "456")
     private Long episodeId;
 
-    //업데이트시간
+    @Schema(description = "최근 업데이트 시간", example = "2024-12-25T10:15:30")
     private LocalDateTime updatedAt;
 
-
+    @Schema(description = "소설의 섬네일 URL", example = "https://example.com/thumbnail.jpg")
     private String thumbnailUrl;//섬네일 URL
 
 

--- a/src/main/java/com/ham/netnovel/novel/NovelController.java
+++ b/src/main/java/com/ham/netnovel/novel/NovelController.java
@@ -9,6 +9,14 @@ import com.ham.netnovel.novel.dto.*;
 import com.ham.netnovel.novel.service.NovelEditingService;
 import com.ham.netnovel.novel.service.NovelSearchService;
 import com.ham.netnovel.novel.service.NovelService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -27,12 +35,14 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Novels", description = "소설과 관련된 작업")
 public class NovelController {
     private final NovelService novelService;
     private final Authenticator authenticator;
     private final NovelEditingService novelEditingService;
 
     private final NovelSearchService novelSearchService;
+
     public NovelController(NovelService novelService, Authenticator authenticator, NovelEditingService novelEditingService, NovelSearchService novelSearchService) {
         this.novelService = novelService;
         this.authenticator = authenticator;
@@ -41,11 +51,82 @@ public class NovelController {
     }
 
     /**
+     * 검색어로 소설을 조회하는 API 입니다.
+     * <p>이 메서드는 유저가 입력한 검색어에 따라 소설제목 또는 작가명으로 소설을 검색하여
+     * 소설 목록을 반환합니다.</p>
+     * <p>페이지 네이션을 위해 Pageable 객체를 생성하여,
+     * 서비스 계층에서 소설 정보를 DTO 리스트로 받아 이를 HTTP 응답으로 전송합니다.</p>
+     *
+     * @param searchWord 검색어 {@link String} 객체입니다.
+     * @param searchType 검색 타입 {@link String} 객체입니다. 기본값은 소설 제목 입니다.
+     * @param pageNumber 조회할 페이지 번호 {@link Integer} 객체 입니다. 기본값은 0입니다.
+     * @param pageSize   한 페이지에 포함될 항목의 수 {@link Integer} 객체  입니다. 기본값은 30입니다.
+     * @return {@link ResponseEntity<>} 소설 정보가 포함된 리스트를 HTTP 200 응답으로 반환합니다.
+     */
+
+    @Operation(summary = "검색어 기반 소설 검색", description = "검색어에 따라 소설 제목 또는 작가명을 기반으로 소설 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "searchWord", description = "검색어", example = "마음"),
+                    @Parameter(name = "searchType", description = "제목 또는 작가명", example = "title"),
+                    @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0"),
+                    @Parameter(name = "pageSize", description = "페이지 크기 기본값 30", example = "30")
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 소설 목록을 반환",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NovelListDto.class))),
+            @ApiResponse(responseCode = "400", description = "검색어가 너무 짧거나 잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = """
+                                    {"error": "Bad Request", "message": "검색어는 최소 2글자 이상이어야 합니다.","status": 400}
+                                     """))
+            )})
+
+    @GetMapping("/novels/search")
+    public ResponseEntity<?> getNovelsBySearchWord(
+            @RequestParam(name = "searchWord") String searchWord,
+            @RequestParam(name = "searchType", defaultValue = "title") String searchType,
+            @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "30") Integer pageSize) {
+        String trimWord = searchWord.trim();
+        // 앞뒤 공백 제거 후 2글자 미만일 경우 BAD REQUEST 반환
+        if (trimWord.length() < 2) {
+            return ResponseEntity.badRequest().body("검색어는 2글자 이상 입력해주세요!");
+        }
+        //페이지 사이즈 수 제한
+        if (pageSize > 200) {
+            pageSize = 200;
+        }
+
+        // 클라이언트가 선택한 seachType을 enum 상수로 변환, 디폴트값은 소설제목 검색
+        NovelSearchType novelSearchType;
+        switch (searchType) {
+            case "author" -> novelSearchType = NovelSearchType.AUTHOR_NAME;
+            default -> novelSearchType = NovelSearchType.NOVEL_TITLE;
+        }
+        //페이지 네이션을 위한 Pageable 객체 생성
+        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
+        //조건을 메서드에 전달하여, 소설 정보 List를 받아옴
+        List<NovelListDto> novels = novelSearchService.getNovelsBySearchWord(trimWord, novelSearchType, pageable);
+        return ResponseEntity.ok(novels);//소설 정보 전송
+    }
+
+    /**
      * 소설 상세 페이지에서 Novel 데이터 응답하는 API
      *
      * @param novelId novelId를 담은 url path variable
      * @return ResponseEntity
      */
+    @Operation(summary = "소설 상세페이지 조회", description = "소설 ID를 기반으로 소설 상세 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", example = "125")
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 소설 목록을 반환",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NovelInfoDto.class))),
+            @ApiResponse(responseCode = "404", description = "소설을 찾을 수 없음")
+    })
     @GetMapping("/novels/{novelId}")
     public ResponseEntity<NovelInfoDto> getNovel(@PathVariable("novelId") Long novelId) {
         return ResponseEntity.ok(novelService.getNovelInfo(novelId));
@@ -65,13 +146,26 @@ public class NovelController {
      * @return {@link ResponseEntity<>} 소설 정보가 포함된 리스트를 HTTP 200 응답으로 반환합니다.
      * 응답 본문에는 소설 정보 리스트가 담겨 있습니다.
      */
+
+    @Operation(summary = "소설 조회 API", description = "검색 조건에 따라 소설 목록을 조회합니다."
+            , parameters = {
+            @Parameter(name = "sortBy", description = "정렬조건, 기본값 조회수", example = "view"),
+            @Parameter(name = "tagIds", description = "검색조건 태그", example = "무협"),
+            @Parameter(name = "pageNumber", description = "페이지번호 0부터 시작", example = "0"),
+            @Parameter(name = "pageSize", description = "페이지 크기 기본값 30", example = "30")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 소설 목록을 반환, 결과가 없으면 빈리스트 반환",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NovelListDto.class))),
+    })
     @GetMapping("/novels/browse")
+
     public ResponseEntity<List<NovelListDto>> getNovelsBySearchCondition(
             @RequestParam(name = "sortBy", defaultValue = "view") String sortBy,
             @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "100") Integer pageSize,
             @RequestParam(name = "tagIds", required = false) String ids) {
-
         List<Long> idList = new ArrayList<>();
         //"," 로 구분된 tag 들을 분리하여 List 객체에 담음
         if (!(ids == null)) {
@@ -92,49 +186,6 @@ public class NovelController {
     }
 
     /**
-     * 검색어로 소설을 조회하는 API 입니다.
-     * <p>이 메서드는 유저가 입력한 검색어에 따라 소설제목 또는 작가명으로 소설을 검색하여
-     * 소설 목록을 반환합니다.</p>
-     * <p>페이지 네이션을 위해 Pageable 객체를 생성하여,
-     * 서비스 계층에서 소설 정보를 DTO 리스트로 받아 이를 HTTP 응답으로 전송합니다.</p>
-     *
-     * @param searchWord 검색어 {@link String} 객체입니다.
-     * @param searchType 검색 타입 {@link String} 객체입니다. 기본값은 소설 제목 입니다.
-     * @param pageNumber 조회할 페이지 번호 {@link Integer} 객체 입니다. 기본값은 0입니다.
-     * @param pageSize   한 페이지에 포함될 항목의 수 {@link Integer} 객체  입니다. 기본값은 30입니다.
-     * @return {@link ResponseEntity<>} 소설 정보가 포함된 리스트를 HTTP 200 응답으로 반환합니다.
-     */
-    @GetMapping("/novels/search")
-    public ResponseEntity<?> getNovelsBySearchWord(
-            @RequestParam(name = "searchWord") String searchWord,
-            @RequestParam(name = "searchType",defaultValue = "title") String searchType,
-            @RequestParam(name = "pageNumber", defaultValue = "0") Integer pageNumber,
-            @RequestParam(name = "pageSize", defaultValue = "30") Integer pageSize) {
-        String trimWord = searchWord.trim();
-        // 앞뒤 공백 제거 후 2글자 미만일 경우 BAD REQUEST 반환
-        if (trimWord.length() < 2) {
-            return ResponseEntity.badRequest().body("검색어는 2글자 이상 입력해주세요!");
-        }
-        //페이지 사이즈 수 제한
-        if (pageSize > 200) {
-            pageSize = 200;
-        }
-
-        // 클라이언트가 선택한 seachType을 enum 상수로 변환, 디폴트값은 소설제목 검색
-        NovelSearchType novelSearchType;
-        switch (searchType){
-            case "author" -> novelSearchType =NovelSearchType.AUTHOR_NAME;
-            default ->novelSearchType= NovelSearchType.NOVEL_TITLE ;
-        }
-        //페이지 네이션을 위한 Pageable 객체 생성
-        Pageable pageable = PageableUtil.createPageable(pageNumber, pageSize);
-        //조건을 메서드에 전달하여, 소설 정보 List를 받아옴
-        List<NovelListDto> novels = novelSearchService.getNovelsBySearchWord(trimWord, novelSearchType,pageable);
-        return ResponseEntity.ok(novels);//소설 정보 전송
-    }
-
-
-    /**
      * 소설 랭킹을 기간에 따라 조회하는 API 엔드포인트입니다.
      * <p>
      * 사용자가 제공한 기간과 페이지 정보를 바탕으로 소설 목록을 랭킹 순서대로 정렬하여 반환합니다.
@@ -150,12 +201,26 @@ public class NovelController {
      * @return {@link ResponseEntity<> } 소설 정보가 포함된 랭킹 순서의 리스트를 HTTP 200 응답으로 반환합니다.
      * 응답 본문에는 랭킹이 반영된 소설 목록이 담겨 있습니다.
      */
+    @Operation(summary = "소설 랭킹 조회 API", description = "사용자가 지정한 기간에 따라 소설 랭킹 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 소설 목록을 반환",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NovelListDto.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 유효하지 않은 파라미터",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = """
+                                            {   "error": "Bad Request",
+                                                "message": "유효하지 않은 period 값입니다. (daily, weekly, monthly 중 하나를 사용해야 합니다.)",
+                                                "status": 400
+                                            }
+                                    """)))
+    })
     @GetMapping("/novels/ranking")
     public ResponseEntity<List<NovelListDto>> getNovelsByRanking(
             @RequestParam("period") String period,
             @RequestParam(name = "pageNumber", defaultValue = "0") int pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "100") int pageSize) {
-
 
         //페이지 사이즈 수 제한
         if (pageSize > 200) {
@@ -199,6 +264,24 @@ public class NovelController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
+    @Operation(summary = "소설 생성 API", description = "새로운 소설을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "소설 생성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "integer", example = "42"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 전송",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = """
+                                    {"error": "Bad Request", "message": "소설 제목은 30자 이하로 작성해주세요!","status": 400}
+                                     """))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            { "error": "Unauthorized","message": "로그인 정보가 없습니다.","status": 401}
+                                    """)))
+    })
+
+
     @PostMapping("/novels")
     public ResponseEntity<?> createNovel(@Valid @RequestBody NovelCreateDto reqBody,
                                          BindingResult bindingResult,
@@ -229,6 +312,24 @@ public class NovelController {
      * @param authentication 유저의 인증 정보
      * @return ResponseEntity HttpStatus, Novel 데이터 문자열 반환.
      */
+    @Operation(summary = "소설 내용을 변경하는 API", description = "기존 소설의 내용을 업데이트합니다.",
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", example = "125")
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "소설 생성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "작품 업데이트 완료."))),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 전송",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = """
+                                    {"error": "Bad Request", "message": "소설제목은 30자 이하로 작성해주세요!.","status": 400}
+                                     """))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            { "error": "Unauthorized","message": "로그인 정보가 없습니다.","status": 401}
+                                    """)))})
     @PutMapping("/novels/{novelId}")
     public ResponseEntity<String> updateNovel(
             @PathVariable("novelId") Long novelId,
@@ -270,6 +371,17 @@ public class NovelController {
      * @param authentication 현재 인증된 사용자 정보
      * @return 성공적으로 삭제되었을 경우 "작품 삭제 완료." 메시지를 포함한 HTTP 200 응답
      */
+    @Operation(summary = "소설을 삭제하는 API", description = "소설의 상태를 삭제 상태로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "소설 삭제 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "작품 삭제 완료."))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            { "error": "Unauthorized","message": "로그인 정보가 없습니다.","status": 401}
+                                    """)))})
+    @Parameter(name = "novelId", description = "소설의 ID", example = "125")
     @DeleteMapping("/novels/{novelId}")
     public ResponseEntity<String> deleteNovel(@PathVariable("novelId") Long novelId,
                                               Authentication authentication) {
@@ -287,7 +399,6 @@ public class NovelController {
 
         return ResponseEntity.ok("작품 삭제 완료.");
     }
-
 
 
     /**
@@ -309,6 +420,32 @@ public class NovelController {
      * @param authentication 현재 인증된 사용자의 인증 정보입니다. {@code notNull}
      * @return 성공 시 HTTP 200과 "섬네일 변경 성공!" 메시지, 실패 시 HTTP 500과 "섬네일 변경 실패." 메시지를 반환합니다.
      */
+    @Operation(summary = "소설의 섬네일을 S3에 업로드하는 API", description = "소설의 섬네일을 S3에 업로드하고, DB에 변경된 섬네일이름을 기록합니다.",
+            parameters = {
+                    @Parameter(name = "novelId", description = "소설의 ID", required = true),
+                    @Parameter(name = "file", description = "소설의 섬네일 이미지 파일", required = true,
+                            schema = @Schema(type = "string", format = "binary"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "섬네일 변경 성공시",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "string", example = "섬네일 변경 성공!"))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            { "error": "Unauthorized","message": "로그인 정보가 없습니다.","status": 401}
+                                    """))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 문제로 섬네일 변경 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(type = "object", example = """
+                                            {
+                                                "error": "Internal Server Error",
+                                                "message": "섬네일 변경 실패.",
+                                                "status": 500
+                                            }
+                                    """)))
+
+    })
     @PostMapping("/novels/{novelId}/thumbnail")
     public ResponseEntity<?> uploadNovelThumbnail(
             @PathVariable("novelId") Long urlNovelId,

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelCreateDto.java
@@ -1,5 +1,6 @@
 package com.ham.netnovel.novel.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -12,16 +13,22 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "소설 생성 DTO")
+
 public class NovelCreateDto {
     @NotBlank
-    @Size(max = 30)
+    @Size(max = 30,message = "소설 제목은 30자 이하로 작성해주세요!")
+    @Schema(description = "소설 제목", example = "마음의 소리", maxLength = 30)
     private String title;
 
     @Size(max = 300)
+    @Schema(description = "작품 소개 (최대 300자)", example = "이 작품은 판타지 세계에서 펼쳐지는 흥미로운 모험을 다룹니다.")
     private String description;
 
+    @Schema(description = "소설 작가 ID", example = "125")
     private String accessorProviderId; //실행자 유저 ID
 
+    @Schema(description = "작품 태그 리스트")
     private List<String> tagNames;//작가가 선택한 태그의 이름들
 
 

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelInfoDto.java
@@ -2,6 +2,7 @@ package com.ham.netnovel.novel.dto;
 
 import com.ham.netnovel.novel.data.NovelType;
 import com.ham.netnovel.tag.dto.TagDataDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,41 +17,54 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "소설 상세 정보를 제공하는 DTO")
 public class NovelInfoDto {
 
     @NotNull
+    @Schema(description = "소설 ID", example = "12345")
     private Long id; //소설 id
 
     @NotBlank
     @Size(max = 30)
+    @Schema(description = "소설 제목 (최대 30자)", example = "모험의 시작")
     private String title; //소설 제목
 
     @NotBlank
     @Size(max = 300)
+    @Schema(description = "작품 소개 (최대 300자)", example = "이 작품은 판타지 세계에서 펼쳐지는 흥미로운 모험을 다룹니다.")
     private String desc; //작품 소개
 
     @NotNull
+    @Schema(description = "작가 닉네임", example = "김춘배")
     private String authorName; //작가 닉네임
 
     @NotNull
+    @Schema(description = "총 조회수", example = "123456")
     private Integer views; //조회수
 
     @NotNull
+    @Schema(description = "평균 별점", example = "4.7")
     private BigDecimal averageRating; //평균 별점
 
     @NotNull
+    @Schema(description = "선호작 등록 수", example = "1500")
     private Integer favoriteCount; //선호작 수
 
     @NotNull
+    @Schema(description = "작품 태그 리스트")
     private List<TagDataDto> tags; //작품 태그
 
     @NotNull
-    private NovelType type; //소설 등급
+    @Schema(description = "소설 연재상태", example = "ONGOING")
+
+    private NovelType type; //소설 연재상태
 
     @NotNull
+    @Schema(description = "총 에피소드 수", example = "120")
     private Integer episodeCount; //에피소드 총 화수
 
     @NotNull
+    @Schema(description = "소설 섬네일 AWS URL", example = "https://example.com/thumbnail.jpg")
     private String thumbnailUrl;//섬네일 AWS URL
 
 }

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelListDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.novel.dto;
 
 import com.ham.netnovel.tag.dto.TagDataDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -15,36 +16,45 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "소설 정보를 전달하는 DTO, 주로 랭킹 및 리스트에 사용")
 public class NovelListDto {//랭킹 등 리스트로 소설정보를 전달시 사용하는 DTO
 
     @NotNull
+    @Schema(description = "소설 ID", example = "12345")
     private Long id; //소설 id
 
     @NotBlank
     @Size(max = 30)
+    @Schema(description = "소설 제목 (최대 30자)", example = "환상의 모험")
     private String title; //소설 제목
 
     @NotNull
+    @Schema(description = "작가 닉네임", example = "김춘배")
     private String authorName; //작가 닉네임
 
     @NotNull
+    @Schema(description = "작가 소셜 로그인 ID", example = "provider123")
     private String providerId;//작가 소셜로그인 ID
 
     @NotNull
+    @Schema(description = "작품 태그 리스트")
     private List<TagDataDto> tags; //작품 태그
 
 
     @NotNull
+    @Schema(description = "총 좋아요 수", example = "245")
     private Integer totalFavorites; //총좋아요수
 
-
+    @Schema(description = "총 조회수", example = "15000")
     private Long totalView;    //총조회수
 
+    @Schema(description = "최근 업데이트 시간", example = "2024-12-26T14:00:00")
     private LocalDateTime latestUpdateAt;//최근업데이트시간
 
-
+    @Schema(description = "소설 섬네일 URL", example = "https://example.com/thumbnail.jpg")
     private String thumbnailUrl;//섬네일 URL
 
+    @Schema(description = "소설 설명", example = "이 소설은 판타지 세계에서 벌어지는 모험을 다룹니다.")
     private String description;//소설 설명
 
 

--- a/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
+++ b/src/main/java/com/ham/netnovel/novel/dto/NovelUpdateDto.java
@@ -1,6 +1,7 @@
 package com.ham.netnovel.novel.dto;
 
 import com.ham.netnovel.novel.data.NovelType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -13,19 +14,24 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "소설 업데이트 요청 DTO")
+
 public class NovelUpdateDto {
 
     private Long novelId;
 
+    @Schema(description = "소설 작가 ID", example = "125")
     private String accessorProviderId;
 
-    @Size(max = 30)
+    @Size(max = 30,message = "소설 제목은 30자 이하로 작성해주세요!")
+    @Schema(description = "소설 제목", example = "마음의 소리", maxLength = 30)
     private String title;
 
-    @Size(max = 300)
+    @Size(max = 300,message = "소설 상세설명은 300자 이하로 작성해주세요!")
     private String description;
 
     private List<String> tagNames;
 
+    @Schema(description = "소설의 연재 상태", example = "ONGOING", allowableValues = {"ONGOING", "COMPLETED", "PAUSED"})
     private NovelType type;
 }

--- a/src/main/java/com/ham/netnovel/novelTag/NovelTagController.java
+++ b/src/main/java/com/ham/netnovel/novelTag/NovelTagController.java
@@ -1,7 +1,9 @@
 package com.ham.netnovel.novelTag;
 
+import com.ham.netnovel.novelTag.dto.NovelTagListDto;
 import com.ham.netnovel.novelTag.service.NovelTagService;
 import com.ham.netnovel.tag.service.TagService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,9 +11,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api")
+@Tag(name = "NovelTag", description = "소설 Tag와 관련된 작업")
 public class NovelTagController {
     private final NovelTagService novelTagService;
 
@@ -23,6 +28,7 @@ public class NovelTagController {
     public ResponseEntity<?> readTagsByNovel(
             @PathVariable(name = "novelId") Long novelId
     ) {
-        return ResponseEntity.ok(novelTagService.getTagsByNovel(novelId));
+        List<NovelTagListDto> tagsByNovel = novelTagService.getTagsByNovel(novelId);
+        return ResponseEntity.ok(tagsByNovel);
     }
 }


### PR DESCRIPTION
- Swagger를 통해 API 가독성과 사용성을 향상
- Controller API에 @Operation과 @ApiResponses 추가
  - 특정 에피소드 상세 조회 API의 요청과 응답 명세 작성
  - 응답 코드별 상세 설명 및 예제 포함
- DTO 클래스에 @Schema 어노테이션 추가
  - DTO의 설명 문서화